### PR TITLE
DE3845 - When adding or editing MC, make sure the intermediate error …

### DIFF
--- a/osc-server/src/main/java/org/osc/core/broker/service/mc/AddApplianceManagerConnectorService.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/mc/AddApplianceManagerConnectorService.java
@@ -19,7 +19,10 @@ package org.osc.core.broker.service.mc;
 import java.net.SocketException;
 import java.util.ArrayList;
 
+import javax.net.ssl.SSLException;
 import javax.persistence.EntityManager;
+import javax.ws.rs.ForbiddenException;
+import javax.ws.rs.NotAuthorizedException;
 
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.log4j.Logger;
@@ -33,7 +36,6 @@ import org.osc.core.broker.service.ServiceDispatcher;
 import org.osc.core.broker.service.api.AddApplianceManagerConnectorServiceApi;
 import org.osc.core.broker.service.api.server.EncryptionApi;
 import org.osc.core.broker.service.dto.SslCertificateAttrDto;
-import org.osc.core.broker.service.exceptions.RestClientException;
 import org.osc.core.broker.service.exceptions.VmidcBrokerValidationException;
 import org.osc.core.broker.service.persistence.ApplianceManagerConnectorEntityMgr;
 import org.osc.core.broker.service.persistence.OSCEntityManager;
@@ -165,8 +167,11 @@ implements AddApplianceManagerConnectorServiceApi {
                 Throwable rootCause = ExceptionUtils.getRootCause(e);
                 Throwable cause = e;
 
-                if (rootCause instanceof SocketException) {
-                    cause = new RestClientException(rootCause.getMessage(), rootCause);
+                if (rootCause instanceof SocketException
+                        || rootCause instanceof SSLException
+                        || rootCause instanceof ForbiddenException
+                        || rootCause instanceof NotAuthorizedException) {
+                    cause = rootCause;
                 }
 
                 ErrorTypeException errorTypeException = new ErrorTypeException(cause, ErrorType.MANAGER_CONNECTOR_EXCEPTION);

--- a/osc-server/src/main/java/org/osc/core/broker/service/mc/AddApplianceManagerConnectorService.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/mc/AddApplianceManagerConnectorService.java
@@ -17,12 +17,11 @@
 package org.osc.core.broker.service.mc;
 
 import java.net.SocketException;
+import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 
 import javax.net.ssl.SSLException;
 import javax.persistence.EntityManager;
-import javax.ws.rs.ForbiddenException;
-import javax.ws.rs.NotAuthorizedException;
 
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.log4j.Logger;
@@ -169,8 +168,7 @@ implements AddApplianceManagerConnectorServiceApi {
 
                 if (rootCause instanceof SocketException
                         || rootCause instanceof SSLException
-                        || rootCause instanceof ForbiddenException
-                        || rootCause instanceof NotAuthorizedException) {
+                        || rootCause instanceof SocketTimeoutException) {
                     cause = rootCause;
                 }
 

--- a/osc-server/src/main/resources/org/osc/core/broker/service/common/VmidcMessages.properties
+++ b/osc-server/src/main/resources/org/osc/core/broker/service/common/VmidcMessages.properties
@@ -131,18 +131,6 @@ vc.confirm.rabbit = Failed to connect to Openstack Notification Service (RabbitM
 <li>SSL certificates are not set</li>\
 </ul>\
 Are you sure you want to continue?
-vc.confirm.generic = Failed to connect to {0}. \
-<br/><br/> Reported error: ''{1}''. \
-<br/><br/> Possible reasons: \
-<ul>\
-<li>Incorrect IP address/port information</li>\
-<li>Credentials are wrong</li>\
-<li>The exclusive OSC queue is being used by other clients</li>\
-<li>Network connectivity</li>\
-<li>Server end point is down</li>\
-<li>SSL certificates are not set</li>\
-</ul>\
-Are you sure you want to continue?
 
 vs.deploy.policy.required = {0} is required if {1} is specified
 vs.deploy.policy.workload = Workload PortGroup

--- a/osc-server/src/main/resources/org/osc/core/broker/service/common/VmidcMessages.properties
+++ b/osc-server/src/main/resources/org/osc/core/broker/service/common/VmidcMessages.properties
@@ -131,6 +131,18 @@ vc.confirm.rabbit = Failed to connect to Openstack Notification Service (RabbitM
 <li>SSL certificates are not set</li>\
 </ul>\
 Are you sure you want to continue?
+vc.confirm.generic = Failed to connect to {0}. \
+<br/><br/> Reported error: ''{1}''. \
+<br/><br/> Possible reasons: \
+<ul>\
+<li>Incorrect IP address/port information</li>\
+<li>Credentials are wrong</li>\
+<li>The exclusive OSC queue is being used by other clients</li>\
+<li>Network connectivity</li>\
+<li>Server end point is down</li>\
+<li>SSL certificates are not set</li>\
+</ul>\
+Are you sure you want to continue?
 
 vs.deploy.policy.required = {0} is required if {1} is specified
 vs.deploy.policy.workload = Workload PortGroup

--- a/osc-service-api/src/main/java/org/osc/core/broker/service/exceptions/RestClientException.java
+++ b/osc-service-api/src/main/java/org/osc/core/broker/service/exceptions/RestClientException.java
@@ -16,9 +16,10 @@
  *******************************************************************************/
 package org.osc.core.broker.service.exceptions;
 
-import javax.ws.rs.core.Response;
-import java.net.NoRouteToHostException;
+import java.net.SocketException;
 import java.net.SocketTimeoutException;
+
+import javax.ws.rs.core.Response;
 
 /**
  * A general rest exception. Any of the members can be null.
@@ -72,8 +73,10 @@ public class RestClientException extends Exception {
     }
 
     public static boolean isConnectException(final Throwable exception) {
-        return (exception instanceof SocketTimeoutException || exception.getCause() instanceof SocketTimeoutException)
-                || (exception instanceof NoRouteToHostException || exception.getCause() instanceof NoRouteToHostException);
+        // SocketException has four child classes: NoRouteToHostException, ConnectException, BindException,
+        // PortUnreachableException. The last two are probably not relevant, but the first two have been observed.
+        return exception instanceof SocketTimeoutException || exception.getCause() instanceof SocketTimeoutException
+                || exception instanceof SocketException || exception.getCause() instanceof SocketException;
     }
 
     public boolean isCredentialError() {

--- a/osc-ui/src/main/java/org/osc/core/broker/window/add/AddManagerConnectorWindow.java
+++ b/osc-ui/src/main/java/org/osc/core/broker/window/add/AddManagerConnectorWindow.java
@@ -68,6 +68,7 @@ public class AddManagerConnectorWindow extends CRUDBaseWindow<OkCancelButtonMode
     private static final long serialVersionUID = 1L;
 
     final String CAPTION = "Add Manager Connector";
+    final String NODE_DESCRIPTION = "Connector Node";
 
     private static final Logger log = Logger.getLogger(AddManagerConnectorWindow.class);
 
@@ -303,8 +304,9 @@ public class AddManagerConnectorWindow extends CRUDBaseWindow<OkCancelButtonMode
             } else if (rootCause instanceof SocketException) {
                 String msg = rootCause.getMessage() != null ?
                         rootCause.getMessage() : rootCause.getClass().getSimpleName();
-                contentText = VmidcMessages.getString(VmidcMessages_.VC_CONFIRM_RABBIT,
-                        StringEscapeUtils.escapeHtml(msg));
+                contentText = VmidcMessages.getString(VmidcMessages_.VC_CONFIRM_GENERAL,
+                                                        this.NODE_DESCRIPTION,
+                                                        StringEscapeUtils.escapeHtml(msg));
             }
         } else {
             exception = originalException;

--- a/osc-ui/src/main/java/org/osc/core/broker/window/add/AddManagerConnectorWindow.java
+++ b/osc-ui/src/main/java/org/osc/core/broker/window/add/AddManagerConnectorWindow.java
@@ -16,6 +16,7 @@
  *******************************************************************************/
 package org.osc.core.broker.window.add;
 
+import java.net.SocketException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -24,6 +25,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.log4j.Logger;
 import org.osc.core.broker.service.api.AddApplianceManagerConnectorServiceApi;
 import org.osc.core.broker.service.api.plugin.PluginService;
@@ -284,6 +286,7 @@ public class AddManagerConnectorWindow extends CRUDBaseWindow<OkCancelButtonMode
         final Throwable exception;
         if (originalException instanceof ErrorTypeException) {
             exception = originalException.getCause();
+            final Throwable rootCause = ExceptionUtils.getRootCause(originalException);
             if (exception instanceof RestClientException) {
                 RestClientException restClientException = (RestClientException) exception;
                 if (restClientException.isConnectException()) {
@@ -297,6 +300,11 @@ public class AddManagerConnectorWindow extends CRUDBaseWindow<OkCancelButtonMode
                             this.ip.getValue(), exception.getMessage()), exception));
                     return;
                 }
+            } else if (rootCause instanceof SocketException) {
+                String msg = rootCause.getMessage() != null ?
+                        rootCause.getMessage() : rootCause.getClass().getSimpleName();
+                contentText = VmidcMessages.getString(VmidcMessages_.VC_CONFIRM_RABBIT,
+                        StringEscapeUtils.escapeHtml(msg));
             }
         } else {
             exception = originalException;

--- a/osc-ui/src/main/java/org/osc/core/broker/window/update/UpdateManagerConnectorWindow.java
+++ b/osc-ui/src/main/java/org/osc/core/broker/window/update/UpdateManagerConnectorWindow.java
@@ -66,6 +66,7 @@ public class UpdateManagerConnectorWindow extends CRUDBaseWindow<OkCancelButtonM
     protected List<ErrorType> errorTypesToIgnore = new ArrayList<>();
 
     final String CAPTION = "Edit Manager Connector";
+    final String NODE_DESCRIPTION = "Connector Node";
 
     // current view reference
     private final ManagerConnectorView mcView;
@@ -300,8 +301,9 @@ public class UpdateManagerConnectorWindow extends CRUDBaseWindow<OkCancelButtonM
                 } else if (rootCause instanceof SocketException) {
                     String msg = rootCause.getMessage() != null ?
                             rootCause.getMessage() : rootCause.getClass().getSimpleName();
-                    contentText = VmidcMessages.getString(VmidcMessages_.VC_CONFIRM_RABBIT,
-                            StringEscapeUtils.escapeHtml(msg));
+                    contentText = VmidcMessages.getString(VmidcMessages_.VC_CONFIRM_GENERAL,
+                                                            this.NODE_DESCRIPTION,
+                                                            StringEscapeUtils.escapeHtml(msg));
                 }
             } else if (errorType == ErrorType.IP_CHANGED_EXCEPTION) {
                 contentText = VmidcMessages.getString(VmidcMessages_.MC_WARNING_IPUPDATE);

--- a/osc-ui/src/main/java/org/osc/core/broker/window/update/UpdateManagerConnectorWindow.java
+++ b/osc-ui/src/main/java/org/osc/core/broker/window/update/UpdateManagerConnectorWindow.java
@@ -16,14 +16,12 @@
  *******************************************************************************/
 package org.osc.core.broker.window.update;
 
-import java.net.SocketException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang.StringEscapeUtils;
-import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.log4j.Logger;
 import org.osc.core.broker.service.api.UpdateApplianceManagerConnectorServiceApi;
 import org.osc.core.broker.service.api.plugin.PluginService;
@@ -66,7 +64,6 @@ public class UpdateManagerConnectorWindow extends CRUDBaseWindow<OkCancelButtonM
     protected List<ErrorType> errorTypesToIgnore = new ArrayList<>();
 
     final String CAPTION = "Edit Manager Connector";
-    final String NODE_DESCRIPTION = "Connector Node";
 
     // current view reference
     private final ManagerConnectorView mcView;
@@ -282,7 +279,6 @@ public class UpdateManagerConnectorWindow extends CRUDBaseWindow<OkCancelButtonM
         if (originalException instanceof ErrorTypeException) {
             ErrorType errorType = ((ErrorTypeException) originalException).getType();
             exception = originalException.getCause();
-            final Throwable rootCause = ExceptionUtils.getRootCause(originalException);
             if (errorType == ErrorType.MANAGER_CONNECTOR_EXCEPTION) {
                 if (exception instanceof RestClientException) {
                     RestClientException restClientException = (RestClientException) exception;
@@ -298,12 +294,6 @@ public class UpdateManagerConnectorWindow extends CRUDBaseWindow<OkCancelButtonM
                                 exception));
                         return;
                     }
-                } else if (rootCause instanceof SocketException) {
-                    String msg = rootCause.getMessage() != null ?
-                            rootCause.getMessage() : rootCause.getClass().getSimpleName();
-                    contentText = VmidcMessages.getString(VmidcMessages_.VC_CONFIRM_GENERAL,
-                                                            this.NODE_DESCRIPTION,
-                                                            StringEscapeUtils.escapeHtml(msg));
                 }
             } else if (errorType == ErrorType.IP_CHANGED_EXCEPTION) {
                 contentText = VmidcMessages.getString(VmidcMessages_.MC_WARNING_IPUPDATE);

--- a/osc-ui/src/main/java/org/osc/core/broker/window/update/UpdateManagerConnectorWindow.java
+++ b/osc-ui/src/main/java/org/osc/core/broker/window/update/UpdateManagerConnectorWindow.java
@@ -16,12 +16,14 @@
  *******************************************************************************/
 package org.osc.core.broker.window.update;
 
+import java.net.SocketException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.log4j.Logger;
 import org.osc.core.broker.service.api.UpdateApplianceManagerConnectorServiceApi;
 import org.osc.core.broker.service.api.plugin.PluginService;
@@ -279,6 +281,7 @@ public class UpdateManagerConnectorWindow extends CRUDBaseWindow<OkCancelButtonM
         if (originalException instanceof ErrorTypeException) {
             ErrorType errorType = ((ErrorTypeException) originalException).getType();
             exception = originalException.getCause();
+            final Throwable rootCause = ExceptionUtils.getRootCause(originalException);
             if (errorType == ErrorType.MANAGER_CONNECTOR_EXCEPTION) {
                 if (exception instanceof RestClientException) {
                     RestClientException restClientException = (RestClientException) exception;
@@ -294,6 +297,11 @@ public class UpdateManagerConnectorWindow extends CRUDBaseWindow<OkCancelButtonM
                                 exception));
                         return;
                     }
+                } else if (rootCause instanceof SocketException) {
+                    String msg = rootCause.getMessage() != null ?
+                            rootCause.getMessage() : rootCause.getClass().getSimpleName();
+                    contentText = VmidcMessages.getString(VmidcMessages_.VC_CONFIRM_RABBIT,
+                            StringEscapeUtils.escapeHtml(msg));
                 }
             } else if (errorType == ErrorType.IP_CHANGED_EXCEPTION) {
                 contentText = VmidcMessages.getString(VmidcMessages_.MC_WARNING_IPUPDATE);

--- a/osc-ui/src/main/java/org/osc/core/broker/window/update/UpdateManagerConnectorWindow.java
+++ b/osc-ui/src/main/java/org/osc/core/broker/window/update/UpdateManagerConnectorWindow.java
@@ -16,10 +16,15 @@
  *******************************************************************************/
 package org.osc.core.broker.window.update;
 
+import java.net.SocketException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import javax.net.ssl.SSLException;
+import javax.ws.rs.ForbiddenException;
+import javax.ws.rs.NotAuthorizedException;
 
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.log4j.Logger;
@@ -29,7 +34,6 @@ import org.osc.core.broker.service.api.server.ServerApi;
 import org.osc.core.broker.service.api.server.ValidationApi;
 import org.osc.core.broker.service.dto.ApplianceManagerConnectorDto;
 import org.osc.core.broker.service.dto.SslCertificateAttrDto;
-import org.osc.core.broker.service.exceptions.RestClientException;
 import org.osc.core.broker.service.request.ApplianceManagerConnectorRequest;
 import org.osc.core.broker.service.request.DryRunRequest;
 import org.osc.core.broker.service.request.ErrorTypeException;
@@ -275,31 +279,28 @@ public class UpdateManagerConnectorWindow extends CRUDBaseWindow<OkCancelButtonM
     private void handleException(final Exception originalException) {
         String caption = VmidcMessages.getString(VmidcMessages_.MC_CONFIRM_CAPTION);
         String contentText = null;
-        final Throwable exception;
+        final Throwable cause;
         if (originalException instanceof ErrorTypeException) {
             ErrorType errorType = ((ErrorTypeException) originalException).getType();
-            exception = originalException.getCause();
+            cause = originalException.getCause();
             if (errorType == ErrorType.MANAGER_CONNECTOR_EXCEPTION) {
-                if (exception instanceof RestClientException) {
-                    RestClientException restClientException = (RestClientException) exception;
-                    if (restClientException.isConnectException()) {
-                        contentText = VmidcMessages.getString(VmidcMessages_.MC_CONFIRM_IP,
-                                StringEscapeUtils.escapeHtml(this.name.getValue()));
-                    } else if (restClientException.isCredentialError()) {
-                        contentText = VmidcMessages.getString(VmidcMessages_.MC_CONFIRM_CREDS, StringEscapeUtils
-                                .escapeHtml(this.name.getValue()));
-                    } else {
-                        handleCatchAllException(new Exception(VmidcMessages.getString(
-                                VmidcMessages_.GENERAL_REST_ERROR, this.ip.getValue(), exception.getMessage()),
-                                exception));
-                        return;
-                    }
+                if (cause instanceof SocketException || cause instanceof SSLException) {
+                    contentText = VmidcMessages.getString(VmidcMessages_.MC_CONFIRM_IP,
+                            StringEscapeUtils.escapeHtml(this.name.getValue()));
+                } else if (cause instanceof ForbiddenException || cause instanceof NotAuthorizedException) {
+                    contentText = VmidcMessages.getString(VmidcMessages_.MC_CONFIRM_CREDS, StringEscapeUtils
+                            .escapeHtml(this.name.getValue()));
+                } else {
+                    handleCatchAllException(new Exception(VmidcMessages.getString(
+                            VmidcMessages_.GENERAL_REST_ERROR, this.ip.getValue(), cause.getMessage()),
+                            cause));
+                    return;
                 }
             } else if (errorType == ErrorType.IP_CHANGED_EXCEPTION) {
                 contentText = VmidcMessages.getString(VmidcMessages_.MC_WARNING_IPUPDATE);
             }
         } else {
-            exception = originalException;
+            cause = originalException;
         }
         if (contentText != null) {
 
@@ -326,7 +327,7 @@ public class UpdateManagerConnectorWindow extends CRUDBaseWindow<OkCancelButtonM
             });
             ViewUtil.addWindow(alertWindow);
         } else {
-            handleCatchAllException(exception);
+            handleCatchAllException(cause);
         }
     }
 }

--- a/osc-ui/src/main/java/org/osc/core/broker/window/update/UpdateManagerConnectorWindow.java
+++ b/osc-ui/src/main/java/org/osc/core/broker/window/update/UpdateManagerConnectorWindow.java
@@ -17,14 +17,13 @@
 package org.osc.core.broker.window.update;
 
 import java.net.SocketException;
+import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import javax.net.ssl.SSLException;
-import javax.ws.rs.ForbiddenException;
-import javax.ws.rs.NotAuthorizedException;
 
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.log4j.Logger;
@@ -284,12 +283,11 @@ public class UpdateManagerConnectorWindow extends CRUDBaseWindow<OkCancelButtonM
             ErrorType errorType = ((ErrorTypeException) originalException).getType();
             cause = originalException.getCause();
             if (errorType == ErrorType.MANAGER_CONNECTOR_EXCEPTION) {
-                if (cause instanceof SocketException || cause instanceof SSLException) {
+                if (cause instanceof SocketException
+                        || cause instanceof SSLException
+                        ||  cause instanceof SocketTimeoutException) {
                     contentText = VmidcMessages.getString(VmidcMessages_.MC_CONFIRM_IP,
                             StringEscapeUtils.escapeHtml(this.name.getValue()));
-                } else if (cause instanceof ForbiddenException || cause instanceof NotAuthorizedException) {
-                    contentText = VmidcMessages.getString(VmidcMessages_.MC_CONFIRM_CREDS, StringEscapeUtils
-                            .escapeHtml(this.name.getValue()));
                 } else {
                     handleCatchAllException(new Exception(VmidcMessages.getString(
                             VmidcMessages_.GENERAL_REST_ERROR, this.ip.getValue(), cause.getMessage()),


### PR DESCRIPTION
…message window is shown upon socket exceptions.

If the IP address is nonexistent, or the controller a dialogue is supposed to show summarizing one of several possible things that have gone wrong (screenshot attached). At this point, the user has an option to proceed or not. The string template value for the dialogue box is the **vc.confirm.rabbit** property from the **VmidcMessage.properties**.

Decided to get the root cause exception and put its message into the string template. Screenshot is attached.

<img width="532" alt="mcvcbadipdialogs" src="https://user-images.githubusercontent.com/29714087/28193577-b7275ff6-67f2-11e7-9e2e-19cae303c125.PNG">
