### PR TITLE
 vm-tools part of epel packages is given a generic name not with a re…

### DIFF
--- a/osc-server-bom/centos-epel.packages
+++ b/osc-server-bom/centos-epel.packages
@@ -1,4 +1,4 @@
 epel-release-6-8.noarch
 libdnet-1.12-6.el6.x86_64
 libmspack-0.5-0.1.alpha.el6.x86_64
-open-vm-tools-10.1.5-5.el6.x86_64
+open-vm-tools


### PR DESCRIPTION
Recent compile errors

vm-tools part of epel packages is given a generic name not with a release version now.
In this way ..the release version which is always changing in the mirror-list url  will not have an issue.
Tested 
Compilation, OSC bring up , login and ssh.