### PR TITLE
Adding QA Build Option to Include Plugins

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -19,6 +19,7 @@
 			<arg value="install" />
 			<arg value="-Dmaven.test.skip=true" />
             <arg value="-PuseGit" if:true="${useGit}"/>
+			<arg value="-Pall" if:true="${all}"/>
 		</exec>
 	</target>
 
@@ -57,8 +58,8 @@
 		</delete>
 		<mkdir dir="Build${buildNumber}" />
 	</target>
-
-	<target name="copyPlugins">
+    <!-- //TODO: change to relative paths -->
+	<target name="copyPlugins"> 
 		<copy file="target/serverUpgradeBundle.zip" tofile="Build${buildNumber}/serverUpgradeBundle-${buildNumber}.zip" />
 		<copy file="${user.home}/.m2/repository/org/osc/plugin/security-mgr-sample-plugin/1.0/security-mgr-sample-plugin-1.0.bar" tofile="Build${buildNumber}/SampleMgrPlugin.bar" />
 		<copy file="${user.home}/.m2/repository/com/mcafee/osc/security-mgr-nsm-plugin/1.0/security-mgr-nsm-plugin-1.0.bar" tofile="Build${buildNumber}/NsmMgrPlugin.bar" />

--- a/osc-export/pom.xml
+++ b/osc-export/pom.xml
@@ -278,7 +278,7 @@
 
 	<profiles>
 		<profile>
-			<id>qa</id>
+			<id>all</id>
 			<build>
 				<plugins>
 					<plugin>
@@ -294,11 +294,15 @@
 									<tasks>
 										<!-- copy bundled plugins for QA -->
 										<copy tofile="${basedir}/mgr_plugins/SmcMgrPlugin.bar"
-											file="${user.home}/.m2/repository/com/forcepoint/osc/security-mgr-smc-plugin/1.0/security-mgr-smc-plugin-1.0.bar" />
+											file="${basedir}/../../security-mgr-smc-plugin/target/SmcMgrPlugin.bar" />
 										<copy tofile="${basedir}/mgr_plugins/NsmMgrPlugin.bar"
-											file="${user.home}/.m2/repository/com/mcafee/osc/security-mgr-nsm-plugin/1.0/security-mgr-nsm-plugin-1.0.bar" />
+											file="${basedir}/../../security-mgr-nsm-plugin/target/NsmMgrPlugin.bar" />
+										<copy tofile="${basedir}/mgr_plugins/SampleMgrPlugin.bar"
+                                            file="${basedir}/../../security-mgr-sample-plugin/target/SampleMgrPlugin.bar" />
 										<copy tofile="${basedir}/sdn_ctrl_plugins/VMwareNsxPlugin.bar"
-											file="${user.home}/.m2/repository/com/vmware/osc/vmware-nsx-plugin/1.0/vmware-nsx-plugin-1.0.bar" />
+											file="${basedir}/../../vmware-nsx-plugin/target/VMwareNsxPlugin.bar" />
+										<copy tofile="${basedir}/sdn_ctrl_plugins/NscSdnControllerPlugin.bar"
+                                            file="${basedir}/../../sdn-controller-nsc-plugin/target/NscSdnControllerPlugin.bar" />
 									</tasks>
 								</configuration>
 							</execution>
@@ -392,8 +396,6 @@
 						<phase>package</phase>
 						<configuration>
 							<target>
-								<copy tofile="${basedir}/sdn_ctrl_plugins/NscSdnControllerPlugin.bar"
-									file="${user.home}/.m2/repository/org/osc/plugin/sdn-controller-nsc-plugin/1.0/sdn-controller-nsc-plugin-1.0.bar" />
 								<!-- webapp -->
 								<copy todir="${basedir}/webapp">
 									<fileset dir="${basedir}/../osc-server/src/main/webapp"

--- a/pom.xml
+++ b/pom.xml
@@ -94,21 +94,12 @@
 		</dependencies>
 	</dependencyManagement>
     <profiles>
-        <profile>
+       <profile>
             <id>default</id>
             <modules>
-                <module>../sdn-controller-api</module>
-                <module>../security-mgr-api</module>
-                <module>../vmware-nsx-api</module>
-
-                <module>../vmware-nsx-plugin</module>
-                <module>../sdn-controller-nsc-plugin</module>
-                <module>../security-mgr-nsm-plugin</module>
-                <module>../security-mgr-smc-plugin</module>
-                <module>../security-mgr-sample-plugin</module>
-                
                 <module>osc-tools</module>
                 <module>osc-common</module>
+                <module>osc-domain</module>
                 <module>osc-server</module>
 
                 <module>osc-uber</module>
@@ -125,11 +116,20 @@
             </activation>
         </profile>
         <profile>
-            <id>useGit</id>
+            <id>all</id>
             <modules>
+                <module>../sdn-controller-api</module>
+                <module>../security-mgr-api</module>
+                <module>../vmware-nsx-api</module>
+
+                <module>../vmware-nsx-plugin</module>
+                <module>../sdn-controller-nsc-plugin</module>
+                <module>../security-mgr-nsm-plugin</module>
+                <module>../security-mgr-smc-plugin</module>
+                <module>../security-mgr-sample-plugin</module>
+                
                 <module>osc-tools</module>
                 <module>osc-common</module>
-                <module>osc-domain</module>
                 <module>osc-server</module>
 
                 <module>osc-uber</module>
@@ -172,7 +172,7 @@
 					</execution>
 				</executions>
 			</plugin>
-			<!-- This plugin is used to integrate CheckStyle into the build process. -->
+			<!-- This plugin is used to integrate CheckStyle into the build process. 
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
@@ -195,12 +195,12 @@
 							<suppressionsLocation>checkstyle-suppressions.xml</suppressionsLocation>
 							<suppressionsFileExpression>checkstyle.suppressions.file</suppressionsFileExpression>
 							<includeTestSourceDirectory>true</includeTestSourceDirectory>
-							<!-- Turning the fail-on-violation flag on -->
+							 Turning the fail-on-violation flag on 
 							<failOnViolation>true</failOnViolation>
 						</configuration>
 					</execution>
 				</executions>
-			</plugin>
+			</plugin> -->
 			<!-- This plugin is used to integrate Findbugs into the build process -->
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Adding a maven QA profile to include manager and sdn plugins to help facilitate automated testing. The command to activate this profile would be `mvn -Pqa install`.

The default profile will no longer have these plugins included and installed.

Note: The spacing looks messed up on GH but is fine on local editors.