### PR TITLE
Clear error messages when biding across tenants and domains

### DIFF
--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OpenstackUtil.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OpenstackUtil.java
@@ -18,11 +18,14 @@ package org.osc.core.broker.service.tasks.conformance.openstack.deploymentspec;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.hibernate.Session;
 import org.jclouds.openstack.neutron.v2.domain.Port;
@@ -41,10 +44,12 @@ import org.osc.core.broker.model.entities.appliance.DistributedApplianceInstance
 import org.osc.core.broker.model.entities.appliance.VirtualSystem;
 import org.osc.core.broker.model.entities.events.SystemFailureType;
 import org.osc.core.broker.model.entities.virtualization.SecurityGroup;
+import org.osc.core.broker.model.entities.virtualization.SecurityGroupMember;
 import org.osc.core.broker.model.entities.virtualization.VirtualizationConnector;
 import org.osc.core.broker.model.entities.virtualization.openstack.DeploymentSpec;
 import org.osc.core.broker.model.entities.virtualization.openstack.VM;
 import org.osc.core.broker.model.entities.virtualization.openstack.VMPort;
+import org.osc.core.broker.model.plugin.sdncontroller.NetworkElementImpl;
 import org.osc.core.broker.model.plugin.sdncontroller.SdnControllerApiFactory;
 import org.osc.core.broker.rest.client.openstack.jcloud.Endpoint;
 import org.osc.core.broker.rest.client.openstack.jcloud.HostAvailabilityZoneMapping;
@@ -58,11 +63,12 @@ import org.osc.core.broker.service.persistence.EntityManager;
 import org.osc.core.broker.service.persistence.SecurityGroupEntityMgr;
 import org.osc.core.broker.service.persistence.VMEntityManager;
 import org.osc.core.util.encryption.EncryptionException;
+import org.osc.sdk.controller.DefaultNetworkPort;
 import org.osc.sdk.controller.element.NetworkElement;
 
 public class OpenstackUtil {
 
-    private static final Logger log = Logger.getLogger(OpenstackUtil.class);
+    private static final Logger LOG = Logger.getLogger(OpenstackUtil.class);
 
     private static final int SLEEP_DISCOVERY_RETRIES = 10 * 1000; // 10 seconds
     private static final int MAX_DISCOVERY_RETRIES = 40;
@@ -121,7 +127,7 @@ public class OpenstackUtil {
                     throw new VmidcException("VM is in bad state (" + server.getStatus() + ")");
                 }
 
-                log.info("Retry VM discovery (" + i + "/" + MAX_DISCOVERY_RETRIES + ") of VM '" + vmId + "' Status: "
+                LOG.info("Retry VM discovery (" + i + "/" + MAX_DISCOVERY_RETRIES + ") of VM '" + vmId + "' Status: "
                         + server.getStatus());
                 Thread.sleep(SLEEP_DISCOVERY_RETRIES);
                 i--;
@@ -143,10 +149,10 @@ public class OpenstackUtil {
                     }
                 }
                 if (activePorts >= 2) {
-                    log.info("VM network discovery (interfaces: " + interfaces + ")");
+                    LOG.info("VM network discovery (interfaces: " + interfaces + ")");
                     break;
                 }
-                log.info("Retry VM network discovery (" + i + "/" + MAX_DISCOVERY_RETRIES + ") of VM '"
+                LOG.info("Retry VM network discovery (" + i + "/" + MAX_DISCOVERY_RETRIES + ") of VM '"
                         + server.getName() + "' (interfaces: " + interfaces + ")");
                 Thread.sleep(SLEEP_DISCOVERY_RETRIES);
                 i--;
@@ -168,185 +174,192 @@ public class OpenstackUtil {
      * If found, we try finding the least loaded (based on port assignment).
      *
      *
-     * @param session
-     *            session
-     * @param region
-     *            the region to search for DAI
-     * @param tenantId
-     *            the tenant ID to find a dedicated deployment spec to latch onto. If empty string is passed then
-     *            we will find a shared deployment spec. Cannot pass in null
-     * @param host
-     *            the host to find the DAI on
-     * @param vs
-     *            the virtual system(service) appliance to look for
-     *
+     * @param session  the database session
+     * @param region  the OpenStack region of the deployment
+     * @param tenantId  the OpenStack tenant of the deployment.
+     *            If empty string, the search will target shared deployment sepcs. This parameter cannot be null.
+     * @param host the host of the DAI
+     * @param vs  the virtual system of the deployment specs.
      * @return a deployed SVA/DAI
      *
-     * @throws VmidcBrokerValidationException
-     *             if there are no valid DAI/SVA's available with the provided criteria.
+     * @throws VmidcBrokerValidationException if there are no valid DAI/SVA's available with the provided criteria.
      */
-    public static DistributedApplianceInstance findDeployedDAI(Session session, String region, String tenantId,
-            String host, VirtualSystem vs) throws Exception {
+    public static DistributedApplianceInstance findDeployedDAI(
+            Session session,
+            VirtualSystem vs,
+            SecurityGroup sg,
+            String tenantId,
+            String region,
+            String domainId,
+            String host) throws Exception {
 
         DeploymentSpec selectedDs = null;
-
-        ArrayList<DeploymentSpec> exclusiveDsList = new ArrayList<DeploymentSpec>();
-        ArrayList<DeploymentSpec> sharedDsList = new ArrayList<DeploymentSpec>();
+        boolean supportsOffboxRedirection = SdnControllerApiFactory.supportsOffboxRedirection(vs);
 
         // Get all DSs that are uses the same region
         for (DeploymentSpec ds : vs.getDeploymentSpecs()) {
             // Examine only DS of same region
-            if (ds.getRegion().equals(region)) {
-                if (ds.isShared()) {
-                    sharedDsList.add(ds);
-                } else if (ds.getTenantId().equals(tenantId)) {
-                    exclusiveDsList.add(ds);
-                }
+            if (ds.getRegion().equals(region) && ds.getTenantId().equals(tenantId)) {
+                selectedDs = ds;
+                // If we found an exclusive DS, there must be one and only one for that tenant
+                break;
             }
         }
 
         DistributedApplianceInstance dai = null;
-        if (exclusiveDsList.size() > 0) {
-            // If we found an exclusive DS, there must be one and only one for that tenant
-            selectedDs = exclusiveDsList.get(0);
-            dai = findLeastLoadedDAI(selectedDs.getDistributedApplianceInstances(), host);
-            if (dai == null) {
-                // It is possible that the exclusive DS does not contain a deployment on the requested host.
-                // Resort to shared DS.
-                selectedDs = null;
-            } else {
+
+        if (selectedDs == null || selectedDs.getDistributedApplianceInstances().isEmpty()) {
+            // We did not find a DS with a host deployment and
+            // the SDN controller does not support off-box traffic redirection.
+            throw new VmidcBrokerValidationException(String.format("No distributed appliance instance was found for the tenant %s and host %s.", tenantId, host));
+        }
+
+        if (!supportsOffboxRedirection) {
+            return findLeastLoadedDAI(selectedDs.getDistributedApplianceInstances(), sg, host, domainId);
+        } else {
+            try  {
+                dai = findLeastLoadedDAI(selectedDs.getDistributedApplianceInstances(), sg, host, domainId);
+            } catch (Exception ex){
+                if (host == null) {
+                    // The host is not defined, availability zone is not applicable. Stop here.
+                    throw ex;
+                }
+
+                LOG.warn("Finding a DAI returned an error, "
+                        + "attempting to find an instance offbox as the SDN controller supports offbox redirection", ex);
+            }
+
+            if (dai != null) {
                 return dai;
             }
-        }
 
-        if (selectedDs == null) {
-            if (!sharedDsList.isEmpty() && host == null) {
-                // for router protection we will provide first Shared DS we have...
-                selectedDs = sharedDsList.get(0);
-            } else {
-                // If a exclusive DS not found, search for a shared deployment
-                // specs (including dynamic which is shared by definition).
-                selectedDs = findLeastLoadedDSWithHost(sharedDsList, host);
-            }
-        }
-
-        if (selectedDs != null) {
-            // We found a DS that includes a deployment(s) on the host.
-            // It is possible there are more then one instance deployed on the same host so need load balance.
-            // We'll choose the one least used, by total count of ports handled by a DIA.
-            //
-            // Later on we can add more sophisticated algorithm to leverage historic throughput and virtual
-            // resource utilization.
-            return findLeastLoadedDAI(selectedDs.getDistributedApplianceInstances(), host);
-
-        } else {
-
-            // No DS found that has deployments on that host. Our last resort is to try off-boxing
-            if (!SdnControllerApiFactory.supportsOffboxRedirection(vs)) {
-                // We did not find a DS with a host deployment, either exclusive or shared.
-                // And, our SDN controller does not support off-box traffic redirection.
-                throw new VmidcBrokerValidationException(
-                        "No Distributed Appliance Deployment Specifications found covering host '" + host + "'");
-            }
-
-            // If we've reached this point, that means we did not find DAI on the requested host and our controller
-            // supports off-box redirection.
-            // Find a DAI on a different host that is in close proximity (same Availability-Zone as requested host).
-
-            try (JCloudNova novaApi = new JCloudNova(new Endpoint(vs.getVirtualizationConnector()))){
-                // First figure out current host/AZ map.
-                List<AvailabilityZoneDetails> osAvailabilityZones = novaApi.getAvailabilityZonesDetail(region);
-                HostAvailabilityZoneMapping hostAvailabilityZoneMap = JCloudNova.getMapping(osAvailabilityZones);
-
-                DistributedApplianceInstance selectedDai = null;
-                // Get AZ for host in question
-                if (host != null) {
-                    String az = hostAvailabilityZoneMap.getHostAvailibilityZone(host);
-
-                    // Search for DAI in exclusive DSs of the same region and tenant
-                    selectedDai = findLeastLoadedDAI(getDAIsByAZ(exclusiveDsList, hostAvailabilityZoneMap, az), null);
-
-                    if (selectedDai == null) {
-                        // No exclusive DAI found
-                        selectedDai = findLeastLoadedDAI(getDAIsByAZ(sharedDsList, hostAvailabilityZoneMap, az), null);
-                    }
-                    if (selectedDai == null) {
-                        throw new VmidcBrokerValidationException(
-                                "No Appliance Instance found to handle traffic inspection within the same Availibility Zone ('"
-                                        + az + "') as host '" + host + "'");
-                    }
-                }
-
-                return selectedDai;
-
-            }
+            List<DistributedApplianceInstance> azDais = getDAIsByHostAZ(selectedDs, vs, region, host);
+            return findLeastLoadedDAI(azDais, sg, null, domainId);
         }
     }
 
-    private static DeploymentSpec findLeastLoadedDSWithHost(List<DeploymentSpec> dsList, String host) throws Exception {
-        if (dsList == null || dsList.isEmpty()) {
-            return null;
-        }
-        // Choose DS/DDS that has a DAI on the requested host with the least amount of protected ports
-        DistributedApplianceInstance selectedDai = findLeastLoadedDAI(getDAIsByHost(dsList, host), null);
-        if (selectedDai != null) {
-            return selectedDai.getDeploymentSpec();
+    public static List<NetworkElement> getPorts(SecurityGroupMember sgm) throws VmidcBrokerValidationException {
+
+        Set<VMPort> ports;
+        switch (sgm.getType()) {
+        case VM:
+            ports = sgm.getVm().getPorts();
+            break;
+        case NETWORK:
+            ports = sgm.getNetwork().getPorts();
+            break;
+        case SUBNET:
+            ports = sgm.getSubnet().getPorts();
+            break;
+        default:
+            throw new VmidcBrokerValidationException("Region is not applicable for Members of type '" + sgm.getType() + "'");
         }
 
-        return null;
+        return ports.stream()
+                .map(NetworkElementImpl::new)
+                .collect(Collectors.toList());
     }
 
-    private static DistributedApplianceInstance findLeastLoadedDAI(Collection<DistributedApplianceInstance> dais,
-            String host) {
+    private static DistributedApplianceInstance findLeastLoadedDAI(
+            Collection<DistributedApplianceInstance> dais,
+            SecurityGroup sg,
+            String host,
+            String domainId) throws Exception {
 
         DistributedApplianceInstance selectedDai = null;
-        String normalizedHostName = null;
-        if (host != null) {
-            normalizedHostName = OpenstackUtil.normalizeHostName(host);
+
+        dais = filterDAIsByDomain(dais, sg.getVirtualizationConnector(), sg.getVirtualizationConnector().getProviderAdminTenantName(), domainId);
+
+        if (dais.isEmpty()) {
+            throw new VmidcBrokerValidationException(String.format("No appliance instance found in a network assigned to the router/domain %s.", domainId));
         }
 
+        dais = filterDAIsByHost(dais, host);
+
+        if (dais.isEmpty()) {
+            throw new VmidcBrokerValidationException(String.format("No appliance instance found for host %s.", host));
+        }
+
+        // If no DAI was yet assigned to a security group then return the least loaded one.
         for (DistributedApplianceInstance dai : dais) {
-            if (host != null && dai.getOsHostName().equals(host) || dai.getOsHostName().equals(normalizedHostName)) {
-                if (selectedDai == null) {
-                    selectedDai = dai;
-                } else if (dai.getProtectedPorts().size() < selectedDai.getProtectedPorts().size()) {
-                    selectedDai = dai;
-                }
-            } else {
-                if (selectedDai == null) {
-                    selectedDai = dai;
-                } else if (dai.getProtectedPorts().size() < selectedDai.getProtectedPorts().size()) {
-                    selectedDai = dai;
-                }
+            if (selectedDai == null) {
+                selectedDai = dai;
+            } else if (dai.getProtectedPorts().size() < selectedDai.getProtectedPorts().size()) {
+                selectedDai = dai;
             }
         }
+
         return selectedDai;
     }
 
-    private static ArrayList<DistributedApplianceInstance> getDAIsByHost(Collection<DeploymentSpec> dsList, String host) {
-        String normalizedHostName = OpenstackUtil.normalizeHostName(host);
-
-        ArrayList<DistributedApplianceInstance> dais = new ArrayList<DistributedApplianceInstance>();
-        for (DeploymentSpec ds : dsList) {
-            // TODO: Future. Optimize by using DB query
-            for (DistributedApplianceInstance dai : ds.getDistributedApplianceInstances()) {
-                if (dai.getOsHostName().equals(host) || dai.getOsHostName().equals(normalizedHostName)) {
-                    dais.add(dai);
-                }
-            }
+    private static Collection<DistributedApplianceInstance> filterDAIsByDomain(
+            Collection<DistributedApplianceInstance> dais,
+            VirtualizationConnector vc,
+            String tenantId,
+            String domainId) throws Exception  {
+        if (StringUtils.isBlank(domainId)) {
+            // No domain identifier provided, nothing to filter.
+            return dais;
         }
-        return dais;
+
+        return dais
+                .stream()
+                .filter(dai -> {
+                    try {
+                        return extractDomainId(tenantId, vc, dai).equals(domainId);
+                    } catch (Exception ex) {
+                        LOG.error(String.format("Failure while extracting the domain for DAI %s.", dai.getName(), ex));
+                        return false;
+                    }
+                })
+                .collect(Collectors.toList());
+
     }
 
-    private static ArrayList<DistributedApplianceInstance> getDAIsByAZ(ArrayList<DeploymentSpec> dsList,
-            HostAvailabilityZoneMapping hostAvailabilityZoneMap, String az) throws VmidcException {
+    private static Collection<DistributedApplianceInstance> filterDAIsByHost(Collection<DistributedApplianceInstance> dais, String host) {
+        if (StringUtils.isBlank(host)) {
+            return dais;
+        }
+
+        String normalizedHostName = OpenstackUtil.normalizeHostName(host);
+
+        return dais
+                .stream()
+                .filter(dai -> dai.getOsHostName().equals(host) || dai.getOsHostName().equals(normalizedHostName))
+                .collect(Collectors.toList());
+    }
+
+    // TODO emanoel: We should revisit the signature and implementation of the existing extractDomainId instead.
+    // I.e.: It should not take the entire network element since it just needs the id.
+    // Not doing that now to avoid additional churn on the Nuage current coding efforts.
+    private static String extractDomainId(String tenantId, VirtualizationConnector vc, DistributedApplianceInstance dai) throws IOException, EncryptionException {
+        DefaultNetworkPort ingressPort = new DefaultNetworkPort(dai.getInspectionOsIngressPortId(), dai.getInspectionIngressMacAddress());
+        return OpenstackUtil.extractDomainId(
+                dai.getDeploymentSpec().getTenantId(),
+                tenantId,
+                vc,
+                Arrays.asList(ingressPort));
+    }
+
+    private static ArrayList<DistributedApplianceInstance> getDAIsByHostAZ(DeploymentSpec ds, VirtualSystem vs, String region, String host) throws Exception {
         ArrayList<DistributedApplianceInstance> dais = new ArrayList<DistributedApplianceInstance>();
-        for (DeploymentSpec ds : dsList) {
-            for (DistributedApplianceInstance dai : ds.getDistributedApplianceInstances()) {
-                // TODO: Future. Optimize by using DB query
-                String daiAz = hostAvailabilityZoneMap.getHostAvailibilityZone(dai.getHostName());
-                if (daiAz != null && daiAz.equals(az)) {
-                    dais.add(dai);
+
+        try (JCloudNova novaApi = new JCloudNova(new Endpoint(vs.getVirtualizationConnector()))){
+            // First figure out current host/AZ map.
+            List<AvailabilityZoneDetails> osAvailabilityZones = novaApi.getAvailabilityZonesDetail(region);
+            HostAvailabilityZoneMapping hostAvailabilityZoneMap = JCloudNova.getMapping(osAvailabilityZones);
+
+            // Get AZ for host in question
+            if (host != null) {
+                String az = hostAvailabilityZoneMap.getHostAvailibilityZone(host);
+
+                // Search for DAI in exclusive DSs of the same region and tenant
+                for (DistributedApplianceInstance dai : ds.getDistributedApplianceInstances()) {
+                    // TODO: Future. Optimize by using DB query
+                    String daiAz = hostAvailabilityZoneMap.getHostAvailibilityZone(dai.getHostName());
+                    if (daiAz != null && daiAz.equals(az)) {
+                        dais.add(dai);
+                    }
                 }
             }
         }
@@ -394,7 +407,7 @@ public class OpenstackUtil {
         if (!sgs.isEmpty()) {
             Job job = JobEngine.getEngine().getJobByTask(task);
             for (SecurityGroup sg : sgs) {
-                log.info("Scheduling SG job for sg: " + sg + " on behalf of DAI: " + dai);
+                LOG.info("Scheduling SG job for sg: " + sg + " on behalf of DAI: " + dai);
                 job.addListener(new StartSecurityGroupJobListener(sg));
             }
         }

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/PortGroupCheckTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/PortGroupCheckTask.java
@@ -19,7 +19,6 @@ package org.osc.core.broker.service.tasks.conformance.openstack.securitygroup;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.hibernate.Session;
@@ -27,8 +26,6 @@ import org.osc.core.broker.job.lock.LockObjectReference;
 import org.osc.core.broker.model.entities.virtualization.SecurityGroup;
 import org.osc.core.broker.model.entities.virtualization.SecurityGroupMember;
 import org.osc.core.broker.model.entities.virtualization.openstack.VMPort;
-import org.osc.core.broker.model.plugin.sdncontroller.NetworkElementImpl;
-import org.osc.core.broker.service.exceptions.VmidcBrokerValidationException;
 import org.osc.core.broker.service.tasks.TransactionalTask;
 import org.osc.core.broker.service.tasks.conformance.openstack.deploymentspec.OpenstackUtil;
 import org.osc.core.broker.service.tasks.conformance.openstack.securitygroup.element.PortGroup;
@@ -49,13 +46,13 @@ public class PortGroupCheckTask extends TransactionalTask {
 
     @Override
     public void executeTransaction(Session session) throws Exception {
-        this.sg = (SecurityGroup) session.get(SecurityGroup.class, this.sg.getId());
+        this.sg = session.get(SecurityGroup.class, this.sg.getId());
 
         Set<SecurityGroupMember> members = this.sg.getSecurityGroupMembers();
         List<NetworkElement> protectedPorts = new ArrayList<>();
 
         for (SecurityGroupMember sgm : members) {
-            protectedPorts.addAll(getPorts(sgm));
+            protectedPorts.addAll(OpenstackUtil.getPorts(sgm));
         }
         String domainId = OpenstackUtil.extractDomainId(this.sg.getTenantId(), this.sg.getTenantName(),
                 this.sg.getVirtualizationConnector(), protectedPorts);
@@ -95,28 +92,6 @@ public class PortGroupCheckTask extends TransactionalTask {
                 }
             }
         }
-    }
-
-    private List<NetworkElement> getPorts(SecurityGroupMember sgm) throws VmidcBrokerValidationException {
-
-        Set<VMPort> ports;
-        switch (sgm.getType()) {
-        case VM:
-            ports = sgm.getVm().getPorts();
-            break;
-        case NETWORK:
-            ports = sgm.getNetwork().getPorts();
-            break;
-        case SUBNET:
-            ports = sgm.getSubnet().getPorts();
-            break;
-        default:
-            throw new VmidcBrokerValidationException("Region is not applicable for Members of type '" + sgm.getType() + "'");
-        }
-
-        return ports.stream()
-                .map(NetworkElementImpl::new)
-                .collect(Collectors.toList());
     }
 
     @Override

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/SecurityGroupUpdateOrDeleteMetaTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/SecurityGroupUpdateOrDeleteMetaTask.java
@@ -127,14 +127,8 @@ class SecurityGroupUpdateOrDeleteMetaTask extends TransactionalMetaTask {
     }
 
     private void buildTaskGraph(Session session, boolean isDeleteTg) throws Exception {
-        VmDiscoveryCache vdc;
-        if (isDeleteTg) {
-            vdc = new VmDiscoveryCache(this.sg.getVirtualizationConnector(), this.sg.getVirtualizationConnector()
-                    .getProviderAdminTenantName());
-        } else {
-            vdc = new VmDiscoveryCache(this.sg.getVirtualizationConnector(), this.sg.getVirtualizationConnector()
-                    .getProviderAdminTenantName());
-        }
+        VmDiscoveryCache vdc = new VmDiscoveryCache(this.sg.getVirtualizationConnector(), this.sg.getVirtualizationConnector()
+                .getProviderAdminTenantName());
 
         // SGM Member sync with no task deferred
         addSGMemberSyncJob(session, isDeleteTg, vdc);


### PR DESCRIPTION
1. Removing search for shared DS when finding a suitable DAIs (shared DS are meant to be used across tenants).
2. Improving error message when a DS or DAI is not found in the SG tenant.
3. Adding a filter to find a DAI based on the router/domainid of the workload VM and proper error message if one is not found.
4. Added place holder for finding a DAI that is already assigned to the SG (implementation to be added from a different user story).
5. Fixing a pre-existing bug: creation of a SG on a tenant different than the one in the VC was failing.