### PR TITLE
Bug fixes for delete port groups and port group hooks

### DIFF
--- a/osc-server/src/main/java/org/osc/core/broker/model/plugin/sdncontroller/VirtualizationConnectorElementImpl.java
+++ b/osc-server/src/main/java/org/osc/core/broker/model/plugin/sdncontroller/VirtualizationConnectorElementImpl.java
@@ -57,7 +57,7 @@ public class VirtualizationConnectorElementImpl implements VirtualizationConnect
     @Override
     public boolean isControllerHttps() {
         // TODO: Future. Need to add support for Controller HTTPS access
-        return false;
+        return this.virtualizationConnector.getControllerType().equals("NSC") ? false : true;
     }
 
     @Override

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/DeleteInspectionPortTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/DeleteInspectionPortTask.java
@@ -83,7 +83,7 @@ public class DeleteInspectionPortTask extends TransactionalTask {
 
     @Override
     public String getName() {
-        return String.format("Deleting Inspection Port of Server '%s' using SDN Controller plugin", this.dai);
+        return String.format("Deleting Inspection Port of Server '%s' using SDN Controller plugin", this.dai.getName());
     }
 
     @Override

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OpenstackUtil.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OpenstackUtil.java
@@ -46,6 +46,7 @@ import org.osc.core.broker.model.entities.appliance.VirtualSystem;
 import org.osc.core.broker.model.entities.events.SystemFailureType;
 import org.osc.core.broker.model.entities.virtualization.SecurityGroup;
 import org.osc.core.broker.model.entities.virtualization.SecurityGroupMember;
+import org.osc.core.broker.model.entities.virtualization.SecurityGroupMemberType;
 import org.osc.core.broker.model.entities.virtualization.VirtualizationConnector;
 import org.osc.core.broker.model.entities.virtualization.openstack.DeploymentSpec;
 import org.osc.core.broker.model.entities.virtualization.openstack.VM;
@@ -106,6 +107,20 @@ public class OpenstackUtil {
                 }
         }
         return domainId;
+    }
+
+    public static VMPort getAnyProtectedPort(SecurityGroup sg) {
+        for (SecurityGroupMember sgm : sg.getSecurityGroupMembers()) {
+            if (sgm.getType() == SecurityGroupMemberType.VM) {
+                return sgm.getVm().getPorts().iterator().next();
+            } else if (sgm.getType() == SecurityGroupMemberType.NETWORK) {
+                return sgm.getNetwork().getPorts().iterator().next();
+            } else if (sgm.getType() == SecurityGroupMemberType.SUBNET) {
+                return sgm.getSubnet().getPorts().iterator().next();
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/CheckPortGroupHookMetaTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/CheckPortGroupHookMetaTask.java
@@ -76,6 +76,9 @@ public final class CheckPortGroupHookMetaTask extends TransactionalMetaTask {
         if (this.sgi.getNetworkElementId() != null) {
             try (SdnRedirectionApi redirection = SdnControllerApiFactory.createNetworkRedirectionApi(this.sgi.getVirtualSystem())) {
                 existingInspHook = redirection.getInspectionHook(this.sgi.getNetworkElementId());
+                if (existingInspHook == null) {
+                    LOG.info(String.format("A inspection hook with the id %s was not found.", this.sgi.getNetworkElementId()));
+                }
             }
         }
 
@@ -94,13 +97,14 @@ public final class CheckPortGroupHookMetaTask extends TransactionalMetaTask {
 
                 // If the existing inspection hook has ingress or egress port IDs
                 // different than the found assigned DAI then update the inspection hook.
-                if (!existingInspHook.getInspectionPort().getIngressPort().getElementId()
+                // TODO emanoel: Update is curretly not support by the Nuage plugin. Skipping the code below.
+                /*if (!existingInspHook.getInspectionPort().getIngressPort().getElementId()
                         .equals(assignedRedirectedDai.getInspectionOsIngressPortId()) ||
                         !existingInspHook.getInspectionPort().getEgressPort().getElementId()
                         .equals(assignedRedirectedDai.getInspectionOsEgressPortId())) {
 
                     this.tg.appendTask(new UpdatePortGroupHookTask(this.sgi, assignedRedirectedDai));
-                }
+                }*/
             }
         } else {
             if (existingInspHook != null) {

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/DeallocateDAIOfSGIMembersTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/DeallocateDAIOfSGIMembersTask.java
@@ -48,6 +48,6 @@ public class DeallocateDAIOfSGIMembersTask extends UpdateDAIToSGIMembersTask {
 
     @Override
     public String getName() {
-        return String.format("Detaching the DAI %s from all the ports in the SGI %s.", getDai().getName(), getSGI());
+        return String.format("Detaching the DAI %s from all the ports in the SGI %s.", getDai().getName(), getSGI().getName());
     }
 }

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/DeletePortGroupTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/DeletePortGroupTask.java
@@ -18,7 +18,6 @@ package org.osc.core.broker.service.tasks.conformance.openstack.securitygroup;
 
 import javax.persistence.EntityManager;
 
-import org.apache.log4j.Logger;
 import org.osc.core.broker.model.entities.virtualization.SecurityGroup;
 import org.osc.core.broker.model.plugin.sdncontroller.SdnControllerApiFactory;
 import org.osc.core.broker.service.tasks.TransactionalTask;
@@ -26,7 +25,6 @@ import org.osc.core.broker.service.tasks.conformance.openstack.securitygroup.ele
 import org.osc.sdk.controller.api.SdnRedirectionApi;
 
 class DeletePortGroupTask extends TransactionalTask {
-    private static final Logger LOG = Logger.getLogger(DeletePortGroupTask.class);
     private PortGroup portGroup;
     private SecurityGroup securityGroup;
 
@@ -37,6 +35,8 @@ class DeletePortGroupTask extends TransactionalTask {
 
     @Override
     public void executeTransaction(EntityManager em) throws Exception {
+        this.securityGroup = em.find(SecurityGroup.class, this.securityGroup.getId());
+
         SdnRedirectionApi controller = SdnControllerApiFactory.createNetworkRedirectionApi(
                 this.securityGroup.getVirtualizationConnector());
         controller.deleteNetworkElement(this.portGroup);

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/PortGroupCheckMetaTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/PortGroupCheckMetaTask.java
@@ -32,11 +32,13 @@ public class PortGroupCheckMetaTask extends TransactionalMetaTask {
 
     private SecurityGroup securityGroup;
     boolean deleteTg;
+    private final String domainId;
     TaskGraph tg;
 
-    public PortGroupCheckMetaTask(SecurityGroup sg, boolean deleteTg) {
+    public PortGroupCheckMetaTask(SecurityGroup sg, boolean deleteTg, String domainId) {
         this.securityGroup = sg;
         this.deleteTg = deleteTg;
+        this.domainId = domainId;
     }
 
     @Override
@@ -48,6 +50,7 @@ public class PortGroupCheckMetaTask extends TransactionalMetaTask {
         String portGroupId = this.securityGroup.getNetworkElementId();
         PortGroup portGroup = new PortGroup();
         portGroup.setPortGroupId(portGroupId);
+        portGroup.setParentId(this.domainId);
 
         if (portGroupId != null) {
             if (this.deleteTg) {

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/RemovePortGroupHookTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/RemovePortGroupHookTask.java
@@ -66,7 +66,7 @@ public class RemovePortGroupHookTask extends TransactionalTask {
 
     @Override
     public String getName() {
-        return String.format("Deleting the inspection hook for the security group interface '%s' ", this.sgi.getName());
+        return String.format("Deleting the inspection hook for the security group interface %s.", this.sgi.getName());
     }
 
     @Override

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/SecurityGroupUpdateOrDeleteMetaTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/SecurityGroupUpdateOrDeleteMetaTask.java
@@ -17,6 +17,7 @@
 package org.osc.core.broker.service.tasks.conformance.openstack.securitygroup;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -37,10 +38,12 @@ import org.osc.core.broker.model.entities.virtualization.SecurityGroupMember;
 import org.osc.core.broker.model.entities.virtualization.SecurityGroupMemberType;
 import org.osc.core.broker.model.entities.virtualization.openstack.VMPort;
 import org.osc.core.broker.model.plugin.manager.ManagerApiFactory;
+import org.osc.core.broker.model.plugin.sdncontroller.NetworkElementImpl;
 import org.osc.core.broker.model.plugin.sdncontroller.SdnControllerApiFactory;
 import org.osc.core.broker.rest.client.openstack.discovery.VmDiscoveryCache;
 import org.osc.core.broker.rest.client.openstack.jcloud.Endpoint;
 import org.osc.core.broker.rest.client.openstack.jcloud.JCloudNova;
+import org.osc.core.broker.service.exceptions.VmidcBrokerValidationException;
 import org.osc.core.broker.service.persistence.DistributedApplianceInstanceEntityMgr;
 import org.osc.core.broker.service.persistence.OSCEntityManager;
 import org.osc.core.broker.service.securitygroup.BaseSecurityGroupService;
@@ -48,6 +51,7 @@ import org.osc.core.broker.service.securitygroup.SecurityGroupMemberItemDto;
 import org.osc.core.broker.service.securitygroup.exception.SecurityGroupMemberPartOfAnotherSecurityGroupException;
 import org.osc.core.broker.service.tasks.FailedWithObjectInfoTask;
 import org.osc.core.broker.service.tasks.TransactionalMetaTask;
+import org.osc.core.broker.service.tasks.conformance.openstack.deploymentspec.OpenstackUtil;
 import org.osc.core.broker.service.tasks.conformance.securitygroup.DeleteMgrSecurityGroupTask;
 import org.osc.core.broker.service.tasks.conformance.securitygroupinterface.DeleteSecurityGroupInterfaceTask;
 import org.osc.sdk.manager.api.ManagerSecurityGroupApi;
@@ -75,7 +79,24 @@ class SecurityGroupUpdateOrDeleteMetaTask extends TransactionalMetaTask {
 
         if (this.sg.getMarkedForDeletion()) {
             this.log.info("Security Group " + this.sg.getName() + " marked for deletion, deleting Endpoint Group");
-            buildTaskGraph(em, true);
+            // If the SDN supports PG hook we need to retrieve the domainId before
+            // the members are deleted.
+            String domainId = null;
+            if (SdnControllerApiFactory.supportsPortGroup(this.sg)){
+                VMPort sgMemberPort = OpenstackUtil.getAnyProtectedPort(this.sg);
+
+                domainId = OpenstackUtil.extractDomainId(
+                        this.sg.getTenantId(),
+                        this.sg.getVirtualizationConnector().getProviderAdminTenantName(),
+                        this.sg.getVirtualizationConnector(),
+                        Arrays.asList(new NetworkElementImpl(sgMemberPort)));
+
+                if (domainId == null) {
+                    throw new VmidcBrokerValidationException(String.format("No domain found for port %s.", sgMemberPort));
+                }
+            }
+
+            buildTaskGraph(em, true, domainId);
         } else {
             this.log.info("Checking Security Group " + this.sg.getName());
 
@@ -121,12 +142,12 @@ class SecurityGroupUpdateOrDeleteMetaTask extends TransactionalMetaTask {
                 }
 
             }
-            buildTaskGraph(em, false);
+            buildTaskGraph(em, false, null);
         }
 
     }
 
-    private void buildTaskGraph(EntityManager em, boolean isDeleteTg) throws Exception {
+    private void buildTaskGraph(EntityManager em, boolean isDeleteTg, String domainId) throws Exception {
         VmDiscoveryCache vdc = new VmDiscoveryCache(this.sg.getVirtualizationConnector(), this.sg.getVirtualizationConnector()
                 .getProviderAdminTenantName());
 
@@ -135,19 +156,21 @@ class SecurityGroupUpdateOrDeleteMetaTask extends TransactionalMetaTask {
 
         if (this.sg.getVirtualizationConnector().isControllerDefined()){
             if (SdnControllerApiFactory.supportsPortGroup(this.sg)){
-                this.tg.appendTask(new PortGroupCheckMetaTask(this.sg, isDeleteTg),
+                this.tg.appendTask(new PortGroupCheckMetaTask(this.sg, isDeleteTg, domainId),
                         TaskGuard.ALL_PREDECESSORS_COMPLETED);
             }
         }
 
         for (SecurityGroupInterface sgi : this.sg.getSecurityGroupInterfaces()) {
+            List<Task> tasksToSucceedToDeleteSGI = new ArrayList<>();
             if (SdnControllerApiFactory.supportsPortGroup(this.sg)) {
-                this.tg.addTask(new CheckPortGroupHookMetaTask(sgi, isDeleteTg));
+                CheckPortGroupHookMetaTask checkPortGroupMT = new CheckPortGroupHookMetaTask(sgi, isDeleteTg);
+                this.tg.appendTask(checkPortGroupMT);
+                tasksToSucceedToDeleteSGI.add(checkPortGroupMT);
             }
 
             if (sgi.getMarkedForDeletion() || isDeleteTg) {
                 VirtualSystem vs = sgi.getVirtualSystem();
-                List<Task> tasksToSucceedToDeleteSGI = new ArrayList<>();
                 if (ManagerApiFactory.syncsSecurityGroup(vs)) {
                     ManagerSecurityGroupApi mgrSgApi = ManagerApiFactory.createManagerSecurityGroupApi(vs);
                     ManagerSecurityGroupElement mepg = mgrSgApi.getSecurityGroupById(this.sg.getMgrId());

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/UpdateDAIToSGIMembersTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/UpdateDAIToSGIMembersTask.java
@@ -53,7 +53,7 @@ public abstract class UpdateDAIToSGIMembersTask extends TransactionalTask {
         this.sgi = em.find(SecurityGroupInterface.class, this.sgi.getId());
         this.dai = em.find(DistributedApplianceInstance.class, this.dai.getId(), LockModeType.PESSIMISTIC_WRITE);
 
-        if (this.sgi.getSecurityGroup().getSecurityGroupMembers() == null) {
+        if (this.sgi.getSecurityGroup() == null || this.sgi.getSecurityGroup().getSecurityGroupMembers() == null) {
             LOG.info(String.format("The SGI %s security group does not have members.", this.sgi.getName()));
             return;
         }


### PR DESCRIPTION
This PR fixes the following issues:
1. For the Nuage plugin tests to pass the property isHttps needed to be consumed from the VCElement. OSC was providing always 'http' to the SDN controller plugins though.  As it was, either the tests could pass or OSC could use the plugin. This fixes the issue on the OSC side and the tests can be once again reenable in the Nuage plugin. I recommend that we do a more flexible solution for this though, see #136
2. Provides the domain id when deleting the port group.
3. Places the check port group hook metatask in the correct place in the graph, previously it was being added after the SGI deletion happens. 
4. Fixes other NPE and problems when generating task names.