### PR TITLE
1. ISM do not support policy mapping. For manager type, ISM or not supporting policy mapping, policy can be null. 2. Fixing check style issues

### DIFF
--- a/osc-common/src/main/java/org/osc/core/rest/client/crypto/SslContextProvider.java
+++ b/osc-common/src/main/java/org/osc/core/rest/client/crypto/SslContextProvider.java
@@ -16,14 +16,14 @@
  *******************************************************************************/
 package org.osc.core.rest.client.crypto;
 
-import org.apache.log4j.Logger;
-import org.osc.core.util.KeyStoreProvider;
-
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+
+import org.apache.log4j.Logger;
 
 public class SslContextProvider {
 
@@ -35,15 +35,15 @@ public class SslContextProvider {
         // load SSL context
         TrustManager[] trustManager = new TrustManager[]{X509TrustManagerFactory.getInstance()};
         try {
-            sslContext = SSLContext.getInstance("TLSv1.2");
-            sslContext.init(null, trustManager, new SecureRandom());
+            this.sslContext = SSLContext.getInstance("TLSv1.2");
+            this.sslContext.init(null, trustManager, new SecureRandom());
 
             // disable SSL session caching - we load SSL certificates dinamically so we need to ensure
             // that we have up to date cached certificates list
-            sslContext.getClientSessionContext().setSessionCacheSize(1);
-            sslContext.getClientSessionContext().setSessionTimeout(1);
-            sslContext.getServerSessionContext().setSessionCacheSize(1);
-            sslContext.getServerSessionContext().setSessionTimeout(1);
+            this.sslContext.getClientSessionContext().setSessionCacheSize(1);
+            this.sslContext.getClientSessionContext().setSessionTimeout(1);
+            this.sslContext.getServerSessionContext().setSessionCacheSize(1);
+            this.sslContext.getServerSessionContext().setSessionTimeout(1);
 
         } catch (NoSuchAlgorithmException | KeyManagementException e) {
             LOG.error("Encountering security exception in SSL context", e);
@@ -71,6 +71,6 @@ public class SslContextProvider {
      * @return SSLContext
      */
     public SSLContext getSSLContext() {
-        return sslContext;
+        return this.sslContext;
     }
 }

--- a/osc-domain/src/main/java/org/osc/core/broker/model/entities/virtualization/SecurityGroupInterface.java
+++ b/osc-domain/src/main/java/org/osc/core/broker/model/entities/virtualization/SecurityGroupInterface.java
@@ -61,8 +61,7 @@ public class SecurityGroupInterface extends BaseEntity {
     private VirtualSystem virtualSystem;
 
     @ManyToOne(fetch = FetchType.EAGER)
-    @JoinColumn(name = "policy_fk", nullable = false,
-        foreignKey = @ForeignKey(name = "FK_SGI_POLICY"))
+    @JoinColumn(name = "policy_fk", foreignKey = @ForeignKey(name = "FK_SGI_POLICY"))
     private Policy policy;
 
     /**

--- a/osc-server/src/main/java/org/osc/core/broker/service/vc/UpdateVirtualizationConnectorService.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/vc/UpdateVirtualizationConnectorService.java
@@ -221,9 +221,10 @@ public class UpdateVirtualizationConnectorService
         // Transforms the existing vc based on the update request
         updateVirtualizationConnector(request, existingVc);
 
-		if (dto.getType().isOpenstack()) {
-		}
-		this.util.checkOpenstackConnection(request, existingVc);
+        if (dto.getType().isOpenstack()) {
+            this.util.checkOpenstackConnection(request, existingVc);
+        }
+
     }
 
     /**

--- a/osc-server/src/main/java/org/osc/core/broker/util/VirtualizationConnectorUtil.java
+++ b/osc-server/src/main/java/org/osc/core/broker/util/VirtualizationConnectorUtil.java
@@ -16,7 +16,9 @@
  *******************************************************************************/
 package org.osc.core.broker.util;
 
-import com.rabbitmq.client.ShutdownSignalException;
+import java.util.ArrayList;
+import java.util.Map;
+
 import org.apache.log4j.Logger;
 import org.osc.core.broker.model.entities.virtualization.VirtualizationConnector;
 import org.osc.core.broker.model.plugin.sdncontroller.SdnControllerApiFactory;
@@ -33,9 +35,7 @@ import org.osc.core.rest.client.crypto.SslContextProvider;
 import org.osc.core.rest.client.crypto.X509TrustManagerFactory;
 import org.osc.core.rest.client.crypto.model.CertificateResolverModel;
 
-import java.rmi.RemoteException;
-import java.util.ArrayList;
-import java.util.Map;
+import com.rabbitmq.client.ShutdownSignalException;
 
 public class VirtualizationConnectorUtil {
 

--- a/osc-server/src/test/java/org/osc/core/broker/util/VirtualizationConnectorUtilTest.java
+++ b/osc-server/src/test/java/org/osc/core/broker/util/VirtualizationConnectorUtilTest.java
@@ -16,7 +16,20 @@
  *******************************************************************************/
 package org.osc.core.broker.util;
 
-import com.rabbitmq.client.ShutdownSignalException;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -44,20 +57,7 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.rmi.RemoteException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import com.rabbitmq.client.ShutdownSignalException;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({SdnControllerApiFactory.class, RabbitMQRunner.class, EncryptionUtil.class,


### PR DESCRIPTION
-  ISM do not support policy mapping. For manager type, ISM or not supporting policy mapping, policy can be null. 
- Fixing check style issues

Parameterized build: http://10.3.240.52:8080/view/Parameterized/job/osc-ovf-parametrized/749/