### PR TITLE
Injecting the get agent status service to avoid a NPE

### DIFF
--- a/osc-server/src/main/java/org/osc/core/broker/util/StaticRegistry.java
+++ b/osc-server/src/main/java/org/osc/core/broker/util/StaticRegistry.java
@@ -20,6 +20,7 @@ import org.osc.core.broker.model.plugin.ApiFactoryService;
 import org.osc.core.broker.service.ConformService;
 import org.osc.core.broker.service.DeleteDistributedApplianceService;
 import org.osc.core.broker.service.DeleteUserService;
+import org.osc.core.broker.service.GetAgentStatusService;
 import org.osc.core.broker.service.SetNATSettingsService;
 import org.osc.core.broker.service.SetNetworkSettingsService;
 import org.osc.core.broker.service.UpdateUserService;
@@ -87,6 +88,9 @@ public class StaticRegistry {
     @Reference
     private DeleteDistributedApplianceService deleteDistributedApplianceService;
 
+    @Reference
+    private GetAgentStatusService getAgentStatusService;
+
     private static StaticRegistry instance = null;
 
     @Activate
@@ -150,4 +154,8 @@ public class StaticRegistry {
         return instance.updateUserService;
     }
 
+
+    public static GetAgentStatusService getAgentStatusService() {
+        return instance.getAgentStatusService;
+    }
 }

--- a/osc-server/src/main/java/org/osc/core/broker/view/ApplianceInstanceView.java
+++ b/osc-server/src/main/java/org/osc/core/broker/view/ApplianceInstanceView.java
@@ -29,6 +29,7 @@ import org.osc.core.broker.service.dto.BaseDto;
 import org.osc.core.broker.service.dto.DistributedApplianceInstanceDto;
 import org.osc.core.broker.service.request.BaseRequest;
 import org.osc.core.broker.service.response.ListResponse;
+import org.osc.core.broker.util.StaticRegistry;
 import org.osc.core.broker.view.common.VmidcMessages;
 import org.osc.core.broker.view.common.VmidcMessages_;
 import org.osc.core.broker.view.util.ToolbarButtons;
@@ -51,7 +52,7 @@ public class ApplianceInstanceView extends CRUDBaseView<DistributedApplianceInst
 
     private static final Logger LOG = Logger.getLogger(ApplianceInstanceView.class);
 
-    private GetAgentStatusService getAgentStatusService;
+    private GetAgentStatusService getAgentStatusService = StaticRegistry.getAgentStatusService();;
 
     public ApplianceInstanceView() {
         super();


### PR DESCRIPTION
Currently retrieving an appliance status is throwing a NPE. This PR fixes that by injecting the `ApplianceInstanceView` with an instance of the `GetAgentStatusService` through the `StaticRegistry`