### PR TITLE
FIxed DE3634: Services showing SG name instead of DA name on OSC Virtualization connector page under Security Group

### DIFF
--- a/osc-server/src/main/java/org/osc/core/broker/service/persistence/SecurityGroupEntityMgr.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/persistence/SecurityGroupEntityMgr.java
@@ -78,7 +78,7 @@ public class SecurityGroupEntityMgr {
         Join<DistributedAppliance, SecurityGroupInterface> sgi = root.join("virtualSystems").join("securityGroupInterfaces");
         Join<SecurityGroupInterface, SecurityGroup> sgEntity = sgi.join("securityGroups");
 
-        query = query.select(sgEntity.get("name"))
+        query = query.select(root.get("name"))
                 .where(cb.equal(sgEntity.get("id"), dto.getId()))
                 .orderBy(cb.asc(sgi.get("order")));
 


### PR DESCRIPTION
Services showing SG name instead of DA name on OSC Virtualization connector page under Security Group