### PR TITLE
Ensure that Distributed Appliance deletion uses a live entity

### DIFF
--- a/osc-server/src/main/java/org/osc/core/broker/service/DeleteDistributedApplianceService.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/DeleteDistributedApplianceService.java
@@ -139,7 +139,11 @@ public class DeleteDistributedApplianceService extends ServiceDispatcher<BaseDel
                 chain(() -> {
                     try {
                         BaseJobResponse result = new BaseJobResponse();
-                        Job job = startDeleteDAJob(da, forLambda);
+                        // This is a new transaction so we need to get a live
+                        // managed DA instance - if not then we can't read lazy fields
+                        // and or may have invalid state
+                        DistributedAppliance liveDA = em.find(DistributedAppliance.class, da.getId());
+                        Job job = startDeleteDAJob(liveDA, forLambda);
                         result.setJobId(job.getId());
                         return result;
                     } catch (Exception e) {

--- a/osc-server/src/test/java/org/osc/core/broker/service/DeleteDistributedApplianceServiceTest.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/DeleteDistributedApplianceServiceTest.java
@@ -124,6 +124,7 @@ public class DeleteDistributedApplianceServiceTest {
         Mockito.when(HibernateUtil.getTransactionControl()).thenReturn(this.txControl);
 
         VALID_DA_WITH_SYSTEMS.setName("name");
+        VALID_DA_WITH_SYSTEMS.setId(VALID_ID);
         VirtualizationConnector openStackVirtualizationConnector = new VirtualizationConnector();
         openStackVirtualizationConnector.setVirtualizationType(VirtualizationType.OPENSTACK);
         VirtualSystem openStackVirtualSystem = new VirtualSystem();
@@ -141,6 +142,9 @@ public class DeleteDistributedApplianceServiceTest {
         Mockito.when(this.validatorMock.validateAndLoad(VALID_REQUEST_FORCE_DELETE)).thenReturn(VALID_DA);
         Mockito.when(this.validatorMock.validateAndLoad(VALID_REQUEST_NOT_FORCE_DELETE)).thenReturn(VALID_DA_WITH_SYSTEMS);
         Mockito.when(this.validatorMock.validateAndLoad(UNLOCKABLE_DA_REQUEST)).thenReturn(UNLOCKABLE_DA);
+
+        Mockito.when(this.em.find(DistributedAppliance.class, VALID_REQUEST_NOT_FORCE_DELETE.getId()))
+            .thenReturn(VALID_DA_WITH_SYSTEMS);
 
         UnlockObjectMetaTask ult = new UnlockObjectMetaTask(null);
         PowerMockito.mockStatic(LockUtil.class);


### PR DESCRIPTION
Lazy-loaded fields are only available for "live" managed entities. Distributed Appliance deletion takes place in two transactions, meaning that the entities become detached part way through. Reloading the entity avoids this by ensuring that the entity is managed.