### PR TITLE
Changing API source directory to SNAPSHOT

### DIFF
--- a/osc-export/pom.xml
+++ b/osc-export/pom.xml
@@ -450,11 +450,11 @@
 
 								<copy todir="${basedir}/webapp/SDK">
 									<fileset
-										dir="${user.home}/.m2/repository/org/osc/api/sdn-controller-api/1.0.0-SNAPSHOT//">
+										dir="${user.home}/.m2/repository/org/osc/api/sdn-controller-api/1.0.0-SNAPSHOT">
 										<include name="**/*-sources.jar" />
 									</fileset>
 									<fileset
-										dir="${user.home}/.m2/repository/org/osc/api/security-mgr-api/1.0.0-SNAPSHOT//">
+										dir="${user.home}/.m2/repository/org/osc/api/security-mgr-api/1.0.0-SNAPSHOT">
 										<include name="**/*-sources.jar" />
 									</fileset>
 								</copy>


### PR DESCRIPTION
Build all=true: [Build 28](http://10.3.240.52:8080/view/Parameterized/job/osc-ovf-parametrized/600) 
Build all=false: [Build 26](http://10.3.240.52:8080/view/Parameterized/job/osc-ovf-parametrized/599)

API dir: serverUpgradeBundle\opt\vmidc\bin\webapp\SDK

> Note there are multiple commits to identify the two different build options