### PR TITLE
fix issue with not being able to call update on MC

### DIFF
--- a/osc-server/src/main/java/org/osc/core/broker/service/mc/AddApplianceManagerConnectorService.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/mc/AddApplianceManagerConnectorService.java
@@ -122,8 +122,7 @@ public class AddApplianceManagerConnectorService
 
         ManagerType managerType = ManagerType.fromText(request.getDto().getManagerType());
         boolean basicAuth = this.apiFactoryService.isBasicAuth(managerType);
-        boolean keyAuth = this.apiFactoryService.isKeyAuth(managerType);
-        ApplianceManagerConnectorDtoValidator.checkForNullFields(request.getDto(), basicAuth, keyAuth);
+        ApplianceManagerConnectorDtoValidator.checkForNullFields(request.getDto(), false, basicAuth);
         ApplianceManagerConnectorDtoValidator.checkFieldLength(request.getDto(), basicAuth);
 
         // check for uniqueness of mc name

--- a/osc-server/src/main/java/org/osc/core/broker/service/validator/ApplianceManagerConnectorDtoValidator.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/validator/ApplianceManagerConnectorDtoValidator.java
@@ -35,7 +35,7 @@ public class ApplianceManagerConnectorDtoValidator {
      *             NOT be specified are specified
      */
     public static void checkForNullFields(ApplianceManagerConnectorDto dto, boolean skipPasswordNullCheck,
-            boolean isBasicAuth, boolean isKeyAuth) throws Exception {
+            boolean isBasicAuth) throws Exception {
 
         // build a map of (field,value) pairs to be checked for null/empty
         // values
@@ -46,22 +46,24 @@ public class ApplianceManagerConnectorDtoValidator {
         notNullFieldsMap.put("Type", dto.getManagerType());
         notNullFieldsMap.put("IP Address", dto.getIpAddress());
 
-        if (isKeyAuth && !skipPasswordNullCheck) {
-            notNullFieldsMap.put("API Key", dto.getApiKey());
-        } else if (isBasicAuth) {
+         if (isBasicAuth) {
+            notNullFieldsMap.put("User Name", dto.getUsername());
             if (!skipPasswordNullCheck) {
                 notNullFieldsMap.put("Password", dto.getPassword());
             }
-            notNullFieldsMap.put("User Name", dto.getUsername());
 
             nullFieldsMap.put("API Key", dto.getApiKey());
+        } else {
+            // Key auth
+            if (!skipPasswordNullCheck) {
+                notNullFieldsMap.put("API Key", dto.getApiKey());
+            }
+            nullFieldsMap.put("User Name", dto.getUsername());
+            nullFieldsMap.put("Password", dto.getPassword());
         }
+
         ValidateUtil.checkForNullFields(notNullFieldsMap);
         ValidateUtil.validateFieldsAreNull(nullFieldsMap);
-    }
-
-    public static void checkForNullFields(ApplianceManagerConnectorDto dto, boolean isBasicAuth, boolean isKeyAuth) throws Exception {
-        checkForNullFields(dto, false, isBasicAuth, isKeyAuth);
     }
 
     public static void checkFieldLength(ApplianceManagerConnectorDto dto, boolean isBasicAuth) throws Exception {


### PR DESCRIPTION
UpdateApplianceManagerConnectorService calls the method below(which is deleted as part of this change)

        ApplianceManagerConnectorDtoValidator.checkForNullFields(request.getDto(), request.isApi(), basicAuth);

which calls the overloaded checkForNullFields method with bad arguments. it uses the request.isApi() as isBasicAuth
