### PR TITLE
Mlos clean up

### DIFF
--- a/osc-server-bom/makefiles/master.mk
+++ b/osc-server-bom/makefiles/master.mk
@@ -18,6 +18,9 @@ blddir=$(realpath $(makedir)/..)/build
 bindir=$(realpath $(makedir)/..)/bin
 
 export buildNumber blddir bindir
+
+#Proxy setting needed for jenkins. By default these env variables exist in the shell. But for jenkins shell we have to add these env variables
+#here,due to a bug in jenkins.
 export http_proxy=http://proxy-us.intel.com:911
 export https_proxy=http://proxy-us.intel.com:912
 export ftp_proxy=http://proxy-us.intel.com:911


### PR DESCRIPTION
osc-core/osc-server-bom/makefiles/master.mk

We have added proxy settting for Jenkins into the makefile. As Jenkins shell is not able to set the http_proxy  env setting in lower case. And shell need this env varibales in lower case. Till the Jenkins is issue
https://issues.jenkins-ci.org/browse/JENKINS-16255 is fixed we will have this fix in makefile.
We are tracking this issue separately in OSC as a bug.
Hence this checkin has become official