### PR TITLE
[tx-control] Ensure Job and Task updates happen in a new transaction

### DIFF
--- a/osc-server/src/main/java/org/osc/core/broker/job/Job.java
+++ b/osc-server/src/main/java/org/osc/core/broker/job/Job.java
@@ -130,7 +130,8 @@ public class Job implements Runnable, JobElement {
         try {
             EntityManager em = HibernateUtil.getTransactionalEntityManager();
             TransactionControl txControl = HibernateUtil.getTransactionControl();
-            txControl.required(() -> {
+            // Use a new transaction to persist this update come what may
+            txControl.requiresNew(() -> {
                     this.jobRecord = em.find(JobRecord.class, this.jobRecord.getId());
                     this.jobRecord.setStatus(getEntityStatus());
                     OSCEntityManager.update(em, this.jobRecord);
@@ -390,7 +391,8 @@ public class Job implements Runnable, JobElement {
         try {
             EntityManager em = HibernateUtil.getTransactionalEntityManager();
             TransactionControl txControl = HibernateUtil.getTransactionControl();
-            txControl.required(() -> {
+            // Use a new transaction to persist this update come what may
+            txControl.requiresNew(() -> {
                     this.jobRecord = em.find(JobRecord.class, this.jobRecord.getId());
 
                     this.jobRecord.setState(getEntityState());
@@ -572,7 +574,8 @@ public class Job implements Runnable, JobElement {
         try {
             EntityManager em = HibernateUtil.getTransactionalEntityManager();
             TransactionControl txControl = HibernateUtil.getTransactionControl();
-            txControl.required(() -> {
+            // Use a new transaction to persist this Job come what may
+            txControl.requiresNew(() -> {
                     JobRecord jobRecord = getJobRecord();
 
                     if (jobRecord == null) {

--- a/osc-server/src/main/java/org/osc/core/broker/job/TaskNode.java
+++ b/osc-server/src/main/java/org/osc/core/broker/job/TaskNode.java
@@ -133,7 +133,8 @@ public class TaskNode implements Runnable, TaskElement {
         try {
             EntityManager em = HibernateUtil.getTransactionalEntityManager();
             TransactionControl txControl = HibernateUtil.getTransactionControl();
-            txControl.required(() -> {
+            // Use a new transaction to persist this update come what may
+            txControl.requiresNew(() -> {
                     this.taskRecord = em.find(TaskRecord.class, this.taskRecord.getId(),
                             LockModeType.PESSIMISTIC_WRITE);
 
@@ -219,7 +220,8 @@ public class TaskNode implements Runnable, TaskElement {
         try {
             EntityManager em = HibernateUtil.getTransactionalEntityManager();
             TransactionControl txControl = HibernateUtil.getTransactionControl();
-            txControl.required(() -> {
+            // Use a new transaction to persist this update come what may
+            txControl.requiresNew(() -> {
                     this.taskRecord = em.find(TaskRecord.class, this.taskRecord.getId(),
                             LockModeType.PESSIMISTIC_WRITE);
 


### PR DESCRIPTION
See Issue #127

When creating a Job the current code inherits the surrounding transaction. This means that the Job is actually started before the Job is committed to the database, and so is not guaranteed to be available to task nodes when they complete. This race condition is resulting in NPEs when using the Conform Service.

The simple and effective fix is to ensure a new transaction is used to persist and update the Job. This is easily achieved by using `requiresNew` rather than `required`. After this change the Job will be persisted before the Job starts, eliminating the race condition. Updates receive similar treatment to avoid potential lock collisions. 

