### PR TITLE
MV_STORE disabled for H2 connection

### DIFF
--- a/osc-export/vmidcServer.conf
+++ b/osc-export/vmidcServer.conf
@@ -4,7 +4,7 @@ db.connection.default.password.keystore.password=JgA\!JMtuj-NgK\=MzHd3QRt-StN$PQ
 server.reboots=0
 nsxExtraAutomation=true
 db.backup.iv.password=42pJrRzUw\=k8\!E\!DkC$rmUMhvSw_Kwy\!
-db.connection.url=jdbc\:h2\:./vmiDCDB;MVCC\=TRUE;LOCK_TIMEOUT\=10000;
+db.connection.url=jdbc\:h2\:./vmiDCDB;MVCC\=TRUE;LOCK_TIMEOUT\=10000;MV_STORE=FALSE;
 db.connection.password.keystore.alias=DB_PASSWORD
 db.backup.iv.alias=DB_BACKUP_IV
 server.port=8090

--- a/osc-server-bom/root/opt/vmidc/bin/vmidcServer.conf
+++ b/osc-server-bom/root/opt/vmidc/bin/vmidcServer.conf
@@ -17,7 +17,7 @@ db.connection.password.keystore.password=pGszjP_6t&pbJcJqm@NFm@Qan7BPyDwB
 db.connection.default.password.keystore.alias=DB_DEFAULT_PASSWORD
 db.connection.default.password.keystore.password=JgA\!JMtuj-NgK\=MzHd3QRt-StN$PQs&^
 
-db.connection.url=jdbc\:h2\:./vmiDCDB;MVCC\=TRUE;LOCK_TIMEOUT\=10000;
+db.connection.url=jdbc\:h2\:./vmiDCDB;MVCC\=TRUE;LOCK_TIMEOUT\=10000;MV_STORE=FALSE;
 db.connection.url.extraArgs=
 
 db.connection.login=admin


### PR DESCRIPTION
Since H2 version 1.4.177 MV_STORE is automatically enabled. Disabled it to maintain compatibility.