### PR TITLE
Deleting the sg reference only if not null

### DIFF
--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/ForceDeleteDSTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/ForceDeleteDSTask.java
@@ -62,7 +62,7 @@ public class ForceDeleteDSTask extends TransactionalTask {
         boolean osSgCanBeDeleted = DeploymentSpecEntityMgr.findDeploymentSpecsByVirtualSystemTenantAndRegion(em,
                 this.ds.getVirtualSystem(), this.ds.getTenantId(), this.ds.getRegion()).size() <= 1;
 
-        if (osSgCanBeDeleted) {
+        if (osSgCanBeDeleted && this.ds.getOsSecurityGroupReference() != null) {
             OSCEntityManager.delete(em, this.ds.getOsSecurityGroupReference());
         }
 


### PR DESCRIPTION
Currently when force deleting a DS if it does not have a security group reference the deletion task is failing with IllegalArgumentException. This is reported by DE3902. 