### PR TITLE
Enabling k8s virtualization connector

### DIFF
--- a/osc-common/src/main/java/org/osc/core/common/virtualization/VirtualizationType.java
+++ b/osc-common/src/main/java/org/osc/core/common/virtualization/VirtualizationType.java
@@ -18,7 +18,7 @@ package org.osc.core.common.virtualization;
 
 
 public enum VirtualizationType {
-    OPENSTACK("OPENSTACK");
+    OPENSTACK("OPENSTACK"), KUBERNETES("KUBERNETES");
 
     private final String text;
 
@@ -40,7 +40,12 @@ public enum VirtualizationType {
     }
 
     public boolean isOpenstack() {
-        return this.equals(VirtualizationType.OPENSTACK);
+        return equals(VirtualizationType.OPENSTACK);
+    }
+
+
+    public boolean isKubernetes() {
+        return equals(VirtualizationType.KUBERNETES);
     }
 
     @Override

--- a/osc-server/src/main/java/org/osc/core/broker/rest/client/k8s/KubernetesApi.java
+++ b/osc-server/src/main/java/org/osc/core/broker/rest/client/k8s/KubernetesApi.java
@@ -29,5 +29,13 @@ public class KubernetesApi {
     KubernetesClient getKubernetesClient() {
         return this.client;
     }
+
+    public void setKubernetesClient(org.osc.core.broker.rest.client.k8s.KubernetesClient client) {
+        if (client == null || client.getClient() == null) {
+            throw new IllegalArgumentException("The provided client cannot be null.");
+        }
+
+        this.client = client.getClient();
+    }
 }
 

--- a/osc-server/src/main/java/org/osc/core/broker/rest/client/k8s/KubernetesStatusApi.java
+++ b/osc-server/src/main/java/org/osc/core/broker/rest/client/k8s/KubernetesStatusApi.java
@@ -51,7 +51,6 @@ public class KubernetesStatusApi extends KubernetesApi {
         boolean result = false;
         try {
             ComponentStatus status = getKubernetesClient().componentstatuses().withName(K8S_CONTROLLER_COMPONENT_NAME).get();
-
             if (status == null) {
                 LOG.warn(String.format("Kubernetes returned a null component for %s.", K8S_CONTROLLER_COMPONENT_NAME));
                 return result;

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/virtualizationconnector/CheckSSLConnectivityVcTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/virtualizationconnector/CheckSSLConnectivityVcTask.java
@@ -16,7 +16,7 @@
  *******************************************************************************/
 package org.osc.core.broker.service.tasks.conformance.virtualizationconnector;
 
-import static java.util.stream.Collectors.*;
+import static java.util.stream.Collectors.toSet;
 
 import java.util.Set;
 
@@ -64,9 +64,7 @@ public class CheckSSLConnectivityVcTask extends TransactionalTask {
         this.vc = em.find(VirtualizationConnector.class, this.vc.getId());
         log.debug("Start executing CheckSSLConnectivityVcTask Task. VC: '" + this.vc.getName() + "'");
         DryRunRequest<VirtualizationConnectorDto> request = createRequest(this.vc);
-        if (VirtualizationType.fromText(this.vc.getVirtualizationType().name()).equals(VirtualizationType.OPENSTACK)) {
-            this.virtualizationConnectorUtil.checkOpenstackConnection(request, this.vc);
-        }
+        this.virtualizationConnectorUtil.checkConnection(request, this.vc);
     }
 
     @Override

--- a/osc-server/src/main/java/org/osc/core/broker/service/validator/AddVirtualizationConnectorServiceRequestValidator.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/validator/AddVirtualizationConnectorServiceRequestValidator.java
@@ -29,7 +29,7 @@ import org.osc.core.broker.util.TransactionalBroadcastUtil;
 import org.osc.core.broker.util.VirtualizationConnectorUtil;
 
 public class AddVirtualizationConnectorServiceRequestValidator
-        implements RequestValidator<DryRunRequest<VirtualizationConnectorRequest>, VirtualizationConnector> {
+implements RequestValidator<DryRunRequest<VirtualizationConnectorRequest>, VirtualizationConnector> {
     private EntityManager em;
 
     private DtoValidator<VirtualizationConnectorDto, VirtualizationConnector> dtoValidator;
@@ -60,9 +60,7 @@ public class AddVirtualizationConnectorServiceRequestValidator
 
         VirtualizationConnector vc = VirtualizationConnectorEntityMgr.createEntity(dto, StaticRegistry.encryptionApi());
 
-        if (dto.getType().isOpenstack()) {
-            this.virtualizationConnectorUtil.checkOpenstackConnection(request, vc);
-        }
+        this.virtualizationConnectorUtil.checkConnection(request, vc);
     }
 
     @Override

--- a/osc-server/src/main/java/org/osc/core/broker/service/validator/VirtualizationConnectorDtoValidator.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/validator/VirtualizationConnectorDtoValidator.java
@@ -52,6 +52,11 @@ implements DtoValidator<VirtualizationConnectorDto, VirtualizationConnector> {
         OSCEntityManager<VirtualizationConnector> emgr = new OSCEntityManager<>(
                 VirtualizationConnector.class, this.em, this.txBroadcastUtil);
 
+        if (dto.getType().isKubernetes() && !dto.isControllerDefined()) {
+            throw new VmidcBrokerValidationException(
+                    "Virtualization connectors for Kubernetes must have a SDN controller.");
+        }
+
         boolean usesProviderCreds = dto.isControllerDefined() && this.apiFactoryService.usesProviderCreds(dto.getControllerType());
         VirtualizationConnectorDtoValidator.checkForNullFields(dto, usesProviderCreds);
         VirtualizationConnectorDtoValidator.checkFieldLength(dto);
@@ -64,7 +69,6 @@ implements DtoValidator<VirtualizationConnectorDto, VirtualizationConnector> {
 
         // check for uniqueness of vc name
         if (emgr.isExisting("name", dto.getName())) {
-
             throw new VmidcBrokerValidationException(
                     "Virtualization Connector Name: " + dto.getName() + " already exists.");
         }

--- a/osc-server/src/main/java/org/osc/core/broker/service/vc/UpdateVirtualizationConnectorService.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/vc/UpdateVirtualizationConnectorService.java
@@ -16,7 +16,7 @@
  *******************************************************************************/
 package org.osc.core.broker.service.vc;
 
-import static java.util.stream.Collectors.*;
+import static java.util.stream.Collectors.toSet;
 
 import java.util.List;
 import java.util.Set;
@@ -67,8 +67,8 @@ import org.osgi.service.component.annotations.Reference;
 
 @Component
 public class UpdateVirtualizationConnectorService
-        extends ServiceDispatcher<DryRunRequest<VirtualizationConnectorRequest>, BaseJobResponse>
-        implements UpdateVirtualizationConnectorServiceApi {
+extends ServiceDispatcher<DryRunRequest<VirtualizationConnectorRequest>, BaseJobResponse>
+implements UpdateVirtualizationConnectorServiceApi {
 
     private static final Logger log = Logger.getLogger(UpdateVirtualizationConnectorService.class);
 
@@ -116,8 +116,8 @@ public class UpdateVirtualizationConnectorService
             updateVirtualizationConnector(request, vc);
             SslCertificateAttrEntityMgr sslMgr = new SslCertificateAttrEntityMgr(em, this.txBroadcastUtil);
             vc.setSslCertificateAttrSet(sslMgr.storeSSLEntries(request.getDto().getSslCertificateAttrSet().stream()
-                            .map(SslCertificateAttrEntityMgr::createEntity)
-                            .collect(toSet()),
+                    .map(SslCertificateAttrEntityMgr::createEntity)
+                    .collect(toSet()),
                     request.getDto().getId(), persistentSslCertificatesSet));
             vcEntityMgr.update(vc);
 
@@ -150,7 +150,7 @@ public class UpdateVirtualizationConnectorService
 
     private DryRunRequest<VirtualizationConnectorRequest> internalSSLCertificatesFetch(
             DryRunRequest<VirtualizationConnectorRequest> request, SslCertificatesExtendedException sslCertificatesException)
-            throws Exception {
+                    throws Exception {
         X509TrustManagerFactory trustManagerFactory = X509TrustManagerFactory.getInstance();
 
         int i = 1;
@@ -164,7 +164,7 @@ public class UpdateVirtualizationConnectorService
     }
 
     void validate(EntityManager em, DryRunRequest<VirtualizationConnectorRequest> request,
-                  VirtualizationConnector existingVc, OSCEntityManager<VirtualizationConnector> emgr) throws Exception {
+            VirtualizationConnector existingVc, OSCEntityManager<VirtualizationConnector> emgr) throws Exception {
 
         // check for null/empty values
         VirtualizationConnectorDto dto = request.getDto();
@@ -231,9 +231,7 @@ public class UpdateVirtualizationConnectorService
         // Transforms the existing vc based on the update request
         updateVirtualizationConnector(request, existingVc);
 
-        if (dto.getType().isOpenstack()) {
-            this.util.checkOpenstackConnection(request, existingVc);
-        }
+        this.util.checkConnection(request, existingVc);
     }
 
     /**
@@ -241,7 +239,7 @@ public class UpdateVirtualizationConnectorService
      * no password specified, it uses the password from the DB.
      */
     private void updateVirtualizationConnector(DryRunRequest<VirtualizationConnectorRequest> request,
-                                               VirtualizationConnector existingVc) throws EncryptionException {
+            VirtualizationConnector existingVc) throws EncryptionException {
         // cache existing DB passwords
         String providerDbPassword = existingVc.getProviderPassword();
         String controllerDbPassword = existingVc.getControllerPassword();

--- a/osc-server/src/main/java/org/osc/core/broker/util/VirtualizationConnectorUtil.java
+++ b/osc-server/src/main/java/org/osc/core/broker/util/VirtualizationConnectorUtil.java
@@ -16,15 +16,22 @@
  *******************************************************************************/
 package org.osc.core.broker.util;
 
-import com.rabbitmq.client.ShutdownSignalException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.apache.log4j.Logger;
 import org.osc.core.broker.model.entities.virtualization.VirtualizationConnector;
 import org.osc.core.broker.model.plugin.ApiFactoryService;
+import org.osc.core.broker.rest.client.k8s.KubernetesClient;
+import org.osc.core.broker.rest.client.k8s.KubernetesStatusApi;
 import org.osc.core.broker.rest.client.openstack.openstack4j.Endpoint;
 import org.osc.core.broker.rest.client.openstack.openstack4j.Openstack4jKeystone;
 import org.osc.core.broker.rest.client.openstack.vmidc.notification.OsRabbitMQClient;
 import org.osc.core.broker.rest.client.openstack.vmidc.notification.runner.RabbitMQRunner;
 import org.osc.core.broker.service.dto.VirtualizationConnectorDto;
+import org.osc.core.broker.service.exceptions.VmidcException;
 import org.osc.core.broker.service.request.DryRunRequest;
 import org.osc.core.broker.service.request.ErrorTypeException;
 import org.osc.core.broker.service.request.ErrorTypeException.ErrorType;
@@ -32,6 +39,7 @@ import org.osc.core.broker.service.ssl.CertificateResolverModel;
 import org.osc.core.broker.service.ssl.SslCertificatesExtendedException;
 import org.osc.core.broker.util.crypto.SslContextProvider;
 import org.osc.core.broker.util.crypto.X509TrustManagerFactory;
+import org.osc.core.common.virtualization.VirtualizationType;
 import org.osgi.service.component.ComponentServiceObjects;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
@@ -39,9 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 
-import java.util.ArrayList;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
+import com.rabbitmq.client.ShutdownSignalException;
 
 @Component(service = VirtualizationConnectorUtil.class)
 public class VirtualizationConnectorUtil {
@@ -49,6 +55,8 @@ public class VirtualizationConnectorUtil {
     private static final Logger LOG = Logger.getLogger(VirtualizationConnectorUtil.class);
 
     private X509TrustManagerFactory managerFactory = null;
+
+    private KubernetesStatusApi k8sStatusApi = null;
 
     @Reference
     private ApiFactoryService apiFactoryService;
@@ -75,16 +83,8 @@ public class VirtualizationConnectorUtil {
         }
     }
 
-    /**
-     * Checks connection for openstack.
-     *
-     * @throws ErrorTypeException in case of keystone/controller/rabbitmq connection issues
-     * @throws Exception          in case of any other issues
-     */
-    public <T extends VirtualizationConnectorDto> void checkOpenstackConnection(DryRunRequest<T> request,
-                                                                                VirtualizationConnector vc) throws Exception {
+    public <T extends VirtualizationConnectorDto> void checkConnection(DryRunRequest<T> request,  VirtualizationConnector vc) throws Exception {
         if (!request.isSkipAllDryRun()) {
-
             ErrorTypeException errorTypeException = null;
             final ArrayList<CertificateResolverModel> certificateResolverModels = new ArrayList<>();
 
@@ -92,65 +92,10 @@ public class VirtualizationConnectorUtil {
                 this.managerFactory = X509TrustManagerFactory.getInstance();
             }
 
-            if (request.getDto().isControllerDefined()
-                    && !request.isIgnoreErrorsAndCommit(ErrorType.CONTROLLER_EXCEPTION)) {
-                initSSLCertificatesListener(this.managerFactory, certificateResolverModels, "openstack");
-                try {
-                    // Check NSC Connectivity and Credentials
-                    this.apiFactoryService.getStatus(vc, null);
-                } catch (Exception exception) {
-                    errorTypeException = new ErrorTypeException(exception, ErrorType.CONTROLLER_EXCEPTION);
-                    LOG.warn(
-                            "Exception encountered when trying to add SDN Controller info to Virtualization Connector, allowing user to either ignore or correct issue");
-                }
-            }
-            // Check Connectivity with Key stone if https response exception is not to be ignored
-            if (!request.isIgnoreErrorsAndCommit(ErrorType.PROVIDER_EXCEPTION)) {
-                initSSLCertificatesListener(this.managerFactory, certificateResolverModels, "openstackkeystone");
-                try {
-                    VirtualizationConnectorDto vcDto = request.getDto();
-                    boolean isHttps = isHttps(vcDto.getProviderAttributes());
-
-                    Endpoint endPoint = new Endpoint(vcDto.getProviderIP(), vcDto.getAdminDomainId(), vcDto.getAdminProjectName(),
-                            vcDto.getProviderUser(), vcDto.getProviderPassword(), isHttps,
-                            SslContextProvider.getInstance().getSSLContext());
-
-                    try (Openstack4jKeystone keystoneAPi = new Openstack4jKeystone(endPoint)) {
-                        keystoneAPi.listProjects();
-                    }
-                } catch (Exception exception) {
-                    errorTypeException = new ErrorTypeException(exception, ErrorType.PROVIDER_EXCEPTION);
-                    LOG.warn(
-                            "Exception encountered when trying to add Keystone info to Virtualization Connector, allowing user to either ignore or correct issue");
-                }
-            }
-
-            if (!request.isIgnoreErrorsAndCommit(ErrorType.RABBITMQ_EXCEPTION)) {
-                initSSLCertificatesListener(this.managerFactory, certificateResolverModels, "rabbitmq");
-                try {
-                    OsRabbitMQClient rabbitClient = new OsRabbitMQClient(vc);
-                    rabbitClient.testConnection();
-                } catch (ShutdownSignalException shutdownException) {
-                    // If its an existing VC which we are connected to, then this exception is expected
-                    if (vc.getId() != null) {
-                        delayedInit();
-                        OsRabbitMQClient osRabbitMQClient = this.activeRunner.getVcToRabbitMQClientMap().get(vc.getId());
-                        if (osRabbitMQClient != null && osRabbitMQClient.isConnected()) {
-                            LOG.info(
-                                    "Exception encountered when connecting to RabbitMQ, ignoring since we are already connected",
-                                    shutdownException);
-                        } else {
-                            errorTypeException = new ErrorTypeException(shutdownException,
-                                    ErrorType.RABBITMQ_EXCEPTION);
-                        }
-                    } else {
-                        errorTypeException = new ErrorTypeException(shutdownException, ErrorType.RABBITMQ_EXCEPTION);
-                    }
-                } catch (Throwable exception) {
-                    errorTypeException = new ErrorTypeException(exception, ErrorType.RABBITMQ_EXCEPTION);
-                    LOG.warn(
-                            "Exception encountered when trying to connect to RabbitMQ, allowing user to either ignore or correct issue");
-                }
+            if (vc.getVirtualizationType().equals(VirtualizationType.OPENSTACK)) {
+                errorTypeException = checkOpenstackConnection(request, certificateResolverModels, vc);
+            } else if (vc.getVirtualizationType().equals(VirtualizationType.KUBERNETES)) {
+                errorTypeException = checkKubernetesConnection(request, certificateResolverModels, vc);
             }
 
             this.managerFactory.clearListener();
@@ -163,13 +108,122 @@ public class VirtualizationConnectorUtil {
         }
     }
 
+    private <T extends VirtualizationConnectorDto>  ErrorTypeException checkSDNControllerConnection(
+            DryRunRequest<T> request,
+            ArrayList<CertificateResolverModel> certificateResolverModels,
+            VirtualizationConnector vc) {
+
+        ErrorTypeException errorTypeException = null;
+        if (request.getDto().isControllerDefined()
+                && !request.isIgnoreErrorsAndCommit(ErrorType.CONTROLLER_EXCEPTION)) {
+            initSSLCertificatesListener(this.managerFactory, certificateResolverModels, "openstack");
+            try {
+                // Check NSC Connectivity and Credentials
+                this.apiFactoryService.getStatus(vc, null);
+            } catch (Exception exception) {
+                errorTypeException = new ErrorTypeException(exception, ErrorType.CONTROLLER_EXCEPTION);
+                LOG.warn(
+                        "Exception encountered when trying to add SDN Controller info to Virtualization Connector, allowing user to either ignore or correct issue");
+            }
+        }
+
+        return errorTypeException;
+    }
+
+    private <T extends VirtualizationConnectorDto> ErrorTypeException checkKubernetesConnection(
+            DryRunRequest<T> request,
+            ArrayList<CertificateResolverModel> certificateResolverModels,
+            VirtualizationConnector vc) throws IOException, VmidcException {
+        ErrorTypeException errorTypeException = null;
+        errorTypeException = this.checkSDNControllerConnection(request, certificateResolverModels, vc);
+        if (!request.isIgnoreErrorsAndCommit(ErrorType.PROVIDER_EXCEPTION)) {
+            try (KubernetesClient client = new KubernetesClient(vc)) {
+                if (this.k8sStatusApi == null) {
+                    this.k8sStatusApi = new KubernetesStatusApi(client);
+                }
+
+                if (!this.k8sStatusApi.isServiceReady()) {
+                    errorTypeException = new ErrorTypeException("Kubernetes reported service NOT ready.", ErrorType.PROVIDER_EXCEPTION);
+                }
+            }
+        }
+        return errorTypeException;
+    }
+
+    /**
+     * Checks connection for openstack.
+     *
+     * @throws ErrorTypeException in case of keystone/controller/rabbitmq connection issues
+     * @throws Exception          in case of any other issues
+     */
+    private <T extends VirtualizationConnectorDto> ErrorTypeException checkOpenstackConnection(
+            DryRunRequest<T> request,
+            ArrayList<CertificateResolverModel> certificateResolverModels,
+            VirtualizationConnector vc) throws Exception {
+
+        ErrorTypeException errorTypeException = null;
+
+        errorTypeException = this.checkSDNControllerConnection(request, certificateResolverModels, vc);
+
+        // Check Connectivity with Key stone if https response exception is not to be ignored
+        if (!request.isIgnoreErrorsAndCommit(ErrorType.PROVIDER_EXCEPTION)) {
+            initSSLCertificatesListener(this.managerFactory, certificateResolverModels, "openstackkeystone");
+            try {
+                VirtualizationConnectorDto vcDto = request.getDto();
+                boolean isHttps = isHttps(vcDto.getProviderAttributes());
+
+                Endpoint endPoint = new Endpoint(vcDto.getProviderIP(), vcDto.getAdminDomainId(), vcDto.getAdminProjectName(),
+                        vcDto.getProviderUser(), vcDto.getProviderPassword(), isHttps,
+                        SslContextProvider.getInstance().getSSLContext());
+
+                try (Openstack4jKeystone keystoneAPi = new Openstack4jKeystone(endPoint)) {
+                    keystoneAPi.listProjects();
+                }
+            } catch (Exception exception) {
+                errorTypeException = new ErrorTypeException(exception, ErrorType.PROVIDER_EXCEPTION);
+                LOG.warn(
+                        "Exception encountered when trying to add Keystone info to Virtualization Connector, allowing user to either ignore or correct issue");
+            }
+        }
+
+        if (!request.isIgnoreErrorsAndCommit(ErrorType.RABBITMQ_EXCEPTION)) {
+            initSSLCertificatesListener(this.managerFactory, certificateResolverModels, "rabbitmq");
+            try {
+                OsRabbitMQClient rabbitClient = new OsRabbitMQClient(vc);
+                rabbitClient.testConnection();
+            } catch (ShutdownSignalException shutdownException) {
+                // If its an existing VC which we are connected to, then this exception is expected
+                if (vc.getId() != null) {
+                    delayedInit();
+                    OsRabbitMQClient osRabbitMQClient = this.activeRunner.getVcToRabbitMQClientMap().get(vc.getId());
+                    if (osRabbitMQClient != null && osRabbitMQClient.isConnected()) {
+                        LOG.info(
+                                "Exception encountered when connecting to RabbitMQ, ignoring since we are already connected",
+                                shutdownException);
+                    } else {
+                        errorTypeException = new ErrorTypeException(shutdownException,
+                                ErrorType.RABBITMQ_EXCEPTION);
+                    }
+                } else {
+                    errorTypeException = new ErrorTypeException(shutdownException, ErrorType.RABBITMQ_EXCEPTION);
+                }
+            } catch (Throwable exception) {
+                errorTypeException = new ErrorTypeException(exception, ErrorType.RABBITMQ_EXCEPTION);
+                LOG.warn(
+                        "Exception encountered when trying to connect to RabbitMQ, allowing user to either ignore or correct issue");
+            }
+        }
+
+        return errorTypeException;
+    }
+
     private static boolean isHttps(Map<String, String> attributes) {
         return attributes.containsKey(VirtualizationConnector.ATTRIBUTE_KEY_HTTPS)
                 && String.valueOf(true).equals(attributes.get(VirtualizationConnector.ATTRIBUTE_KEY_HTTPS));
     }
 
     private void initSSLCertificatesListener(X509TrustManagerFactory managerFactory,
-                                             ArrayList<CertificateResolverModel> resolverList, String aliasPrefix) {
+            ArrayList<CertificateResolverModel> resolverList, String aliasPrefix) {
         try {
             managerFactory.setListener(model -> {
                 model.setAlias(aliasPrefix + "_" + model.getAlias());

--- a/osc-server/src/main/java/org/osc/core/broker/util/VirtualizationConnectorUtil.java
+++ b/osc-server/src/main/java/org/osc/core/broker/util/VirtualizationConnectorUtil.java
@@ -140,6 +140,8 @@ public class VirtualizationConnectorUtil {
             try (KubernetesClient client = new KubernetesClient(vc)) {
                 if (this.k8sStatusApi == null) {
                     this.k8sStatusApi = new KubernetesStatusApi(client);
+                } else {
+                    this.k8sStatusApi.setKubernetesClient(client);
                 }
 
                 if (!this.k8sStatusApi.isServiceReady()) {
@@ -147,6 +149,7 @@ public class VirtualizationConnectorUtil {
                 }
             }
         }
+
         return errorTypeException;
     }
 

--- a/osc-server/src/test/java/org/osc/core/broker/service/request/AddVirtualizationConnectorServiceRequestValidatorTest.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/request/AddVirtualizationConnectorServiceRequestValidatorTest.java
@@ -36,7 +36,7 @@ import org.osc.core.broker.service.dto.VirtualizationConnectorDto;
 import org.osc.core.broker.service.exceptions.VmidcBrokerValidationException;
 import org.osc.core.broker.service.validator.AddVirtualizationConnectorServiceRequestValidator;
 import org.osc.core.broker.service.validator.DtoValidator;
-import org.osc.core.broker.service.vc.VirtualizationConnectorServiceData;
+import org.osc.core.broker.service.validator.VirtualizationConnectorDtoValidatorTestData;
 import org.osc.core.broker.util.StaticRegistry;
 import org.osc.core.broker.util.VirtualizationConnectorUtil;
 import org.powermock.api.mockito.PowerMockito;
@@ -46,7 +46,6 @@ import org.powermock.modules.junit4.PowerMockRunner;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ StaticRegistry.class})
 public class AddVirtualizationConnectorServiceRequestValidatorTest {
-
     @Mock
     private EntityManager em;
 
@@ -65,6 +64,9 @@ public class AddVirtualizationConnectorServiceRequestValidatorTest {
     @InjectMocks
     private AddVirtualizationConnectorServiceRequestValidator validator;
 
+    private DryRunRequest<VirtualizationConnectorRequest> request =
+            new DryRunRequest<VirtualizationConnectorRequest>((VirtualizationConnectorRequest)VirtualizationConnectorDtoValidatorTestData.generateOpenStackVCWithSDN());
+
     @Before
     public void testInitialize() throws EncryptionException {
         MockitoAnnotations.initMocks(this);
@@ -78,14 +80,14 @@ public class AddVirtualizationConnectorServiceRequestValidatorTest {
     @SuppressWarnings("unchecked")
     public void testValidate_WithValidOpenStackRequest_ReturnsSuccess() throws Exception {
         // Arrange.
-    	doNothing().when(this.dtoValidator).validateForCreate(VirtualizationConnectorServiceData.OPENSTACK_NSC_REQUEST.getDto());
-        doNothing().when(this.virtualizationConnectorUtil).checkOpenstackConnection(any(DryRunRequest.class), any(VirtualizationConnector.class));
+        doNothing().when(this.dtoValidator).validateForCreate(this.request.getDto());
+        doNothing().when(this.virtualizationConnectorUtil).checkConnection(any(DryRunRequest.class), any(VirtualizationConnector.class));
 
         // Act.
-        this.validator.validate(VirtualizationConnectorServiceData.OPENSTACK_NSC_REQUEST);
+        this.validator.validate(this.request);
 
         // Assert.
-        verify(this.dtoValidator).validateForCreate(VirtualizationConnectorServiceData.OPENSTACK_NSC_REQUEST.getDto());
+        verify(this.dtoValidator).validateForCreate(this.request.getDto());
     }
 
     @Test
@@ -101,13 +103,13 @@ public class AddVirtualizationConnectorServiceRequestValidatorTest {
     public void testValidate_WithInvalidOpenStackRequest_ThrowsValidationException() throws Exception {
         // Arrange.
         this.exception.expect(VmidcBrokerValidationException.class);
-        doThrow(VmidcBrokerValidationException.class).when(this.dtoValidator).validateForCreate(VirtualizationConnectorServiceData.OPENSTACK_NSC_REQUEST.getDto());
+        doThrow(VmidcBrokerValidationException.class).when(this.dtoValidator).validateForCreate(this.request.getDto());
 
         // Act.
-        this.validator.validate(VirtualizationConnectorServiceData.OPENSTACK_NSC_REQUEST);
+        this.validator.validate(this.request);
 
         // Assert.
-        verify(this.dtoValidator).validateForCreate(VirtualizationConnectorServiceData.OPENSTACK_NSC_REQUEST.getDto());
+        verify(this.dtoValidator).validateForCreate(this.request.getDto());
     }
 
     @Test
@@ -116,7 +118,7 @@ public class AddVirtualizationConnectorServiceRequestValidatorTest {
         this.exception.expect(UnsupportedOperationException.class);
 
         // Act.
-        this.validator.validateAndLoad(VirtualizationConnectorServiceData.OPENSTACK_NSC_REQUEST);
+        this.validator.validateAndLoad(this.request);
     }
 
 }

--- a/osc-server/src/test/java/org/osc/core/broker/service/validator/VirtualizationConnectorDtoValidatorBaseTest.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/validator/VirtualizationConnectorDtoValidatorBaseTest.java
@@ -16,7 +16,7 @@
  *******************************************************************************/
 package org.osc.core.broker.service.validator;
 
-import static org.osc.core.broker.service.vc.VirtualizationConnectorServiceData.*;
+import static org.osc.core.broker.service.validator.VirtualizationConnectorDtoValidatorTestData.*;
 
 import javax.persistence.EntityManager;
 
@@ -71,12 +71,11 @@ public class VirtualizationConnectorDtoValidatorBaseTest {
     }
 
     private void populateDatabase() {
-       this.em.getTransaction().begin();
+        this.em.getTransaction().begin();
 
-       this.em.persist(createVirtualisationConnector(OPENSTACK_NAME_ALREADY_EXISTS,
-               CONTROLLER_IP_ALREADY_EXISTS, PROVIDER_IP_ALREADY_EXISTS));
+        this.em.persist(createVirtualizationConnector(OPENSTACK_NAME_ALREADY_EXISTS,
+                CONTROLLER_IP_ALREADY_EXISTS, PROVIDER_IP_ALREADY_EXISTS));
 
-       this.em.getTransaction().commit();
-
+        this.em.getTransaction().commit();
     }
 }

--- a/osc-server/src/test/java/org/osc/core/broker/service/validator/VirtualizationConnectorDtoValidatorParameterizedTest.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/validator/VirtualizationConnectorDtoValidatorParameterizedTest.java
@@ -16,7 +16,7 @@
  *******************************************************************************/
 package org.osc.core.broker.service.validator;
 
-import static org.osc.core.broker.service.validator.DistributedApplianceDtoValidatorTestData.*;
+import static org.osc.core.broker.service.validator.DistributedApplianceDtoValidatorTestData.EMPTY_VALUE_ERROR_MESSAGE;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -30,7 +30,7 @@ import org.junit.runners.Parameterized.Parameters;
 import org.osc.core.broker.model.entities.virtualization.VirtualizationConnector;
 import org.osc.core.broker.service.dto.VirtualizationConnectorDto;
 import org.osc.core.broker.service.exceptions.VmidcBrokerInvalidEntryException;
-import org.osc.core.broker.service.vc.VirtualizationConnectorServiceData;
+import org.osc.core.broker.service.exceptions.VmidcBrokerValidationException;
 import org.osc.core.broker.util.ValidateUtil;
 import org.osc.core.server.Server;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -77,17 +77,17 @@ public class VirtualizationConnectorDtoValidatorParameterizedTest extends Virtua
         result.addAll(getInvalidMqPasswordTestData());
         result.addAll(getInvalidMqPortTestData());
         result.addAll(getInvalidIpAddresses());
-
+        result.addAll(getInvalidControllerTypeTestData());
         return result;
     }
 
     static List<Object[]> getInvalidIpAddresses() {
         String[] invalidIps = new String[] { "abc", "2.a.1.5", "2a.1", "8.8.8.8888", "127.0.0..1", "127.0.0.1.3" };
 
-		List<Object[]> result = new ArrayList<>();
+        List<Object[]> result = new ArrayList<>();
 
         for (String invalidIp : invalidIps) {
-            VirtualizationConnectorDto vcDto = VirtualizationConnectorServiceData.getVCDtoforOpenStack();
+            VirtualizationConnectorDto vcDto = VirtualizationConnectorDtoValidatorTestData.generateOpenStackVCWithoutSDN();
             vcDto.getProviderAttributes().put(VirtualizationConnector.ATTRIBUTE_KEY_RABBITMQ_IP, invalidIp);
             String errorMessage = Server.PRODUCT_NAME + ": " + "IP Address: '" + invalidIp + "' has invalid format.";
 
@@ -103,24 +103,24 @@ public class VirtualizationConnectorDtoValidatorParameterizedTest extends Virtua
         String[] invalidNames = new String[] { null, "",
                 StringUtils.rightPad("dtoName", ValidateUtil.DEFAULT_MAX_LEN + 10, 'e') };
 
-		List<Object[]> result = new ArrayList<>();
+        List<Object[]> result = new ArrayList<>();
 
         for (String invalidName : invalidNames) {
-            VirtualizationConnectorDto vcDto = VirtualizationConnectorServiceData.getVCDtoforOpenStack();
+            VirtualizationConnectorDto vcDto = VirtualizationConnectorDtoValidatorTestData.generateOpenStackVCWithoutSDN();
             vcDto.getProviderAttributes().put(VirtualizationConnector.ATTRIBUTE_KEY_RABBITMQ_PORT, invalidName);
 
-			String errorMessage;
-			if (invalidName == null || invalidName.equals("")) {
-				errorMessage = Server.PRODUCT_NAME + ": " + "Rabbit MQ Port " + EMPTY_VALUE_ERROR_MESSAGE;
-			} else if (!StringUtils.isNumeric(invalidName)) {
-				errorMessage = VirtualizationConnector.ATTRIBUTE_KEY_RABBITMQ_PORT
-						+ " expected to be an Integer. Value is: " + invalidName;
-			} else {
-				errorMessage = Server.PRODUCT_NAME + ": " + VirtualizationConnector.ATTRIBUTE_KEY_RABBITMQ_PORT
-						+ " length should not exceed " + ValidateUtil.DEFAULT_MAX_LEN
-						+ " characters. The provided field exceeds this limit by "
-						+ (invalidName.length() - ValidateUtil.DEFAULT_MAX_LEN) + " characters.";
-			}
+            String errorMessage;
+            if (invalidName == null || invalidName.equals("")) {
+                errorMessage = Server.PRODUCT_NAME + ": " + "Rabbit MQ Port " + EMPTY_VALUE_ERROR_MESSAGE;
+            } else if (!StringUtils.isNumeric(invalidName)) {
+                errorMessage = VirtualizationConnector.ATTRIBUTE_KEY_RABBITMQ_PORT
+                        + " expected to be an Integer. Value is: " + invalidName;
+            } else {
+                errorMessage = Server.PRODUCT_NAME + ": " + VirtualizationConnector.ATTRIBUTE_KEY_RABBITMQ_PORT
+                        + " length should not exceed " + ValidateUtil.DEFAULT_MAX_LEN
+                        + " characters. The provided field exceeds this limit by "
+                        + (invalidName.length() - ValidateUtil.DEFAULT_MAX_LEN) + " characters.";
+            }
 
             Class<?> expectedException = VmidcBrokerInvalidEntryException.class;
 
@@ -133,18 +133,18 @@ public class VirtualizationConnectorDtoValidatorParameterizedTest extends Virtua
     static List<Object[]> getInvalidMqPasswordTestData() {
         String[] invalidNames = new String[] { null, "" };
 
-		List<Object[]> result = new ArrayList<>();
+        List<Object[]> result = new ArrayList<>();
 
-		for (String invalidName : invalidNames) {
-			VirtualizationConnectorDto vcDto = VirtualizationConnectorServiceData.getVCDtoforOpenStack();
-			vcDto.getProviderAttributes().put(VirtualizationConnector.ATTRIBUTE_KEY_RABBITMQ_USER_PASSWORD,
-					invalidName);
-			String errorMessage = invalidName == null || invalidName.equals("")
-					? Server.PRODUCT_NAME + ": " + "Rabbit MQ Password " + EMPTY_VALUE_ERROR_MESSAGE
-					: Server.PRODUCT_NAME + ": " + VirtualizationConnector.ATTRIBUTE_KEY_RABBITMQ_USER_PASSWORD
-							+ " length should not exceed " + ValidateUtil.DEFAULT_MAX_LEN
-							+ " characters. The provided field exceeds this limit by "
-							+ (invalidName.length() - ValidateUtil.DEFAULT_MAX_LEN) + " characters.";
+        for (String invalidName : invalidNames) {
+            VirtualizationConnectorDto vcDto = VirtualizationConnectorDtoValidatorTestData.generateOpenStackVCWithoutSDN();
+            vcDto.getProviderAttributes().put(VirtualizationConnector.ATTRIBUTE_KEY_RABBITMQ_USER_PASSWORD,
+                    invalidName);
+            String errorMessage = invalidName == null || invalidName.equals("")
+                    ? Server.PRODUCT_NAME + ": " + "Rabbit MQ Password " + EMPTY_VALUE_ERROR_MESSAGE
+                            : Server.PRODUCT_NAME + ": " + VirtualizationConnector.ATTRIBUTE_KEY_RABBITMQ_USER_PASSWORD
+                            + " length should not exceed " + ValidateUtil.DEFAULT_MAX_LEN
+                            + " characters. The provided field exceeds this limit by "
+                            + (invalidName.length() - ValidateUtil.DEFAULT_MAX_LEN) + " characters.";
 
             Class<?> expectedException = VmidcBrokerInvalidEntryException.class;
 
@@ -157,17 +157,17 @@ public class VirtualizationConnectorDtoValidatorParameterizedTest extends Virtua
     static List<Object[]> getInvalidMqUserTestData() {
         String[] invalidNames = new String[] { null, "" };
 
-		List<Object[]> result = new ArrayList<>();
+        List<Object[]> result = new ArrayList<>();
 
-		for (String invalidName : invalidNames) {
-			VirtualizationConnectorDto vcDto = VirtualizationConnectorServiceData.getVCDtoforOpenStack();
-			vcDto.getProviderAttributes().put(VirtualizationConnector.ATTRIBUTE_KEY_RABBITMQ_USER, invalidName);
-			String errorMessage = invalidName == null || invalidName.equals("")
-					? Server.PRODUCT_NAME + ": " + "Rabbit MQ User " + EMPTY_VALUE_ERROR_MESSAGE
-					: Server.PRODUCT_NAME + ": " + VirtualizationConnector.ATTRIBUTE_KEY_RABBITMQ_USER
-							+ " length should not exceed " + ValidateUtil.DEFAULT_MAX_LEN
-							+ " characters. The provided field exceeds this limit by "
-							+ (invalidName.length() - ValidateUtil.DEFAULT_MAX_LEN) + " characters.";
+        for (String invalidName : invalidNames) {
+            VirtualizationConnectorDto vcDto = VirtualizationConnectorDtoValidatorTestData.generateOpenStackVCWithoutSDN();
+            vcDto.getProviderAttributes().put(VirtualizationConnector.ATTRIBUTE_KEY_RABBITMQ_USER, invalidName);
+            String errorMessage = invalidName == null || invalidName.equals("")
+                    ? Server.PRODUCT_NAME + ": " + "Rabbit MQ User " + EMPTY_VALUE_ERROR_MESSAGE
+                            : Server.PRODUCT_NAME + ": " + VirtualizationConnector.ATTRIBUTE_KEY_RABBITMQ_USER
+                            + " length should not exceed " + ValidateUtil.DEFAULT_MAX_LEN
+                            + " characters. The provided field exceeds this limit by "
+                            + (invalidName.length() - ValidateUtil.DEFAULT_MAX_LEN) + " characters.";
 
             Class<?> expectedException = VmidcBrokerInvalidEntryException.class;
 
@@ -181,16 +181,16 @@ public class VirtualizationConnectorDtoValidatorParameterizedTest extends Virtua
         String[] invalidNames = new String[] { null, "",
                 StringUtils.rightPad("dtoName", ValidateUtil.DEFAULT_MAX_LEN + 10, 'e') };
 
-		List<Object[]> result = new ArrayList<>();
+        List<Object[]> result = new ArrayList<>();
 
-		for (String invalidName : invalidNames) {
-			VirtualizationConnectorDto vcDto = VirtualizationConnectorServiceData.getVCDtoforOpenStack();
-			vcDto.setAdminProjectName(invalidName);
-			String errorMessage = invalidName == null || invalidName.equals("")
-					? Server.PRODUCT_NAME + ": " + "Admin Project Name " + EMPTY_VALUE_ERROR_MESSAGE
-					: Server.PRODUCT_NAME + ": " + "Admin Project Name" + " length should not exceed "
-							+ ValidateUtil.DEFAULT_MAX_LEN + " characters. The provided field exceeds this limit by "
-							+ (invalidName.length() - ValidateUtil.DEFAULT_MAX_LEN) + " characters.";
+        for (String invalidName : invalidNames) {
+            VirtualizationConnectorDto vcDto = VirtualizationConnectorDtoValidatorTestData.generateOpenStackVCWithoutSDN();
+            vcDto.setAdminProjectName(invalidName);
+            String errorMessage = invalidName == null || invalidName.equals("")
+                    ? Server.PRODUCT_NAME + ": " + "Admin Project Name " + EMPTY_VALUE_ERROR_MESSAGE
+                            : Server.PRODUCT_NAME + ": " + "Admin Project Name" + " length should not exceed "
+                            + ValidateUtil.DEFAULT_MAX_LEN + " characters. The provided field exceeds this limit by "
+                            + (invalidName.length() - ValidateUtil.DEFAULT_MAX_LEN) + " characters.";
 
             Class<?> expectedException = VmidcBrokerInvalidEntryException.class;
 
@@ -203,10 +203,10 @@ public class VirtualizationConnectorDtoValidatorParameterizedTest extends Virtua
     static List<Object[]> getInvalidSoftwareVersions() {
         String[] invalidVersions = new String[] { null, "" };
 
-		List<Object[]> result = new ArrayList<>();
+        List<Object[]> result = new ArrayList<>();
 
         for (String invalidVersion : invalidVersions) {
-            VirtualizationConnectorDto vcDto = VirtualizationConnectorServiceData.getVCDtoforOpenStack();
+            VirtualizationConnectorDto vcDto = VirtualizationConnectorDtoValidatorTestData.generateOpenStackVCWithoutSDN();
             vcDto.setSoftwareVersion(invalidVersion);
             String errorMessage = Server.PRODUCT_NAME + ": " + "Software Version " + EMPTY_VALUE_ERROR_MESSAGE;
 
@@ -221,10 +221,10 @@ public class VirtualizationConnectorDtoValidatorParameterizedTest extends Virtua
     static List<Object[]> getInvalidProviderIpTestData() {
         String[] invalidNames = new String[] { null, "" };
 
-		List<Object[]> result = new ArrayList<>();
+        List<Object[]> result = new ArrayList<>();
 
         for (String invalidName : invalidNames) {
-            VirtualizationConnectorDto vcDto = VirtualizationConnectorServiceData.getVCDtoforOpenStack();
+            VirtualizationConnectorDto vcDto = VirtualizationConnectorDtoValidatorTestData.generateOpenStackVCWithoutSDN();
             vcDto.setProviderIP(invalidName);
             String errorMessage = Server.PRODUCT_NAME + ": " + "Provider IP Address " + EMPTY_VALUE_ERROR_MESSAGE;
 
@@ -239,10 +239,10 @@ public class VirtualizationConnectorDtoValidatorParameterizedTest extends Virtua
     static List<Object[]> getInvalidControllerIpTestData() {
         String[] invalidNames = new String[] { null, "" };
 
-		List<Object[]> result = new ArrayList<>();
+        List<Object[]> result = new ArrayList<>();
 
         for (String invalidName : invalidNames) {
-            VirtualizationConnectorDto vcDto = VirtualizationConnectorServiceData.getVCDtoforOpenStackwithSDN();
+            VirtualizationConnectorDto vcDto = VirtualizationConnectorDtoValidatorTestData.generateOpenStackVCWithSDN();
             vcDto.setControllerIP(invalidName);
             String errorMessage = Server.PRODUCT_NAME + ": " + "Controller IP Address " + EMPTY_VALUE_ERROR_MESSAGE;
 
@@ -254,18 +254,26 @@ public class VirtualizationConnectorDtoValidatorParameterizedTest extends Virtua
         return result;
     }
 
+    static List<Object[]> getInvalidControllerTypeTestData() {
+        final String ERROR_MSG = "Virtualization connectors for Kubernetes must have a SDN controller.";
+        List<Object[]> result = new ArrayList<>();
+        result.add(new Object[] {VirtualizationConnectorDtoValidatorTestData.generateK8sVCWithoSDNNone(), VmidcBrokerValidationException.class, ERROR_MSG });
+
+        return result;
+    }
+
     static List<Object[]> getInvalidNameTestData() {
         String[] invalidNames = new String[] { null, "",
                 StringUtils.rightPad("dtoName", ValidateUtil.DEFAULT_MAX_LEN + 10, 'e') };
 
-		List<Object[]> result = new ArrayList<>();
+        List<Object[]> result = new ArrayList<>();
 
         for (String invalidName : invalidNames) {
-            VirtualizationConnectorDto vcDto = VirtualizationConnectorServiceData.getVCDtoforOpenStack();
+            VirtualizationConnectorDto vcDto = VirtualizationConnectorDtoValidatorTestData.generateOpenStackVCWithoutSDN();
             vcDto.setName(invalidName);
             String errorMessage = invalidName == null || invalidName == ""
                     ? Server.PRODUCT_NAME + ": " + "Name " + EMPTY_VALUE_ERROR_MESSAGE
-                    : Server.PRODUCT_NAME + ": " + "Name" + " length should not exceed " + ValidateUtil.DEFAULT_MAX_LEN
+                            : Server.PRODUCT_NAME + ": " + "Name" + " length should not exceed " + ValidateUtil.DEFAULT_MAX_LEN
                             + " characters. The provided field exceeds this limit by "
                             + (invalidName.length() - ValidateUtil.DEFAULT_MAX_LEN) + " characters.";
 
@@ -284,11 +292,11 @@ public class VirtualizationConnectorDtoValidatorParameterizedTest extends Virtua
         List<Object[]> result = new ArrayList<Object[]>();
 
         for (String invalidName : invalidNames) {
-            VirtualizationConnectorDto vcDto = VirtualizationConnectorServiceData.getVCDtoforOpenStackwithSDN();
+            VirtualizationConnectorDto vcDto = VirtualizationConnectorDtoValidatorTestData.generateOpenStackVCWithSDN();
             vcDto.setControllerPassword(invalidName);
             String errorMessage = invalidName == null || invalidName == ""
                     ? Server.PRODUCT_NAME + ": " + "Controller Password " + EMPTY_VALUE_ERROR_MESSAGE
-                    : Server.PRODUCT_NAME + ": " + "Controller Password" + " length should not exceed "
+                            : Server.PRODUCT_NAME + ": " + "Controller Password" + " length should not exceed "
                             + ValidateUtil.DEFAULT_MAX_LEN + " characters. The provided field exceeds this limit by "
                             + (invalidName.length() - ValidateUtil.DEFAULT_MAX_LEN) + " characters.";
 
@@ -307,11 +315,11 @@ public class VirtualizationConnectorDtoValidatorParameterizedTest extends Virtua
         List<Object[]> result = new ArrayList<Object[]>();
 
         for (String invalidName : invalidNames) {
-            VirtualizationConnectorDto vcDto = VirtualizationConnectorServiceData.getVCDtoforOpenStackwithSDN();
+            VirtualizationConnectorDto vcDto = VirtualizationConnectorDtoValidatorTestData.generateOpenStackVCWithSDN();
             vcDto.setProviderPassword(invalidName);
             String errorMessage = invalidName == null || invalidName == ""
                     ? Server.PRODUCT_NAME + ": " + "Provider Password " + EMPTY_VALUE_ERROR_MESSAGE
-                    : Server.PRODUCT_NAME + ": " + "Provider Password" + " length should not exceed "
+                            : Server.PRODUCT_NAME + ": " + "Provider Password" + " length should not exceed "
                             + ValidateUtil.DEFAULT_MAX_LEN + " characters. The provided field exceeds this limit by "
                             + (invalidName.length() - ValidateUtil.DEFAULT_MAX_LEN) + " characters.";
 
@@ -330,11 +338,11 @@ public class VirtualizationConnectorDtoValidatorParameterizedTest extends Virtua
         List<Object[]> result = new ArrayList<Object[]>();
 
         for (String invalidName : invalidNames) {
-            VirtualizationConnectorDto vcDto = VirtualizationConnectorServiceData.getVCDtoforOpenStackwithSDN();
+            VirtualizationConnectorDto vcDto = VirtualizationConnectorDtoValidatorTestData.generateOpenStackVCWithSDN();
             vcDto.setControllerUser(invalidName);
             String errorMessage = invalidName == null || invalidName == ""
                     ? Server.PRODUCT_NAME + ": " + "Controller User Name " + EMPTY_VALUE_ERROR_MESSAGE
-                    : Server.PRODUCT_NAME + ": " + "Controller User Name" + " length should not exceed "
+                            : Server.PRODUCT_NAME + ": " + "Controller User Name" + " length should not exceed "
                             + ValidateUtil.DEFAULT_MAX_LEN + " characters. The provided field exceeds this limit by "
                             + (invalidName.length() - ValidateUtil.DEFAULT_MAX_LEN) + " characters.";
 
@@ -353,11 +361,11 @@ public class VirtualizationConnectorDtoValidatorParameterizedTest extends Virtua
         List<Object[]> result = new ArrayList<Object[]>();
 
         for (String invalidName : invalidNames) {
-            VirtualizationConnectorDto vcDto = VirtualizationConnectorServiceData.getVCDtoforOpenStack();
+            VirtualizationConnectorDto vcDto = VirtualizationConnectorDtoValidatorTestData.generateOpenStackVCWithSDN();
             vcDto.setProviderUser(invalidName);
             String errorMessage = invalidName == null || invalidName == ""
                     ? Server.PRODUCT_NAME + ": " + "Provider User Name " + EMPTY_VALUE_ERROR_MESSAGE
-                    : Server.PRODUCT_NAME + ": " + "Provider User Name" + " length should not exceed "
+                            : Server.PRODUCT_NAME + ": " + "Provider User Name" + " length should not exceed "
                             + ValidateUtil.DEFAULT_MAX_LEN + " characters. The provided field exceeds this limit by "
                             + (invalidName.length() - ValidateUtil.DEFAULT_MAX_LEN) + " characters.";
 

--- a/osc-server/src/test/java/org/osc/core/broker/service/validator/VirtualizationConnectorDtoValidatorTest.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/validator/VirtualizationConnectorDtoValidatorTest.java
@@ -15,47 +15,40 @@
  * limitations under the License.
  *******************************************************************************/
 package org.osc.core.broker.service.validator;
-//TODO: Hailee
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.osc.core.broker.service.dto.VirtualizationConnectorDto;
 import org.osc.core.broker.service.exceptions.VmidcBrokerValidationException;
-import org.osc.core.broker.service.request.VirtualizationConnectorRequest;
-import org.osc.core.broker.service.vc.VirtualizationConnectorServiceData;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
 public class VirtualizationConnectorDtoValidatorTest extends VirtualizationConnectorDtoValidatorBaseTest{
-
     @Test
-    public void testValidate_WhenVcRequest_ReturnsSuccessful() throws Exception {
-        // Arrange.
-        VirtualizationConnectorRequest dto = VirtualizationConnectorServiceData.OPENSTACK_NOCONTROLLER_REQUEST.getDto();
-
+    public void testValidateForCreate_WhenVcRequest_ReturnsSuccessful() throws Exception {
         // Act.
-        this.dtoValidator.validateForCreate(dto);
+        this.dtoValidator.validateForCreate(VirtualizationConnectorDtoValidatorTestData.OPENSTACK_NOCONTROLLER_VC);
 
         //Assert
         Assert.assertTrue(true);
     }
 
     @Test
-    public void testValidate_WhenVcNameExistsRequest_ThrowsValidationException() throws Exception {
+    public void testValidateForCreate_WhenVcNameExistsRequest_ThrowsValidationException() throws Exception {
         // Arrange.
         this.exception.expect(VmidcBrokerValidationException.class);
-        this.exception.expectMessage("Virtualization Connector Name: " + VirtualizationConnectorServiceData.OPENSTACK_NAME_ALREADY_EXISTS_NOCONTROLLER_REQUEST.getDto().getName() + " already exists.");
-
-        VirtualizationConnectorRequest dto = VirtualizationConnectorServiceData.OPENSTACK_NAME_ALREADY_EXISTS_NOCONTROLLER_REQUEST.getDto();
+        VirtualizationConnectorDto dto = VirtualizationConnectorDtoValidatorTestData.OPENSTACK_NAME_ALREADY_EXISTS_NOCONTROLLER_VC;
+        this.exception.expectMessage("Virtualization Connector Name: " + dto.getName() + " already exists.");
 
         // Act.
         this.dtoValidator.validateForCreate(dto);
     }
 
     @Test
-    public void testValidate_WhenControllerIpExists_ThrowsValidationException() throws Exception {
+    public void testValidateForCreate_WhenControllerIpExists_ThrowsValidationException() throws Exception {
         // Arrange.
         this.exception.expect(VmidcBrokerValidationException.class);
-        VirtualizationConnectorRequest dto = VirtualizationConnectorServiceData.OPENSTACK_CONTROLLER_IP_ALREADY_EXISTS_REQUEST.getDto();
+        VirtualizationConnectorDto dto = VirtualizationConnectorDtoValidatorTestData.OPENSTACK_CONTROLLER_IP_ALREADY_EXISTS_VC;
         this.exception.expectMessage("Controller IP Address: " + dto.getControllerIP() + " already exists.");
 
         // Act.
@@ -63,14 +56,13 @@ public class VirtualizationConnectorDtoValidatorTest extends VirtualizationConne
     }
 
     @Test
-    public void testValidate_WhenProviderIpExists_ThrowsValidationException() throws Exception {
+    public void testValidateForCreate_WhenProviderIpExists_ThrowsValidationException() throws Exception {
         // Arrange.
         this.exception.expect(VmidcBrokerValidationException.class);
-        VirtualizationConnectorRequest dto = VirtualizationConnectorServiceData.PROVIDER_IP_ALREADY_EXISTS_OPENSTACK_REQUEST.getDto();
+        VirtualizationConnectorDto dto = VirtualizationConnectorDtoValidatorTestData.PROVIDER_IP_ALREADY_EXISTS_OPENSTACK_VC;
         this.exception.expectMessage("Provider IP Address: " + dto.getProviderIP() + " already exists.");
 
         // Act.
         this.dtoValidator.validateForCreate(dto);
     }
-
 }

--- a/osc-server/src/test/java/org/osc/core/broker/service/validator/VirtualizationConnectorDtoValidatorTestData.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/validator/VirtualizationConnectorDtoValidatorTestData.java
@@ -1,0 +1,140 @@
+/*******************************************************************************
+ * Copyright (c) Intel Corporation
+ * Copyright (c) 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.osc.core.broker.service.validator;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.osc.core.broker.model.entities.virtualization.VirtualizationConnector;
+import org.osc.core.broker.service.dto.VirtualizationConnectorDto;
+import org.osc.core.broker.service.request.VirtualizationConnectorRequest;
+import org.osc.core.common.virtualization.VirtualizationType;
+
+public class VirtualizationConnectorDtoValidatorTestData {
+    static String OPENSTACK_NAME_ALREADY_EXISTS = "Openstack Name";
+    static String PROVIDER_IP_ALREADY_EXISTS = "127.0.0.2";
+    static String CONTROLLER_IP_ALREADY_EXISTS = "127.0.0.1";
+
+    static VirtualizationConnectorDto OPENSTACK_NOCONTROLLER_VC = createOpenStackVCDto(
+            VirtualizationType.OPENSTACK, "Random Openstack name", null, null, null, null, "2.2.2.2", "provider user",
+            "provider Password", "4.3", "Project Demo", "default", "RabbitMq User", "RabbitMq Password", "1111");
+
+    static VirtualizationConnectorDto OPENSTACK_NAME_ALREADY_EXISTS_NOCONTROLLER_VC = createOpenStackVCDto(
+            VirtualizationType.OPENSTACK, OPENSTACK_NAME_ALREADY_EXISTS, null, null, null, null, "2.2.2.2", "provider user",
+            "provider Password", "4.3", "Project Demo", "default", "RabbitMq User", "RabbitMq Password", "1111");
+
+    static VirtualizationConnectorDto PROVIDER_IP_ALREADY_EXISTS_OPENSTACK_VC = createOpenStackVCDto(
+            VirtualizationType.OPENSTACK, "Random Openstack name", "NSC", "1.1.1.1", "SDNUserName", "SDNPwd", PROVIDER_IP_ALREADY_EXISTS,
+            "provider user", "provider Password", "4.3", "Project Demo", "default", "RabbitMq User", "RabbitMq Password", "1111");
+
+    static VirtualizationConnectorDto OPENSTACK_CONTROLLER_IP_ALREADY_EXISTS_VC = createOpenStackVCDto(
+            VirtualizationType.OPENSTACK, "Random Openstack name", "NSC", CONTROLLER_IP_ALREADY_EXISTS, "SDNUserName", "SDNPwd", "2.2.2.2", "provider user",
+            "provider Password", "4.3", "Project Demo", "default", "RabbitMq User", "RabbitMq Password", "1111");
+
+    static VirtualizationConnector createVirtualizationConnector(String name,
+            String controller, String provider) {
+        VirtualizationConnector vc = new VirtualizationConnector();
+        vc.setName(name);
+        vc.setControllerIpAddress(controller);
+        vc.setProviderIpAddress(provider);
+        vc.setVirtualizationSoftwareVersion("vcSoftwareVersion");
+        vc.setProviderUsername("Natasha");
+        vc.setProviderPassword("********");
+        vc.setVirtualizationType(VirtualizationType.OPENSTACK);
+        return vc;
+    }
+
+    static VirtualizationConnectorDto generateOpenStackVCWithoutSDN(){
+        return createOpenStackVCDto(VirtualizationType.OPENSTACK, "Random Openstack name", null, null, null, null, "2.2.2.2", "provider user",
+                "provider Password", "4.3", "Project Demo", "default", "RabbitMq User", "RabbitMq Password", "1111");
+    }
+
+    static VirtualizationConnectorDto generateK8skVCWithoutSDN(){
+        return createOpenStackVCDto(VirtualizationType.KUBERNETES, "Random Openstack name", null, null, null, null, "2.2.2.2", "provider user",
+                "provider Password", "4.3", "Project Demo", "default", "RabbitMq User", "RabbitMq Password", "1111");
+    }
+
+    static VirtualizationConnectorDto generateK8sVCWithoSDNNone(){
+        return createOpenStackVCDto(VirtualizationType.KUBERNETES, "Random Openstack name", "NONE", null, null, null, "2.2.2.2", "provider user",
+                "provider Password", "4.3", "Project Demo", "default", "RabbitMq User", "RabbitMq Password", "1111");
+    }
+
+    public static VirtualizationConnectorDto generateOpenStackVCWithSDN(){
+        return createOpenStackVCDto(VirtualizationType.OPENSTACK, "Random Openstack name", "NSC", "1.1.1.1", "controller user", "controller password", "2.2.2.2", "provider user",
+                "provider Password", "4.3", "Project Demo", "default", "RabbitMq User", "RabbitMq Password", "1111");
+    }
+
+    private static VirtualizationConnectorDto createOpenStackVCDto(
+            VirtualizationType virtualizationType,
+            String name,
+            String controllerType,
+            String controllerIp,
+            String controllerUser,
+            String controllerPassword,
+            String providerIp,
+            String providerUser,
+            String providerPassword,
+            String version,
+            String projectName,
+            String domainId,
+            String rabbitMqUser,
+            String rabbitMqPassword,
+            String rabbitMqPort
+            ) {
+
+        VirtualizationConnectorDto dto = createVCDto(virtualizationType, name, controllerType, controllerIp,
+                controllerUser, controllerPassword, providerIp, providerUser, providerPassword, version);
+
+
+        dto.setAdminDomainId(domainId);
+        dto.setAdminProjectName(projectName);
+
+        Map<String, String> providerAttributes = new HashMap<>();
+        providerAttributes.put(VirtualizationConnector.ATTRIBUTE_KEY_RABBITMQ_USER, rabbitMqUser);
+        providerAttributes.put(VirtualizationConnector.ATTRIBUTE_KEY_RABBITMQ_USER_PASSWORD, rabbitMqPassword);
+        providerAttributes.put(VirtualizationConnector.ATTRIBUTE_KEY_RABBITMQ_PORT, rabbitMqPort);
+        dto.setProviderAttributes(providerAttributes);
+
+        return dto;
+    }
+
+    private static VirtualizationConnectorDto createVCDto(VirtualizationType virtualizationType,
+            String name,
+            String controllerType,
+            String controllerIp,
+            String controllerUser,
+            String controllerPassword,
+            String providerIp,
+            String providerUser,
+            String providerPassword,
+            String version){
+
+        VirtualizationConnectorDto dto = new VirtualizationConnectorRequest();
+        dto.setType(virtualizationType);
+        dto.setName(name);
+        dto.setControllerType(controllerType);
+        dto.setControllerIP(controllerIp);
+        dto.setControllerUser(controllerUser);
+        dto.setControllerPassword(controllerPassword);
+        dto.setProviderIP(providerIp);
+        dto.setProviderUser(providerUser);
+        dto.setProviderPassword(providerPassword);
+        dto.setSoftwareVersion(version);
+
+        return dto;
+    }
+}

--- a/osc-server/src/test/java/org/osc/core/broker/service/vc/AddVirtualizationConnectorServiceTest.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/vc/AddVirtualizationConnectorServiceTest.java
@@ -65,7 +65,6 @@ import org.powermock.modules.junit4.PowerMockRunner;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({X509TrustManagerFactory.class, LockUtil.class })
 public class AddVirtualizationConnectorServiceTest {
-
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
@@ -133,9 +132,9 @@ public class AddVirtualizationConnectorServiceTest {
     }
 
     private void populateDatabase() {
-       this.em.getTransaction().begin();
+        this.em.getTransaction().begin();
 
-       this.em.getTransaction().commit();
+        this.em.getTransaction().commit();
     }
 
     @Test
@@ -162,14 +161,14 @@ public class AddVirtualizationConnectorServiceTest {
         // Arrange.
         this.exception.expect(VmidcBrokerValidationException.class);
         doThrow(new VmidcBrokerValidationException(NAME_ALREADY_EXISTS)).when(this.validatorMock)
-                .validate(VirtualizationConnectorServiceData.OPENSTACK_NAME_ALREADY_EXISTS_NSC_REQUEST);
+        .validate(VirtualizationConnectorServiceData.OPENSTACK_NAME_ALREADY_EXISTS_NSC_REQUEST);
 
         // Act.
         this.service.dispatch(VirtualizationConnectorServiceData.OPENSTACK_NAME_ALREADY_EXISTS_NSC_REQUEST);
 
         // Assert.
         verify(this.validatorMock)
-                .validate(VirtualizationConnectorServiceData.OPENSTACK_NAME_ALREADY_EXISTS_NSC_REQUEST);
+        .validate(VirtualizationConnectorServiceData.OPENSTACK_NAME_ALREADY_EXISTS_NSC_REQUEST);
     }
 
     @Test
@@ -182,14 +181,14 @@ public class AddVirtualizationConnectorServiceTest {
         OPENSTACK_NAME_ALREADY_EXISTS_NSC_REQUEST.getDto().setForceAddSSLCertificates(true);
 
         doThrow(new SslCertificatesExtendedException(exception, new ArrayList<CertificateResolverModel>())).when(this.validatorMock)
-                .validate(VirtualizationConnectorServiceData.OPENSTACK_NAME_ALREADY_EXISTS_NSC_REQUEST);
+        .validate(VirtualizationConnectorServiceData.OPENSTACK_NAME_ALREADY_EXISTS_NSC_REQUEST);
 
         // Act.
         this.service.dispatch(VirtualizationConnectorServiceData.OPENSTACK_NAME_ALREADY_EXISTS_NSC_REQUEST);
 
         // Assert.
         verify(this.validatorMock)
-                .validate(VirtualizationConnectorServiceData.OPENSTACK_NAME_ALREADY_EXISTS_NSC_REQUEST);
+        .validate(VirtualizationConnectorServiceData.OPENSTACK_NAME_ALREADY_EXISTS_NSC_REQUEST);
 
         // clean up
         OPENSTACK_NAME_ALREADY_EXISTS_NSC_REQUEST.getDto().setForceAddSSLCertificates(false);
@@ -204,14 +203,14 @@ public class AddVirtualizationConnectorServiceTest {
         OPENSTACK_NAME_ALREADY_EXISTS_NSC_REQUEST.getDto().setForceAddSSLCertificates(true);
 
         doThrow(new SslCertificatesExtendedException(exception, new ArrayList<>())).doNothing().when(this.validatorMock)
-                .validate(OPENSTACK_NAME_ALREADY_EXISTS_NSC_REQUEST);
+        .validate(OPENSTACK_NAME_ALREADY_EXISTS_NSC_REQUEST);
 
         // Act.
         BaseJobResponse response = this.service.dispatch(OPENSTACK_NAME_ALREADY_EXISTS_NSC_REQUEST);
 
         // Assert.
         verify(this.validatorMock, times(2))
-                .validate(OPENSTACK_NAME_ALREADY_EXISTS_NSC_REQUEST);
+        .validate(OPENSTACK_NAME_ALREADY_EXISTS_NSC_REQUEST);
         VirtualizationConnector vc = this.em.createQuery("Select vc from VirtualizationConnector vc where vc.name = '" + OPENSTACK_NAME_ALREADY_EXISTS_NSC_REQUEST.getDto().getName() + "'", VirtualizationConnector.class)
                 .getSingleResult();
         validateResponse(response, vc.getId());

--- a/osc-server/src/test/java/org/osc/core/broker/service/vc/VirtualizationConnectorServiceData.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/vc/VirtualizationConnectorServiceData.java
@@ -26,48 +26,14 @@ import org.osc.core.broker.service.request.VirtualizationConnectorRequest;
 import org.osc.core.common.virtualization.VirtualizationType;
 
 public class VirtualizationConnectorServiceData {
+    static String OPENSTACK_NAME_ALREADY_EXISTS = "Openstack Name";
 
-    public static String OPENSTACK_NAME_ALREADY_EXISTS = "Openstack Name";
-    public static String CONTROLLER_IP_ALREADY_EXISTS = "127.0.0.1";
-    public static String PROVIDER_IP_ALREADY_EXISTS = "127.0.0.2";
-    public static String CONTROLLER_IP_ALREADY_EXISTS_2 = "127.0.0.3";
-    public static String PROVIDER_IP_ALREADY_EXISTS_2 = "127.0.0.4";
-
-    public static VirtualizationConnector createVirtualisationConnector(String name,
-            String controller, String provider) {
-        VirtualizationConnector vc = new VirtualizationConnector();
-        vc.setName(name);
-        vc.setControllerIpAddress(controller);
-        vc.setProviderIpAddress(provider);
-        vc.setVirtualizationSoftwareVersion("vcSoftwareVersion");
-        vc.setProviderUsername("Natasha");
-        vc.setProviderPassword("********");
-        vc.setVirtualizationType(VirtualizationType.OPENSTACK);
-        return vc;
-    }
-
-    public static DryRunRequest<VirtualizationConnectorRequest> OPENSTACK_NAME_ALREADY_EXISTS_NOCONTROLLER_REQUEST = createOpenStackRequest(
-            VirtualizationType.OPENSTACK, OPENSTACK_NAME_ALREADY_EXISTS, null, null, null, "2.2.2.2", "provider user",
-            "provider Password", "4.3", "Project Demo", "default", "RabbitMq User", "RabbitMq Password", "1111", null);
-
-    public static DryRunRequest<VirtualizationConnectorRequest> OPENSTACK_NAME_ALREADY_EXISTS_NSC_REQUEST = createOpenStackRequest(
+    static DryRunRequest<VirtualizationConnectorRequest> OPENSTACK_NAME_ALREADY_EXISTS_NSC_REQUEST = createOpenStackRequest(
             VirtualizationType.OPENSTACK, OPENSTACK_NAME_ALREADY_EXISTS, null, null, null, "2.2.2.2", "provider user",
             "provider Password", "4.3", "Project Demo", "default", "RabbitMq User", "RabbitMq Password", "1111", "NSC");
 
-    public static DryRunRequest<VirtualizationConnectorRequest> PROVIDER_IP_ALREADY_EXISTS_OPENSTACK_REQUEST = createOpenStackRequest(
-            VirtualizationType.OPENSTACK, "Random Openstack name", "1.1.1.1", "SDNUserName", "SDNPwd", PROVIDER_IP_ALREADY_EXISTS,
-            "provider user", "provider Password", "4.3", "Project Demo", "default", "RabbitMq User", "RabbitMq Password", "1111",
-            "NSC");
 
-    public static DryRunRequest<VirtualizationConnectorRequest> OPENSTACK_NSC_REQUEST = createOpenStackRequest(
-            VirtualizationType.OPENSTACK, "Random Openstack name", null, null, null, "2.2.2.2", "provider user",
-            "provider Password", "4.3", "Project Demo", "default", "RabbitMq User", "RabbitMq Password", "1111", "NSC");
-
-    public static DryRunRequest<VirtualizationConnectorRequest> OPENSTACK_CONTROLLER_IP_ALREADY_EXISTS_REQUEST = createOpenStackRequest(
-            VirtualizationType.OPENSTACK, "Random Openstack name", CONTROLLER_IP_ALREADY_EXISTS, "SDNUserName", "SDNPwd", "2.2.2.2", "provider user",
-            "provider Password", "4.3", "Project Demo", "default", "RabbitMq User", "RabbitMq Password", "1111", "NSC");
-
-    public static DryRunRequest<VirtualizationConnectorRequest> OPENSTACK_NOCONTROLLER_REQUEST = createOpenStackRequest(
+    static DryRunRequest<VirtualizationConnectorRequest> OPENSTACK_NOCONTROLLER_REQUEST = createOpenStackRequest(
             VirtualizationType.OPENSTACK, "Random Openstack name", null, null, null, "2.2.2.2", "provider user",
             "provider Password", "4.3", "Project Demo", "default", "RabbitMq User", "RabbitMq Password", "1111", null);
 
@@ -112,24 +78,6 @@ public class VirtualizationConnectorServiceData {
         dto.setSoftwareVersion(version);
 
         return dto;
-    }
-
-    public static VirtualizationConnectorDto getVCDtoforOpenStack(){
-
-        VirtualizationConnectorDto vcDto = getVCDto(VirtualizationType.OPENSTACK, "Random Openstack name", null, null, null, "2.2.2.2", "provider user",
-                "provider Password", "4.3");
-        setOpenStackParams(vcDto, "Project Demo", "default", "RabbitMq User", "RabbitMq Password", "1111", null);
-
-        return vcDto;
-    }
-
-    public static VirtualizationConnectorDto getVCDtoforOpenStackwithSDN(){
-
-        VirtualizationConnectorDto vcDto = getVCDto(VirtualizationType.OPENSTACK, "Random Openstack name", "1.1.1.1", "controller user", "controller password", "2.2.2.2", "provider user",
-                "provider Password", "4.3");
-        setOpenStackParams(vcDto, "Project Demo", "default", "RabbitMq User", "RabbitMq Password", "1111", "NSC");
-
-        return vcDto;
     }
 
     private static void setOpenStackParams(VirtualizationConnectorDto vcDto,
@@ -178,13 +126,4 @@ public class VirtualizationConnectorServiceData {
 
         return request;
     }
-
-    public static DryRunRequest<VirtualizationConnectorDto> getOpenStackRequestwithSDN() {
-
-        DryRunRequest<VirtualizationConnectorDto> request = new DryRunRequest<>();
-        request.setDto(getVCDtoforOpenStackwithSDN());
-
-        return request;
-    }
-
 }

--- a/osc-server/src/test/java/org/osc/core/broker/util/VirtualizationConnectorUtilTestData.java
+++ b/osc-server/src/test/java/org/osc/core/broker/util/VirtualizationConnectorUtilTestData.java
@@ -1,0 +1,129 @@
+/*******************************************************************************
+ * Copyright (c) Intel Corporation
+ * Copyright (c) 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.osc.core.broker.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.osc.core.broker.model.entities.virtualization.VirtualizationConnector;
+import org.osc.core.broker.service.dto.VirtualizationConnectorDto;
+import org.osc.core.broker.service.request.DryRunRequest;
+import org.osc.core.broker.service.request.VirtualizationConnectorRequest;
+import org.osc.core.common.virtualization.VirtualizationType;
+
+class VirtualizationConnectorUtilTestData {
+    static DryRunRequest<VirtualizationConnectorRequest> generateOpenStackVCWithSDN() {
+        return createOpenStackRequest(
+                VirtualizationType.OPENSTACK, UUID.randomUUID().toString(), "NSC", null, null, null, "2.2.2.2", "provider user",
+                "provider Password", "4.3", "Project Demo", "default", "RabbitMq User", "RabbitMq Password", "1111");
+    }
+
+    static DryRunRequest<VirtualizationConnectorRequest> generateK8sVCWithSDN() {
+        return createOpenStackRequest(
+                VirtualizationType.KUBERNETES, UUID.randomUUID().toString(), "NSC", null, null, null, "2.2.2.2", "provider user",
+                "provider Password", "4.3", "Project Demo", "default", "RabbitMq User", "RabbitMq Password", "1111");
+    }
+
+    private static DryRunRequest<VirtualizationConnectorRequest> createOpenStackRequest(
+            VirtualizationType virtualizationType,
+            String name,
+            String controllerType,
+            String controllerIp,
+            String controllerUser,
+            String controllerPassword,
+            String providerIp,
+            String providerUser,
+            String providerPassword,
+            String version,
+            String projectName,
+            String domainId,
+            String rabbitMqUser,
+            String rabbitMqPassword,
+            String rabbitMqPort
+            ) {
+        DryRunRequest<VirtualizationConnectorRequest> request = createRequest(virtualizationType, name, controllerType, controllerIp,
+                controllerUser, controllerPassword, providerIp, providerUser, providerPassword, version);
+        VirtualizationConnectorDto dto = request.getDto();
+
+        dto.setAdminDomainId(domainId);
+        dto.setAdminProjectName(projectName);
+
+        Map<String, String> providerAttributes = new HashMap<>();
+        providerAttributes.put(VirtualizationConnector.ATTRIBUTE_KEY_RABBITMQ_USER, rabbitMqUser);
+        providerAttributes.put(VirtualizationConnector.ATTRIBUTE_KEY_RABBITMQ_USER_PASSWORD, rabbitMqPassword);
+        providerAttributes.put(VirtualizationConnector.ATTRIBUTE_KEY_RABBITMQ_PORT, rabbitMqPort);
+        dto.setProviderAttributes(providerAttributes);
+
+        return request;
+    }
+
+    private static DryRunRequest<VirtualizationConnectorRequest> createRequest(
+            VirtualizationType virtualizationType,
+            String name,
+            String controllerType,
+            String controllerIp,
+            String controllerUser,
+            String controllerPassword,
+            String providerIp,
+            String providerUser,
+            String providerPassword,
+            String version) {
+
+        DryRunRequest<VirtualizationConnectorRequest> request = new DryRunRequest<>();
+
+        request.setDto(createVCRequest(
+                virtualizationType,
+                name,
+                controllerType,
+                controllerIp,
+                controllerUser,
+                controllerPassword,
+                providerIp,
+                providerUser,
+                providerPassword,
+                version));
+
+        return request;
+    }
+
+    private static VirtualizationConnectorRequest createVCRequest(VirtualizationType virtualizationType,
+            String name,
+            String controllerType,
+            String controllerIp,
+            String controllerUser,
+            String controllerPassword,
+            String providerIp,
+            String providerUser,
+            String providerPassword,
+            String version){
+
+        VirtualizationConnectorRequest request = new VirtualizationConnectorRequest();
+        request.setType(virtualizationType);
+        request.setName(name);
+        request.setControllerType(controllerType);
+        request.setControllerIP(controllerIp);
+        request.setControllerUser(controllerUser);
+        request.setControllerPassword(controllerPassword);
+        request.setProviderIP(providerIp);
+        request.setProviderUser(providerUser);
+        request.setProviderPassword(providerPassword);
+        request.setSoftwareVersion(version);
+
+        return request;
+    }
+}

--- a/osc-ui/src/main/java/org/osc/core/broker/view/vc/BaseVCWindow.java
+++ b/osc-ui/src/main/java/org/osc/core/broker/view/vc/BaseVCWindow.java
@@ -68,7 +68,9 @@ public abstract class BaseVCWindow extends CRUDBaseWindow<OkCancelButtonModel> {
     public static final String ATTRIBUTE_KEY_RABBITMQ_USER_PASSWORD = "rabbitMQPassword";
     public static final String ATTRIBUTE_KEY_RABBITMQ_PORT = "rabbitMQPort";
 
-    public static final String OPENSTACK_ICEHOUSE = "Icehouse";
+    private static final String OPENSTACK_ICEHOUSE = "Icehouse";
+    private static final String KUBERNETES_1_6 = "v1.6";
+
 
     /**
      *
@@ -130,7 +132,7 @@ public abstract class BaseVCWindow extends CRUDBaseWindow<OkCancelButtonModel> {
     private final EncryptionApi encrypter;
 
     public BaseVCWindow(PluginService pluginService, ValidationApi validator,
-                        X509TrustManagerApi trustManager, EncryptionApi encrypter) {
+            X509TrustManagerApi trustManager, EncryptionApi encrypter) {
         super();
         this.pluginService = pluginService;
         this.validator = validator;
@@ -178,7 +180,10 @@ public abstract class BaseVCWindow extends CRUDBaseWindow<OkCancelButtonModel> {
         this.virtualizationType = new ComboBox("Type");
         this.virtualizationType.setTextInputAllowed(false);
         this.virtualizationType.setNullSelectionAllowed(false);
-        this.virtualizationType.addItem(VirtualizationType.OPENSTACK.toString());
+        for (VirtualizationType virtualizationType : VirtualizationType.values()) {
+            this.virtualizationType.addItem(virtualizationType.toString());
+        }
+
         this.virtualizationType.select(VirtualizationType.OPENSTACK.toString());
 
         // adding not null constraint
@@ -303,7 +308,7 @@ public abstract class BaseVCWindow extends CRUDBaseWindow<OkCancelButtonModel> {
             }
         });
         this.controllerType.select(VirtualizationConnectorDto.CONTROLLER_TYPE_NONE
-);
+                );
 
         return this.controllerPanel;
     }
@@ -404,8 +409,8 @@ public abstract class BaseVCWindow extends CRUDBaseWindow<OkCancelButtonModel> {
                         BaseVCWindow.this.sslCertificateAttrs.addAll(
                                 certificateResolverModels.stream().map(
                                         crm -> new SslCertificateAttrDto(crm.getAlias(), crm.getSha1())).collect(Collectors.toList()
-                                )
-                        );
+                                                )
+                                );
                     }
                 }
 
@@ -459,9 +464,13 @@ public abstract class BaseVCWindow extends CRUDBaseWindow<OkCancelButtonModel> {
         // TODO: Future. Get virtualization version this from user.
         if (this.virtualizationType.getValue().equals(VirtualizationType.OPENSTACK.toString())) {
             request.getDto().setSoftwareVersion(OPENSTACK_ICEHOUSE);
-            request.getDto()
-                    .setControllerType((String) BaseVCWindow.this.controllerType.getValue());
+
+        } else {
+            request.getDto().setSoftwareVersion(KUBERNETES_1_6);
         }
+
+        request.getDto()
+        .setControllerType((String) BaseVCWindow.this.controllerType.getValue());
         return request;
     }
 


### PR DESCRIPTION
1. Adding KUBERNETES VC type
2.  Replacing `virtualizationConnectorUtil.checkOpenstackConnection` with `checkConnection` . `checkConnection` uses `checkOpenstackConnection` and the **newly** added checkK8sConnection. Both of them use the same `checkSDNControllerConnection`. 
3. Avoiding sharing test data across different test classes and packages
Previously it seems that the `AddVCService` was refactored into smaller classes: validators and check connection util but their test data was still referencing a single test data file. This made all these tests a lot harder to update, read and maintain: i.e.: when the data is changed one needs to know which tests are using it and update them as well. This change isolates each test class with their own test data keeping them package private. This is consistent with the approach adopted for other test classes within the code base as well: class file, test class file, test data file. 
3. Additional unit tests:
* Enforcing that K8s VC must have an SDN defined
* Unit tests to ensure K8s connectivity is checked during VC validation
5. Small UI changes to allow K8s VC to be added