### PR TITLE
DE3812 Fix for passwords that whre not encrypted with DES.

### DIFF
--- a/osc-server/src/main/java/org/osc/core/broker/util/db/upgrade/ReleaseUpgradeMgr.java
+++ b/osc-server/src/main/java/org/osc/core/broker/util/db/upgrade/ReleaseUpgradeMgr.java
@@ -296,7 +296,7 @@ public class ReleaseUpgradeMgr {
             try {
                 value = EncryptionUtil.decryptDES(value);
             } catch (EncryptionException e){
-                log.error("Password is not encrypted with DES",e);
+                log.warn("Password is not encrypted with DES",e);
             }
             attrs.put(result.getInt("vc_fk"), EncryptionUtil.encryptAESCTR(value));
         }


### PR DESCRIPTION
If there is a migration from 2.5 to 0.6 via DB backup/restore process, there are situation where passwords are not encrypted with DES and ReleaseUpgradeMgr.upgrade72to73 will fail.

More details in CA Rally DE3812