### PR TITLE
Ensure that the UI works under live updates

### DIFF
--- a/osc-server/pom.xml
+++ b/osc-server/pom.xml
@@ -436,25 +436,6 @@
 								<pluginExecution>
 									<pluginExecutionFilter>
 										<groupId>
-											org.codehaus.mojo
-										</groupId>
-										<artifactId>
-											build-helper-maven-plugin
-										</artifactId>
-										<versionRange>
-											[1.9.1,)
-										</versionRange>
-										<goals>
-											<goal>add-source</goal>
-										</goals>
-									</pluginExecutionFilter>
-									<action>
-										<ignore></ignore>
-									</action>
-								</pluginExecution>
-								<pluginExecution>
-									<pluginExecutionFilter>
-										<groupId>
 											org.apache.maven.plugins
 										</groupId>
 										<artifactId>

--- a/osc-tools/src/main/java/org/osc/core/tools/ResourceBundleKeyGenerator.java
+++ b/osc-tools/src/main/java/org/osc/core/tools/ResourceBundleKeyGenerator.java
@@ -25,6 +25,24 @@ import java.util.regex.Matcher;
 
 public class ResourceBundleKeyGenerator {
 
+	private static final String COPYRIGHT_AND_LICENSE =
+			"/*******************************************************************************\n"+
+			" * Copyright (c) Intel Corporation\n"+
+			" * Copyright (c) 2017\n"+
+			" *\n"+
+			" * Licensed under the Apache License, Version 2.0 (the \"License\");\n"+
+			" * you may not use this file except in compliance with the License.\n"+
+			" * You may obtain a copy of the License at\n"+
+			" *\n"+
+			" *    http://www.apache.org/licenses/LICENSE-2.0\n"+
+			" *\n"+
+			" * Unless required by applicable law or agreed to in writing, software\n"+
+			" * distributed under the License is distributed on an \"AS IS\" BASIS,\n"+
+			" * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"+
+			" * See the License for the specific language governing permissions and\n"+
+			" * limitations under the License.\n"+
+			" *******************************************************************************/\n";
+	
     private String generatedCodeFolder;
     private String bundleName;
 
@@ -44,6 +62,8 @@ public class ResourceBundleKeyGenerator {
 
         try {
             StringBuilder fileContent = new StringBuilder();
+            		
+            fileContent.append(COPYRIGHT_AND_LICENSE);
 
             fileContent.append("package ");
             fileContent.append(packageName);

--- a/osc-ui/pom.xml
+++ b/osc-ui/pom.xml
@@ -387,25 +387,6 @@
 								<pluginExecution>
 									<pluginExecutionFilter>
 										<groupId>
-											org.codehaus.mojo
-										</groupId>
-										<artifactId>
-											build-helper-maven-plugin
-										</artifactId>
-										<versionRange>
-											[1.9.1,)
-										</versionRange>
-										<goals>
-											<goal>add-source</goal>
-										</goals>
-									</pluginExecutionFilter>
-									<action>
-										<ignore></ignore>
-									</action>
-								</pluginExecution>
-								<pluginExecution>
-									<pluginExecutionFilter>
-										<groupId>
 											org.apache.maven.plugins
 										</groupId>
 										<artifactId>

--- a/osc-ui/src/main/java/org/osc/core/ui/UiListenerDelegate.java
+++ b/osc-ui/src/main/java/org/osc/core/ui/UiListenerDelegate.java
@@ -16,7 +16,9 @@
  *******************************************************************************/
 package org.osc.core.ui;
 
-import static org.osgi.service.http.whiteboard.HttpWhiteboardConstants.*;
+import static org.osgi.service.http.whiteboard.HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_NAME;
+import static org.osgi.service.http.whiteboard.HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_SELECT;
+import static org.osgi.service.http.whiteboard.HttpWhiteboardConstants.HTTP_WHITEBOARD_TARGET;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -35,6 +37,7 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 
 import com.vaadin.server.VaadinSession;
+import com.vaadin.ui.UI;
 
 @Component(property = {
         HTTP_WHITEBOARD_CONTEXT_SELECT + "=(" + HTTP_WHITEBOARD_CONTEXT_NAME + "=" + UiServletContext.OSC_UI_NAME + ")",
@@ -80,7 +83,14 @@ public class UiListenerDelegate implements HttpSessionListener, ServerTerminatio
             for (VaadinSession vaadinSession : VaadinSession.getAllSessions(session)) {
                 Object userName = vaadinSession.getAttribute("user");
                 if (loginName == null || loginName.equals(userName)) {
-                    vaadinSession.close();
+                	vaadinSession.close();
+
+                	// Redirect all UIs to force the close
+                	for (UI ui : vaadinSession.getUIs()) {
+                		ui.access(() -> {
+                			ui.getPage().setLocation("/");
+                		});
+					}
                 }
             }
         }


### PR DESCRIPTION
When running OSC inside the Bndtools IDE there can be a live update of the OSC code. This is great for rapid development cycles, but it has shown up a lifecycle problem in the OSC UI code. If the UI component is shut down without updating the UI bundle (for example by making a change to an OSC service) then invalid Vaadin sessions are left hanging.

To get this working required several small changes

* Ensure that the osc-server and osc-ui generated source is built by removing the m2e exclusion for the build-helper-maven-plugin. Without this the generated messages file is not built into the bundle, causing NoClassDefFoundError at runtime.
* Avoid NPEs when shutting down runners. The Server component did not check for null when cleaning up runners.
* Always destroy the UI on component restart. The UI servlet did not have a destroy method which forced client sessions to close
* Always tear down the server component on update. The server component did not clean up if/when it restarted