### PR TITLE
remove NSM and SMC plugin from the all profile

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -76,10 +76,15 @@
 	</target>
 		
 	<target name="copyPlugins" if="${all}">
-		<copy file="${basedir}/../security-mgr-sample-plugin/target/SampleMgrPlugin.bar" tofile="Build${fullVersion}/SampleMgrPlugin.bar" />
-		<copy file="${basedir}/../security-mgr-nsm-plugin/target/NsmMgrPlugin.bar" tofile="Build${fullVersion}/NsmMgrPlugin.bar" />
-		<copy file="${basedir}/../security-mgr-smc-plugin/target/SmcMgrPlugin.bar" tofile="Build${fullVersion}/SmcMgrPlugin.bar" />
-		<copy file="${basedir}/../sdn-controller-nsc-plugin/target/NscSdnControllerPlugin.bar" tofile="Build${fullVersion}/NscSdnControllerPlugin.bar" />
+		<copy tofile="Build${fullVersion}/SampleMgrPlugin.bar">
+			<fileset dir="${basedir}/../security-mgr-sample-plugin/target/" includes="SampleMgrPlugin*.bar" />
+		</copy>
+		<copy tofile="Build${fullVersion}/NscSdnControllerPlugin.bar">
+			<fileset dir="${basedir}/../sdn-controller-nsc-plugin/target/" includes="NscSdnControllerPlugin*.bar" />
+		</copy>
+        <copy tofile="Build${fullVersion}/NuageSdnControllerPlugin.bar">
+        	<fileset dir="${basedir}/../osc-nuage-plugin/target/" includes="NuageSdnControllerPlugin*.bar" />
+        </copy>
 	</target>
 
 	<target name="checkImagesTocopy">

--- a/osc-export/pom.xml
+++ b/osc-export/pom.xml
@@ -297,11 +297,9 @@
 								</goals>
 								<configuration>
 									<tasks>
-										<!-- copy bundled plugins for bundled profile "all". -->
-										<copy tofile="${basedir}/plugins/SmcMgrPlugin.bar"
-											file="${basedir}/../../security-mgr-smc-plugin/target/SmcMgrPlugin.bar" />
-										<copy tofile="${basedir}/plugins/NsmMgrPlugin.bar"
-											file="${basedir}/../../security-mgr-nsm-plugin/target/NsmMgrPlugin.bar" />
+										<!-- copy bundled plugins for bundled profile "all". -->										
+										<copy tofile="${basedir}/plugins/NuageSdnControllerPlugin.bar"
+											file="${basedir}/../../osc-nuage-plugin/target/NuageSdnControllerPlugin.bar" />
 										<copy tofile="${basedir}/plugins/SampleMgrPlugin.bar"
 											file="${basedir}/../../security-mgr-sample-plugin/target/SampleMgrPlugin.bar" />
 										<copy tofile="${basedir}/plugins/NscSdnControllerPlugin.bar"

--- a/osc-export/pom.xml
+++ b/osc-export/pom.xml
@@ -298,12 +298,19 @@
 								<configuration>
 									<tasks>
 										<!-- copy bundled plugins for bundled profile "all". -->										
-										<copy tofile="${basedir}/plugins/NuageSdnControllerPlugin.bar"
-											file="${basedir}/../../osc-nuage-plugin/target/NuageSdnControllerPlugin.bar" />
-										<copy tofile="${basedir}/plugins/SampleMgrPlugin.bar"
-											file="${basedir}/../../security-mgr-sample-plugin/target/SampleMgrPlugin.bar" />
-										<copy tofile="${basedir}/plugins/NscSdnControllerPlugin.bar"
-											file="${basedir}/../../sdn-controller-nsc-plugin/target/NscSdnControllerPlugin.bar" />
+										<copy tofile="${basedir}/plugins/SampleMgrPlugin.bar">
+											<fileset
+												dir="${basedir}/../../security-mgr-sample-plugin/target/"
+												includes="SampleMgrPlugin*.bar" />
+										</copy>
+										<copy tofile="${basedir}/plugins/NscSdnControllerPlugin.bar">
+											<fileset dir="${basedir}/../../sdn-controller-nsc-plugin/target/"
+												includes="NscSdnControllerPlugin*.bar" />
+										</copy>
+                                        <copy tofile="${basedir}/plugins/NuageSdnControllerPlugin.bar">
+                                            <fileset dir="${basedir}/../../osc-nuage-plugin/target/"
+                                                includes="NuageSdnControllerPlugin*.bar" />
+                                        </copy>										
 									</tasks>
 								</configuration>
 							</execution>
@@ -391,7 +398,7 @@
 						<fileset>
 							<directory>${basedir}</directory>
 							<includes>
-								<include>plugins/**</include>								
+								<include>plugins/**</include>
 								<include>generated/**</include>
 								<include>webapp/**</include>
 							</includes>

--- a/pom.xml
+++ b/pom.xml
@@ -129,9 +129,9 @@
                 <module>../security-mgr-api</module>
 
                 <module>../sdn-controller-nsc-plugin</module>
-                <module>../security-mgr-nsm-plugin</module>
-                <module>../security-mgr-smc-plugin</module>
                 <module>../security-mgr-sample-plugin</module>
+                
+                <module>../osc-nuage-plugin</module>
 
                 <module>osc-tools</module>
                 <module>osc-uber-openstack4j</module>


### PR DESCRIPTION
remove NSM and SMC from the all profile until those plugins are open sourced.
Adds nuage to the all profile since it is already part of the opensecuritycontroller org