### PR TITLE
fix test failure 

### DIFF
--- a/osc-rest-server/pom.xml
+++ b/osc-rest-server/pom.xml
@@ -80,6 +80,7 @@
 			<version>2.8.5</version>
 		</dependency>
 		
+    <!--TODO(Paremus): investigate why these exclusions are needed, and whether this dependency can be scope=test -->
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>


### PR DESCRIPTION
by adding explicit dependency on jersey-media-json-jackson.
For some reason this was working ok on my other branches, without explicit dependency.

Hopefully this now closes #243.