### PR TITLE
Issue 366: use Hash Set in the SecurityGroup. Remove the Mockito wraps around theSG in unit tests.

### DIFF
--- a/osc-domain/src/main/java/org/osc/core/broker/model/entities/virtualization/SecurityGroup.java
+++ b/osc-domain/src/main/java/org/osc/core/broker/model/entities/virtualization/SecurityGroup.java
@@ -18,7 +18,6 @@ package org.osc.core.broker.model.entities.virtualization;
 
 import java.util.HashSet;
 import java.util.Set;
-import java.util.TreeSet;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -75,7 +74,7 @@ public class SecurityGroup extends BaseEntity implements LastJobContainer{
 
     @OneToMany(mappedBy = "securityGroup", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @OrderBy("type")
-    private Set<SecurityGroupMember> securityGroupMembers = new TreeSet<>();
+    private Set<SecurityGroupMember> securityGroupMembers = new HashSet<>();
 
     @OneToMany(mappedBy = "securityGroup", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private Set<SecurityGroupInterface> securityGroupInterfaces = new HashSet<SecurityGroupInterface>();

--- a/osc-domain/src/main/java/org/osc/core/broker/model/entities/virtualization/SecurityGroupMember.java
+++ b/osc-domain/src/main/java/org/osc/core/broker/model/entities/virtualization/SecurityGroupMember.java
@@ -37,7 +37,7 @@ import org.osc.core.broker.model.entities.virtualization.openstack.VM;
 @Entity
 @Table(name = "SECURITY_GROUP_MEMBER", uniqueConstraints = { @UniqueConstraint(columnNames = { "security_group_fk",
         "vm_fk", "network_fk", "address" }) })
-public class SecurityGroupMember extends BaseEntity implements Comparable<SecurityGroupMember> {
+public class SecurityGroupMember extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "security_group_fk", nullable = false,
@@ -137,10 +137,4 @@ public class SecurityGroupMember extends BaseEntity implements Comparable<Securi
             return null;
         }
     }
-
-    @Override
-    public int compareTo(SecurityGroupMember o) {
-        return this.type.compareTo(o.getType());
-    }
-
 }

--- a/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/CreatePortGroupTaskTest.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/CreatePortGroupTaskTest.java
@@ -228,10 +228,7 @@ public class CreatePortGroupTaskTest {
 	}
 
 	private SecurityGroupMember newSGM(OsProtectionEntity protectionEntity, Long sgmId) {
-		// TODO emanoel: Remove this mock once the SGM is no longer kept in a
-		// TreeSet in the SGM.
-		SecurityGroupMember sgm = Mockito.spy(new SecurityGroupMember(protectionEntity));
-		Mockito.doReturn(-1).when(sgm).compareTo(Mockito.any());
+		SecurityGroupMember sgm = new SecurityGroupMember(protectionEntity);		
 		sgm.setId(sgmId);
 
 		return sgm;

--- a/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/UpdateDAIToSGIMembersTaskTest.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/UpdateDAIToSGIMembersTaskTest.java
@@ -160,9 +160,7 @@ public class UpdateDAIToSGIMembersTaskTest {
     }
 
     protected SecurityGroupMember newSGM(OsProtectionEntity protectionEntity, Long sgmId) {
-        // TODO emanoel: Remove this mock once the SGM is no longer kept in a TreeSet in the SGM.
-        SecurityGroupMember sgm = Mockito.spy(new SecurityGroupMember(protectionEntity));
-        Mockito.doReturn(-1).when(sgm).compareTo(Mockito.any());
+        SecurityGroupMember sgm = new SecurityGroupMember(protectionEntity);        
         sgm.setId(sgmId);
         return sgm;
     }

--- a/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/UpdatePortGroupTaskTest.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/UpdatePortGroupTaskTest.java
@@ -236,11 +236,8 @@ public class UpdatePortGroupTaskTest {
 		return newSGM(protectionEntity, sgmId);
 	}
 
-	private SecurityGroupMember newSGM(OsProtectionEntity protectionEntity, Long sgmId) {
-		// TODO emanoel: Remove this mock once the SGM is no longer kept in a
-		// TreeSet in the SGM.
-		SecurityGroupMember sgm = Mockito.spy(new SecurityGroupMember(protectionEntity));
-		Mockito.doReturn(-1).when(sgm).compareTo(Mockito.any());
+	private SecurityGroupMember newSGM(OsProtectionEntity protectionEntity, Long sgmId) {		
+		SecurityGroupMember sgm = new SecurityGroupMember(protectionEntity);		
 		sgm.setId(sgmId);
 
 		return sgm;


### PR DESCRIPTION
Also, SecurityGroup no longer implements Comparable. There is no need to, as the SecurityGroup is an entity. If pulled from the database, it will have its SecurityGroupMembers sorted, since the corresponding collection of SecurityGroup is annotated to be ordered by type.