### PR TITLE
Enabling logs at the warn level

### DIFF
--- a/osc-server-bom/root/opt/vmidc/bin/log4j.properties
+++ b/osc-server-bom/root/opt/vmidc/bin/log4j.properties
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-log4j.rootLogger=INFO, fileAppender
+log4j.rootLogger=WARN, fileAppender
 
 log4j.appender.fileAppender=org.apache.log4j.RollingFileAppender
 log4j.appender.fileAppender.layout=org.apache.log4j.PatternLayout
@@ -20,4 +20,4 @@ log4j.appender.fileAppender.layout.ConversionPattern=%d [%-5p| %t| %c{1}]: %m%n
 log4j.appender.fileAppender.MaxFileSize=10485760
 log4j.appender.fileAppender.MaxBackupIndex=10
 log4j.appender.fileAppender.File=./log/securityBroker.log
-log4j.appender.fileAppender.Threshold=INFO
+log4j.appender.fileAppender.Threshold=WARN


### PR DESCRIPTION
Tested with parameterized build http://10.3.240.52:8080/view/Parameterized/job/osc-ovf-parametrized/473/  and confirmed that the deployed OSC logs only contained ERROR and WARN level messages. 