### PR TITLE
Refactor: public constructor in VirtualizationConnectorRequest.

### DIFF
--- a/osc-server/src/main/java/org/osc/core/broker/service/vc/VirtualizationConnectorRequest.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/vc/VirtualizationConnectorRequest.java
@@ -30,7 +30,7 @@ public class VirtualizationConnectorRequest extends VirtualizationConnectorDto i
     private boolean skipRemoteValidation;
     private boolean forceAddSSLCertificates;
 
-    VirtualizationConnectorRequest() {
+    public VirtualizationConnectorRequest() {
     }
 
     public boolean isSkipRemoteValidation() {


### PR DESCRIPTION
Changed to public constructor, is necessary to be parsed from json to dto.