### PR TITLE
Avoid a persistence error when deleting a Deployment

### DIFF
--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/DeleteFlavorTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/DeleteFlavorTask.java
@@ -49,7 +49,10 @@ public class DeleteFlavorTask extends TransactionalTask {
         } finally {
             nova.close();
         }
-        OSCEntityManager.delete(em, this.flavorReference);
+        // We have to find the entity again as the one reference by
+        // this.flavorReference is detached.
+        OSCEntityManager.delete(em, em.find(OsFlavorReference.class,
+                this.flavorReference.getId()));
 
     }
 


### PR DESCRIPTION
Seen:

    Task TaskNode [task=[null], state=RUNNING, status=PASSED, guard=ALL_PREDECESSORS_SUCCEEDED] Failed
    java.lang.IllegalArgumentException: Removing a detached instance org.osc.core.broker.model.entities.virtualization.openstack.OsFlavorReference#1
	at org.hibernate.jpa.event.internal.core.JpaDeleteEventListener.performDetachedEntityDeletionCheck(JpaDeleteEventListener.java:52)
	at org.hibernate.event.internal.DefaultDeleteEventListener.onDelete(DefaultDeleteEventListener.java:89)
	at org.hibernate.event.internal.DefaultDeleteEventListener.onDelete(DefaultDeleteEventListener.java:56)
	at org.hibernate.internal.SessionImpl.fireDelete(SessionImpl.java:984)
	at org.hibernate.internal.SessionImpl.delete(SessionImpl.java:920)
	at org.hibernate.internal.SessionImpl.remove(SessionImpl.java:3341)
	at org.osc.core.broker.service.persistence.OSCEntityManager.delete(OSCEntityManager.java:174)
	at org.osc.core.broker.service.tasks.conformance.openstack.DeleteFlavorTask.executeTransaction(DeleteFlavorTask.java:52)
	at org.osc.core.broker.service.tasks.TransactionalTask.execute(TransactionalTask.java:39)