### PR TITLE
Fix DE3914: Cannot create DS with SDN controller type 'NONE'

### DIFF
--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/OsSecurityGroupCheckMetaTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/OsSecurityGroupCheckMetaTask.java
@@ -81,11 +81,12 @@ public class OsSecurityGroupCheckMetaTask extends TransactionalMetaTask {
             }
 
             // The only SDN controller that currently returns true for supportsPortGroup is Nuage.
-            boolean isNuageController = SdnControllerApiFactory.supportsPortGroup(vs);
+            boolean skipSecurityGroupCreation = vs.getVirtualizationConnector().isControllerDefined()
+                    ? SdnControllerApiFactory.supportsPortGroup(vs) : false;
             // If DS or DDS both have no os security group reference, create OS SG
             if (sgReference == null) {
                 //TODO: sjallapx Hack to workaround Nuage SimpleDateFormat parse errors due to JCloud
-                if (!isNuageController) {
+                if (!skipSecurityGroupCreation) {
                     this.tg.appendTask(new CreateOsSecurityGroupTask(ds, endPoint));
                 }
             } else {
@@ -103,7 +104,7 @@ public class OsSecurityGroupCheckMetaTask extends TransactionalMetaTask {
                             iterator.remove();
                             OSCEntityManager.delete(em, sgReference);
                             //TODO: sjallapx Hack to workaround Nuage SimpleDateFormat parse errors due to JCloud
-                            if (!isNuageController) {
+                            if (!skipSecurityGroupCreation) {
                                 this.tg.appendTask(new CreateOsSecurityGroupTask(ds, endPoint));
                             }
                         } else {

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OsSvaServerCreateTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OsSvaServerCreateTask.java
@@ -121,7 +121,9 @@ class OsSvaServerCreateTask extends TransactionalTask {
             CreatedServerDetails createdServer = null;
 
             //TODO: sjallapx Hack to workaround Nuage (the only SDN controller currently to return true to supportsPortGroup) SimpleDateFormat parse errors due to JCloud
-            if (SdnControllerApiFactory.supportsPortGroup(this.dai.getVirtualSystem())) {
+            boolean createServerWithNoOSTSecurityGroup = this.dai.getVirtualSystem().getVirtualizationConnector().isControllerDefined()
+                    ? SdnControllerApiFactory.supportsPortGroup(this.dai.getVirtualSystem()) : false;
+            if (createServerWithNoOSTSecurityGroup) {
                 createdServer = nova.createServer(ds.getRegion(), availabilityZone, applianceName,
                         imageRefId, flavorRef, generateBootstrapInfo(vs, applianceName), ds.getManagementNetworkId(),
                         ds.getInspectionNetworkId(), applianceSoftwareVersion.hasAdditionalNicForInspection(),


### PR DESCRIPTION
Tested locally.  Created parameterized build [#577](http://10.3.240.52:8080/view/Parameterized/job/osc-ovf-parametrized/577/).
@sjallapx Please test the fix with Nuage environment.
