### PR TITLE
[static-factories] fix ability to add NSX plugin. 

### DIFF
--- a/osc-server/src/main/java/org/osc/core/broker/model/plugin/sdncontroller/SdnControllerApiFactory.java
+++ b/osc-server/src/main/java/org/osc/core/broker/model/plugin/sdncontroller/SdnControllerApiFactory.java
@@ -129,7 +129,11 @@ public class SdnControllerApiFactory {
 
     public static <T> PluginTracker<T> newPluginTracker(PluginTrackerCustomizer<T> customizer, Class<T> pluginClass,
             PluginType pluginType) throws ServiceUnavailableException, VmidcException {
-        return apiFactoryService.newPluginTracker(customizer, pluginClass, pluginType, REQUIRED_SDN_CONTROLLER_PLUGIN_PROPERTIES);
+        Map<String, Class<?>> requiredProperties = null;
+        if (pluginClass == SdnControllerApi.class) {
+            requiredProperties = REQUIRED_SDN_CONTROLLER_PLUGIN_PROPERTIES;
+        }
+        return apiFactoryService.newPluginTracker(customizer, pluginClass, pluginType, requiredProperties);
     }
 
     public static Boolean supportsOffboxRedirection(VirtualSystem vs) throws Exception {


### PR DESCRIPTION
code used to enforce the REQUIRED_SDN_CONTROLLER_PROPERTIES on all plugin types, now only on SDN plugin types.

The NSX plugin now shows in the manage plugins view as READY.