### PR TITLE
DE2957 Corrected a typo in error log of check mark for deletion action

### DIFF
--- a/osc-server/src/main/java/org/osc/core/broker/util/ValidateUtil.java
+++ b/osc-server/src/main/java/org/osc/core/broker/util/ValidateUtil.java
@@ -172,7 +172,7 @@ public class ValidateUtil {
 
     public static void checkMarkedForDeletion(IscEntity entity, String name) throws Exception {
         if (entity.getMarkedForDeletion()) {
-            throw new VmidcBrokerInvalidRequestException("Invalid Request '" + name + "' is marked for Deleted");
+            throw new VmidcBrokerInvalidRequestException("Invalid Request '" + name + "' is marked for deletion");
         }
     }
 


### PR DESCRIPTION
All marked for deletion entities log message error log had a typo.. Fix it.

Tests:
Upgrade OSC with the fix.
Delete DS + executed SYNC , checked the error log for test.
Did same tests for DA, and SG.