### PR TITLE
Travis CI integration for 0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+# Copyright (c) Intel Corporation
+# Copyright (c) 2017
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cache:
+  directories:
+  - $HOME/.m2
+  - $HOME/build/opensecuritycontroller/osc-core/osc-server-bom/Sources/
+sudo: false
+language:
+    - java
+jdk:
+    - oraclejdk8
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
+#Issue with BND tools, see https://github.com/bndtools/bndtools/issues/1294
+before_install:
+    - mkdir -p $HOME/.bnd/default-ws/cnf/cache/3.3.0/bnd-cache/biz.aQute.launcher
+    - wget -O $HOME/.bnd/default-ws/cnf/cache/3.3.0/bnd-cache/biz.aQute.launcher/biz.aQute.launcher-3.3.0.jar http://central.maven.org/maven2/biz/aQute/bnd/biz.aQute.launcher/3.3.0/biz.aQute.launcher-3.3.0.jar
+install: 
+    true
+script:
+    mvn install

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# osc-core
+[![Build Status](https://travis-ci.com/opensecuritycontroller/osc-core.svg?token=FzxT1Qx9H6sqEHPcKhqW&branch=0.6)](https://travis-ci.com/opensecuritycontroller/osc-core)

--- a/osc-server/src/test/java/org/osc/core/broker/service/test/InMemDB.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/test/InMemDB.java
@@ -34,7 +34,7 @@ public class InMemDB {
             props.put("javax.persistence.jdbc.url", "jdbc:h2:mem:test"); // in-memory db
             props.put("javax.persistence.schema-generation.database.action", "drop-and-create"); // create brand-new db schema in memory
             props.put("hibernate.dialect", "org.hibernate.dialect.H2Dialect");
-            props.put("hibernate.show_sql", "true");
+            props.put("hibernate.show_sql", "false"); // Set this to true to debug any DB failures
 
 
             emf = Persistence.createEntityManagerFactory("osc-server", props);


### PR DESCRIPTION
* Travis CI integration

* fix to use latest java8 JDK

* Dont show SQL for unit tests

The large number of log statements for unit tests is causing travis
builds to fail.

* fix bndtools build failure in travis

* Add caching for maven dependencies and jre download

Update readme to point to 0.6

(cherry picked from commit 0b174509bc1393d82b1e1c11f4e7d2313df45a85)