### PR TITLE
Mlos clean up

### DIFF
--- a/osc-server-bom/root/opt/vmidc/bin/vmidcShell.py
+++ b/osc-server-bom/root/opt/vmidc/bin/vmidcShell.py
@@ -60,9 +60,8 @@ VMIDCSERVICE="securityBroker"
 VMIDCLOG="/opt/vmidc/bin/log/securityBroker.log"
 IPREGEX="^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
 IPCIDRREGEX="^(((?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/(?:2[0-4]|1[0-9]|[0-9]))|dhcp)$"
-#Modified Domain regex to accept null value and hence adopted new regex value for NTP_DOMAIN--which is not changed
+#Modified Domain regex to accept null value(no arguments) 
 DOMAINREGEX="^$|^[^\s]+$"
-NTP_DOMAINREGEX="^[^\s]+$"
 HOSTNAMEREGEX="^[^\s]+$"
 
 
@@ -453,7 +452,7 @@ class SetNetworkPrompt(ExtendedCmd):
   def do_ntp(self, args):
     """<IP> [<IP> ...]:Set NTP Server(s)"""
     servers = args.split()
-    if validate2(servers, [IPREGEX, NTP_DOMAINREGEX], "Illegal ntp server %s"):
+    if validate2(servers, [IPREGEX, DOMAINREGEX], "Illegal ntp server %s"):
       replace("/etc/ntp.conf", collect("/etc/ntp.conf", None, "^server ", [], ["server " + s for s in servers]))
       replace("/etc/ntp/step-tickers", collect("/etc/ntp/step-tickers", None, ".*", [], servers))
       stop_service("ntpd")


### PR DESCRIPTION
DOMAINREGEX was used for both  domain and ntp server argument check
Modified DOMAINREEX regex to accept no arguments to clear the value.
Added new/Adopted NTP_DOMAINREGEX for NTP, it is equivalent to old DOMAINREGEX