### PR TITLE
osc-core code changes for sdn sdk 2.0.0 version

### DIFF
--- a/osc-export/pom.xml
+++ b/osc-export/pom.xml
@@ -443,7 +443,7 @@
 
 								<copy todir="${basedir}/webapp/SDK">
 									<fileset
-										dir="${user.home}/.m2/repository/org/osc/api/sdn-controller-api/1.1.0-SNAPSHOT">
+										dir="${user.home}/.m2/repository/org/osc/api/sdn-controller-api/2.0.0-SNAPSHOT">
 										<include name="**/*-sources.jar" />
 									</fileset>
 									<fileset

--- a/osc-server/pom.xml
+++ b/osc-server/pom.xml
@@ -60,7 +60,7 @@
 		<dependency>
 			<groupId>org.osc.api</groupId>
 			<artifactId>sdn-controller-api</artifactId>
-			<version>1.1.0-SNAPSHOT</version>
+			<version>2.0.0-SNAPSHOT</version>
 		</dependency>
 		
         <dependency>

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/DeleteInspectionPortTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/DeleteInspectionPortTask.java
@@ -85,8 +85,9 @@ public class DeleteInspectionPortTask extends TransactionalTask {
 
             ingressPort.setParentId(domainId);
             egressPort.setParentId(domainId);
-
-            InspectionPortElement portEl = new DefaultInspectionPort(ingressPort, egressPort);
+            
+            //Element Object in DefaultInspectionPort is not used for now, hence null
+            InspectionPortElement portEl = new DefaultInspectionPort(ingressPort, egressPort, null);
             LOG.info(String.format("Deleting Inspection port(s): '%s' from region '%s' and Server : '%s' ",
                     portEl, this.region, this.dai));
             controller.removeInspectionPort(portEl);

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OnboardDAITask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OnboardDAITask.java
@@ -76,13 +76,14 @@ public class OnboardDAITask extends TransactionalTask {
                 ingressPort.setParentId(domainId);
                 egressPort.setParentId(domainId);
                 if (domainId != null){
-                    controller.registerInspectionPort(new DefaultInspectionPort(ingressPort, egressPort));
+                	//Element Object is not used in DefaultInstepctionPort for now, hence null
+                    controller.registerInspectionPort(new DefaultInspectionPort(ingressPort, egressPort, null));
                 } else {
                     log.warn("DomainId is missing, cannot be null");
                 }
 
             } else {
-                controller.registerInspectionPort(new DefaultInspectionPort(ingressPort, egressPort));
+                controller.registerInspectionPort(new DefaultInspectionPort(ingressPort, egressPort, null));
             }
 
 

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OsDAIConformanceCheckMetaTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OsDAIConformanceCheckMetaTask.java
@@ -241,13 +241,14 @@ public class OsDAIConformanceCheckMetaTask extends TransactionalMetaTask {
                 if (domainId != null) {
                     ingressPort.setParentId(domainId);
                     egressPort.setParentId(domainId);
-                    inspectionPort = controller.getInspectionPort(new DefaultInspectionPort(ingressPort, egressPort));
+                    //Element object in DefaultInspectionport is not used at this point, hence null
+                    inspectionPort = controller.getInspectionPort(new DefaultInspectionPort(ingressPort, egressPort, null));
                 } else {
                     log.warn("DomainId is missing, cannot be null");
                 }
 
             } else {
-                inspectionPort = controller.getInspectionPort(new DefaultInspectionPort(ingressPort, egressPort));
+                inspectionPort = controller.getInspectionPort(new DefaultInspectionPort(ingressPort, egressPort, null));
             }
             return inspectionPort != null;
         } finally {

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OsSvaServerCreateTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OsSvaServerCreateTask.java
@@ -176,7 +176,8 @@ public class OsSvaServerCreateTask extends TransactionalTask {
                         ingressPort.setParentId(domainId);
                         egressPort.setParentId(domainId);
                     }
-                    controller.registerInspectionPort(new DefaultInspectionPort(ingressPort, egressPort));
+                    //Element object in DefaultInspectionport is not used at this point, hence null
+                    controller.registerInspectionPort(new DefaultInspectionPort(ingressPort, egressPort, null));
             } finally {
                 controller.close();
             }

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/CreatePortGroupHookTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/CreatePortGroupHookTask.java
@@ -16,6 +16,8 @@
  *******************************************************************************/
 package org.osc.core.broker.service.tasks.conformance.openstack.securitygroup;
 
+import java.util.Arrays;
+
 import javax.persistence.EntityManager;
 
 import org.apache.log4j.Logger;
@@ -67,10 +69,10 @@ public final class CreatePortGroupHookTask extends BasePortGroupHookTask {
     public void executeTransaction(EntityManager em) throws Exception {
         super.executeTransaction(em);
         String inspectionHookId = null;
-
+        //Element object in DefaultInspectionPort is not used , hence null
         try (SdnRedirectionApi redirection = this.apiFactoryService.createNetworkRedirectionApi(getSGI().getVirtualSystem())) {
-            inspectionHookId = redirection.installInspectionHook(getPortGroup(),
-                    new DefaultInspectionPort(getIngressPort(), getEgressPort()),
+            inspectionHookId = redirection.installInspectionHook(Arrays.asList(getPortGroup()),
+                    new DefaultInspectionPort(getIngressPort(), getEgressPort(), null),
                     getSGI().getTagValue(), null,
                     getSGI().getOrder(), null);
         }

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/UpdatePortGroupHookTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/UpdatePortGroupHookTask.java
@@ -71,7 +71,7 @@ public final class UpdatePortGroupHookTask extends BasePortGroupHookTask {
         try (SdnRedirectionApi redirection = this.apiFactoryService.createNetworkRedirectionApi(getSGI().getVirtualSystem())) {
             InspectionHookElementImpl inspectionHook =
                     new InspectionHookElementImpl(inspectionHookId, getPortGroup(),
-                            new DefaultInspectionPort(getIngressPort(), getEgressPort()),
+                            new DefaultInspectionPort(getIngressPort(), getEgressPort(), null),
                             getSGI().getTagValue(), TagEncapsulationType.valueOf(getSGI().getVirtualSystem().getEncapsulationType().name()),
                             getSGI().getOrder(), FailurePolicyType.valueOf(getSGI().getFailurePolicyType().name()));
 

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/VmPortHookCheckTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/VmPortHookCheckTask.java
@@ -199,7 +199,7 @@ public class VmPortHookCheckTask extends TransactionalMetaTask {
                         assignedRedirectedDai.getInspectionOsEgressPortId(),
                         assignedRedirectedDai.getInspectionEgressMacAddress());
                 hook = controller.getInspectionHook(new NetworkElementImpl(this.vmPort),
-                        new DefaultInspectionPort(ingressPort, egressPort));
+                        new DefaultInspectionPort(ingressPort, egressPort, null));
             }
 
             // Missing tag indicates missing hook

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/VmPortHookCreateTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/VmPortHookCreateTask.java
@@ -16,6 +16,7 @@
  *******************************************************************************/
 package org.osc.core.broker.service.tasks.conformance.openstack.securitygroup;
 
+import java.util.Arrays;
 import java.util.Set;
 
 import javax.persistence.EntityManager;
@@ -94,13 +95,13 @@ public class VmPortHookCreateTask extends TransactionalTask {
                 if (portGroupId != null){
                     PortGroup portGroup = new PortGroup();
                     portGroup.setPortGroupId(portGroupId);
-                    controller.installInspectionHook(portGroup, new DefaultInspectionPort(ingressPort, egressPort),
+                    controller.installInspectionHook(Arrays.asList(portGroup), new DefaultInspectionPort(ingressPort, egressPort, null),
                             this.securityGroupInterface.getTagValue(), encapsulationType,
                             this.securityGroupInterface.getOrder(), FailurePolicyType.valueOf(this.securityGroupInterface.getFailurePolicyType().name()));
                 }
             } else {
-                controller.installInspectionHook(new NetworkElementImpl(this.vmPort),
-                        new DefaultInspectionPort(ingressPort, egressPort),
+                controller.installInspectionHook(Arrays.asList(new NetworkElementImpl(this.vmPort)),
+                        new DefaultInspectionPort(ingressPort, egressPort, null),
                         this.securityGroupInterface.getTagValue(), encapsulationType,
                         this.securityGroupInterface.getOrder(), FailurePolicyType.valueOf(this.securityGroupInterface.getFailurePolicyType().name()));
             }

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/VmPortHookFailurePolicyUpdateTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/VmPortHookFailurePolicyUpdateTask.java
@@ -74,7 +74,8 @@ public class VmPortHookFailurePolicyUpdateTask extends TransactionalTask {
                     this.dai.getInspectionIngressMacAddress());
             DefaultNetworkPort egressPort = new DefaultNetworkPort(this.dai.getInspectionOsEgressPortId(),
                     this.dai.getInspectionEgressMacAddress());
-            controller.setInspectionHookFailurePolicy(new NetworkElementImpl(this.vmPort), new DefaultInspectionPort(ingressPort, egressPort),
+            //Element object in DefaultInspectionPort is not used, hence null
+            controller.setInspectionHookFailurePolicy(new NetworkElementImpl(this.vmPort), new DefaultInspectionPort(ingressPort, egressPort, null),
                     FailurePolicyType.valueOf(this.securityGroupInterface.getFailurePolicyType().name()));
         } finally {
             controller.close();

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/VmPortHookOrderUpdateTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/VmPortHookOrderUpdateTask.java
@@ -72,8 +72,8 @@ public class VmPortHookOrderUpdateTask extends TransactionalTask {
                     this.dai.getInspectionIngressMacAddress());
             DefaultNetworkPort egressPort = new DefaultNetworkPort(this.dai.getInspectionOsEgressPortId(),
                     this.dai.getInspectionEgressMacAddress());
-
-            controller.setInspectionHookOrder(new NetworkElementImpl(this.vmPort), new DefaultInspectionPort(ingressPort, egressPort),
+            //Element object in DefaultInspectionPort not used, hence null
+            controller.setInspectionHookOrder(new NetworkElementImpl(this.vmPort), new DefaultInspectionPort(ingressPort, egressPort, null),
                     this.securityGroupInterface.getOrder());
         } finally {
             controller.close();

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/VmPortHookRemoveTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/VmPortHookRemoveTask.java
@@ -16,6 +16,8 @@
  *******************************************************************************/
 package org.osc.core.broker.service.tasks.conformance.openstack.securitygroup;
 
+import java.util.Arrays;
+
 import javax.persistence.EntityManager;
 
 import org.apache.log4j.Logger;
@@ -98,9 +100,10 @@ public class VmPortHookRemoveTask extends TransactionalTask {
                     String portGroupId = this.sgm.getSecurityGroup().getNetworkElementId();
                     PortGroup portGroup = new PortGroup();
                     portGroup.setPortGroupId(portGroupId);
-                    controller.removeInspectionHook(portGroup, new DefaultInspectionPort(ingressPort, egressPort));
+                    //Element object in DefaultInpectionPort will only be used in case of SFC , hence pass null
+                    controller.removeInspectionHook(Arrays.asList(portGroup), new DefaultInspectionPort(ingressPort, egressPort, null));
                 } else {
-                    controller.removeInspectionHook(new NetworkElementImpl(this.vmPort), new DefaultInspectionPort(ingressPort, egressPort));
+                    controller.removeInspectionHook(Arrays.asList(new NetworkElementImpl(this.vmPort)), new DefaultInspectionPort(ingressPort, egressPort, null));
                 }
             }
             this.vmPort.removeDai(this.dai);

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/VmPortHookTagUpdateTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/VmPortHookTagUpdateTask.java
@@ -73,7 +73,7 @@ public class VmPortHookTagUpdateTask extends TransactionalTask {
             DefaultNetworkPort egressPort = new DefaultNetworkPort(this.dai.getInspectionOsEgressPortId(),
                     this.dai.getInspectionEgressMacAddress());
 
-            controller.setInspectionHookTag(new NetworkElementImpl(this.vmPort), new DefaultInspectionPort(ingressPort, egressPort),
+            controller.setInspectionHookTag(new NetworkElementImpl(this.vmPort), new DefaultInspectionPort(ingressPort, egressPort, null),
                     this.securityGroupInterface.getTagValue());
         } finally {
             controller.close();

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/VmPortHookUpdateTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/VmPortHookUpdateTask.java
@@ -80,7 +80,7 @@ public class VmPortHookUpdateTask extends TransactionalTask {
             // the other cases as well and provide it here.
             InspectionHookElementImpl inspectionHook =
                     new InspectionHookElementImpl(null, new NetworkElementImpl(this.vmPort),
-                            new DefaultInspectionPort(ingressPort, egressPort),
+                            new DefaultInspectionPort(ingressPort, egressPort, null),
                             this.securityGroupInterface.getTagValue(),
                             TagEncapsulationType.valueOf(this.securityGroupInterface.getVirtualSystem().getEncapsulationType().name()),
                             this.securityGroupInterface.getOrder(),

--- a/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/CreatePortGroupHookTaskTest.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/CreatePortGroupHookTaskTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.junit.Assert;
@@ -164,7 +165,7 @@ public class CreatePortGroupHookTaskTest extends BasePortGroupHookTaskTest {
         }
     }
 
-    private class NetworkElementMatcher extends ArgumentMatcher<NetworkElement> {
+    private class NetworkElementMatcher extends ArgumentMatcher<List<NetworkElement>> {
         private SecurityGroup sg;
 
         public NetworkElementMatcher(SecurityGroup sg) {
@@ -172,12 +173,12 @@ public class CreatePortGroupHookTaskTest extends BasePortGroupHookTaskTest {
         }
 
         @Override
-        public boolean matches(Object object) {
-            if (object == null || !(object instanceof NetworkElement)) {
+        public boolean matches(Object objects) {
+            if (objects == null || !(objects instanceof List<?>)) {
                 return false;
             }
 
-            NetworkElement netElement = (NetworkElement) object;
+            NetworkElement netElement = (NetworkElement) ((List<?>)objects).get(0);
 
             return netElement.getElementId().equals(this.sg.getNetworkElementId());
         }

--- a/osc-service-api/pom.xml
+++ b/osc-service-api/pom.xml
@@ -46,7 +46,7 @@
 		<dependency>
 			<groupId>org.osc.api</groupId>
 			<artifactId>sdn-controller-api</artifactId>
-			<version>1.1.0-SNAPSHOT</version>
+			<version>2.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.osc.api</groupId>

--- a/osc-ui/pom.xml
+++ b/osc-ui/pom.xml
@@ -77,7 +77,7 @@
 		<dependency>
 			<groupId>org.osc.api</groupId>
 			<artifactId>sdn-controller-api</artifactId>
-			<version>1.1.0-SNAPSHOT</version>
+			<version>2.0.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
                 <version>6.0.1</version>
                 <scope>provided</scope>
             </dependency>
-            <!-- Testing Dependencies -->
+            <!-- Testing Dependencies. -->
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>


### PR DESCRIPTION
Modified osc-core files from sdn-api version 2.0.0. 
Compilation done : eclipseand mvn
Testing done :  on Newton setup with new nsc plugin and osc-core changes.