### PR TITLE
sample plugin fix

### DIFF
--- a/osc-export/server-debug.bndrun
+++ b/osc-export/server-debug.bndrun
@@ -82,4 +82,6 @@ x-runproperties.debug: \
 	org.jboss.logging.jboss-logging;version='[3.3.0,3.3.1)',\
 	org.apache.commons.lang;version='[2.6.0,2.6.1)',\
 	org.osgi.service.repository;version='[1.1.0,1.1.1)',\
-	osc-domain;version='[1.0.0,1.0.1)'
+	osc-domain;version='[1.0.0,1.0.1)',\
+	org.hibernate.javax.persistence.hibernate-jpa-2.1-api;version='[1.0.0,1.0.1)'
+

--- a/osc-export/server.bnd
+++ b/osc-export/server.bnd
@@ -24,6 +24,7 @@
 	osgi.identity;filter:='(osgi.identity=org.glassfish.jersey.media.jersey-media-jaxb)',\
 	osgi.identity;filter:='(osgi.identity=com.fasterxml.jackson.module.jackson-module-jaxb-annotations)',\
 	osgi.identity;filter:='(osgi.identity=org.glassfish.web.javax.el)',\
+	osgi.identity;filter:='(osgi.identity=org.hibernate.javax.persistence.hibernate-jpa-2.1-api)',\
 	${hk2}
 
 # These initial requirement are NOT needed by the server, but are to work-around a startup ordering issue

--- a/osc-export/server.bndrun
+++ b/osc-export/server.bndrun
@@ -63,5 +63,6 @@
 	org.glassfish.jersey.ext.jersey-bean-validation;version='[2.25.0,2.25.1)',\
 	org.glassfish.jersey.media.jersey-media-jaxb;version='[2.25.0,2.25.1)',\
 	com.fasterxml.jackson.module.jackson-module-jaxb-annotations;version='[2.8.5,2.8.6)',\
-	org.glassfish.web.javax.el;version='[2.2.4,2.2.5)'
+	org.glassfish.web.javax.el;version='[2.2.4,2.2.5)',\
+	org.hibernate.javax.persistence.hibernate-jpa-2.1-api;version='[1.0.0,1.0.1)'
 

--- a/osc-uber/bnd.bnd
+++ b/osc-uber/bnd.bnd
@@ -10,9 +10,9 @@ Require-Capability: \
     osgi.implementation;filter:="(&(osgi.implementation=osgi.http)(version>=1)(!(version>=2)))"
 
 # Automatically export packages annotated with @Version in package-info.java
-# The JPA and hibernate exports are temporary until Hibernate is extracted from the uber bundle
+# The hibernate exports are temporary until Hibernate is extracted from the uber bundle
 -exportcontents: ${packages;VERSIONED}, \
-    javax.persistence, org.hibernate.annotations;version=5.0.1,\
+    org.hibernate.annotations;version=5.0.1,\
     org.hibernate.proxy;uses:="javassist.util.proxy", \
     javassist.util.proxy
   
@@ -50,7 +50,6 @@ Require-Capability: \
     @${h2.dep},\
     @${hibernate-commons-annotations.dep},\
     @${hibernate-core.dep},\
-    @${hibernate-jpa-2.1-api.dep},\
     @${jackson-annotations.dep},\
     @${jackson-core.dep},\
     @${jackson-databind.dep},\


### PR DESCRIPTION
Pull the JPA API bundle out of osc-uber and into the server.bndrun -runbundles list, to fix sample plugin resolution error:

Unable to resolve security-mgr-sample-plugin [82](R 82.0): missing requirement [security-mgr-sample-plugin [82](R 82.0)] osgi.wiring.package; (&(osgi.wiring.package=javax.persistence)(version>=1.2.0)(!(version>=2.0.0))) Unresolved requirements: [[security-mgr-sample-plugin [82](R 82.0)] osgi.wiring.package; (&(osgi.wiring.package=javax.persistence)(version>=1.2.0)(!(version>=2.0.0)))]