### PR TITLE
Adding POST for ASV and all the db entity changes for container VNF deployment

### DIFF
--- a/osc-domain/src/main/java/org/osc/core/broker/model/entities/appliance/ApplianceSoftwareVersion.java
+++ b/osc-domain/src/main/java/org/osc/core/broker/model/entities/appliance/ApplianceSoftwareVersion.java
@@ -65,6 +65,9 @@ public class ApplianceSoftwareVersion extends BaseEntity {
     @Column(name = "image_url", nullable = false)
     private String imageUrl;
 
+    @Column(name = "image_pull_secret_name")
+    private String imagePullSecretName;
+
     @Column(name = "minimum_cpus")
     private Integer minCpus;
 
@@ -186,27 +189,27 @@ public class ApplianceSoftwareVersion extends BaseEntity {
         this.imageUrl = imageUrl;
     }
 
-    public int getMinCpus() {
+    public Integer getMinCpus() {
         return this.minCpus;
     }
 
-    public void setMinCpus(int minCpus) {
+    public void setMinCpus(Integer minCpus) {
         this.minCpus = minCpus;
     }
 
-    public int getMemoryInMb() {
+    public Integer getMemoryInMb() {
         return this.memoryInMb;
     }
 
-    public void setMemoryInMb(int memoryInMb) {
+    public void setMemoryInMb(Integer memoryInMb) {
         this.memoryInMb = memoryInMb;
     }
 
-    public int getDiskSizeInGb() {
+    public Integer getDiskSizeInGb() {
         return this.diskSizeInGb;
     }
 
-    public void setDiskSizeInGb(int diskSizeInGb) {
+    public void setDiskSizeInGb(Integer diskSizeInGb) {
         this.diskSizeInGb = diskSizeInGb;
     }
 
@@ -216,6 +219,14 @@ public class ApplianceSoftwareVersion extends BaseEntity {
 
     public void setAdditionalNicForInspection(boolean additionalNicForInspection) {
         this.additionalNicForInspection = additionalNicForInspection;
+    }
+
+    public void setImagePullSecretName(String imagePullSecretName) {
+        this.imagePullSecretName = imagePullSecretName;
+    }
+
+    public String getImagePullSecretName() {
+        return this.imagePullSecretName;
     }
 
     public List<TagEncapsulationType> getEncapsulationTypes() {

--- a/osc-domain/src/main/java/org/osc/core/broker/model/entities/appliance/DistributedApplianceInstance.java
+++ b/osc-domain/src/main/java/org/osc/core/broker/model/entities/appliance/DistributedApplianceInstance.java
@@ -167,6 +167,30 @@ public class DistributedApplianceInstance extends BaseEntity {
         this.ipAddress = ipAddress;
     }
 
+    public String getExternalId() {
+        return this.externalId;
+    }
+
+    public void setExternalId(String externalId) {
+        this.externalId = externalId;
+    }
+
+    public String getInspectionElementId() {
+        return this.inspectionElementId;
+    }
+
+    public void setInspectionElementId(String inspectionElementId) {
+        this.inspectionElementId = inspectionElementId;
+    }
+
+    public String getInspectionElementParentId() {
+        return this.inspectionElementParentId;
+    }
+
+    public void setInspectionElementParentId(String inspectionElementParentId) {
+        this.inspectionElementParentId = inspectionElementParentId;
+    }
+
     public Date getLastStatus() {
         return this.lastStatus;
     }

--- a/osc-domain/src/main/java/org/osc/core/broker/model/entities/appliance/DistributedApplianceInstance.java
+++ b/osc-domain/src/main/java/org/osc/core/broker/model/entities/appliance/DistributedApplianceInstance.java
@@ -48,12 +48,12 @@ public class DistributedApplianceInstance extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "virtual_system_fk", nullable = false,
-            foreignKey = @ForeignKey(name = "FK_DAI_VIRTUAL_SYSTEM"))
+    foreignKey = @ForeignKey(name = "FK_DAI_VIRTUAL_SYSTEM"))
     private VirtualSystem virtualSystem;
 
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "deployment_spec_fk", nullable = true,
-            foreignKey = @ForeignKey(name = "FK_DAI_DEPLOYMENT_SPEC"))
+    foreignKey = @ForeignKey(name = "FK_DAI_DEPLOYMENT_SPEC"))
     private DeploymentSpec deploymentSpec;
 
     @Column(name = "ip_address")
@@ -81,6 +81,13 @@ public class DistributedApplianceInstance extends BaseEntity {
     private String osAvailabilityZone;
     @Column(name = "os_server_id")
     private String osServerId;
+
+    @Column(name = "external_id")
+    private String externalId;
+    @Column(name = "inspection_element_id")
+    private String inspectionElementId;
+    @Column(name = "inspection_element_parent_id")
+    private String inspectionElementParentId;
 
     @Column(name = "inspection_os_ingress_port_id")
     private String inspectionOsIngressPortId;

--- a/osc-domain/src/main/java/org/osc/core/broker/model/entities/virtualization/openstack/DeploymentSpec.java
+++ b/osc-domain/src/main/java/org/osc/core/broker/model/entities/virtualization/openstack/DeploymentSpec.java
@@ -179,6 +179,14 @@ public class DeploymentSpec extends BaseEntity implements LastJobContainer {
         this.projectName = projectName;
     }
 
+    public String getNamespace() {
+        return this.namespace;
+    }
+
+    public void setNamespace(String namespace) {
+        this.namespace = namespace;
+    }
+
     public String getManagementNetworkName() {
         return this.managementNetworkName;
     }

--- a/osc-domain/src/main/java/org/osc/core/broker/model/entities/virtualization/openstack/DeploymentSpec.java
+++ b/osc-domain/src/main/java/org/osc/core/broker/model/entities/virtualization/openstack/DeploymentSpec.java
@@ -39,7 +39,7 @@ import org.osc.core.broker.model.entities.job.LastJobContainer;
 
 @Entity
 @Table(name = "DEPLOYMENT_SPEC", uniqueConstraints = { @UniqueConstraint(columnNames = { "vs_fk", "project_id",
-        "region" }) })
+"region" }) })
 public class DeploymentSpec extends BaseEntity implements LastJobContainer {
 
     private static final long serialVersionUID = 1L;
@@ -47,25 +47,31 @@ public class DeploymentSpec extends BaseEntity implements LastJobContainer {
     @Column(name = "name", nullable = false)
     private String name;
 
-    @Column(name = "region", nullable = false)
+    @Column(name = "region")
     private String region;
 
-    @Column(name = "project_name", nullable = false)
+    @Column(name = "project_name")
     private String projectName;
 
-    @Column(name = "project_id", nullable = false)
+    @Column(name = "project_id")
     private String projectId;
 
-    @Column(name = "management_network_name", nullable = false)
+    @Column(name = "namespace")
+    private String namespace;
+
+    @Column(name = "external_id")
+    private String externalId;
+
+    @Column(name = "management_network_name")
     private String managementNetworkName;
 
-    @Column(name = "management_network_id", nullable = false)
+    @Column(name = "management_network_id")
     private String managementNetworkId;
 
-    @Column(name = "inspection_network_name", nullable = false)
+    @Column(name = "inspection_network_name")
     private String inspectionNetworkName;
 
-    @Column(name = "inspection_network_id", nullable = false)
+    @Column(name = "inspection_network_id")
     private String inspectionNetworkId;
 
     @Column(name = "floating_pool_name")
@@ -83,7 +89,7 @@ public class DeploymentSpec extends BaseEntity implements LastJobContainer {
 
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "vs_fk", nullable = false,
-            foreignKey = @ForeignKey(name = "FK_DEPLOYMENT_SPEC_VS"))
+    foreignKey = @ForeignKey(name = "FK_DEPLOYMENT_SPEC_VS"))
     private VirtualSystem virtualSystem;
 
     @OneToMany(mappedBy = "deploymentSpec", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
@@ -100,7 +106,7 @@ public class DeploymentSpec extends BaseEntity implements LastJobContainer {
 
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "os_sg_reference_fk", nullable = true,
-            foreignKey = @ForeignKey(name = "FK_DS_OS_SG_REFERENCE"))
+    foreignKey = @ForeignKey(name = "FK_DS_OS_SG_REFERENCE"))
     private OsSecurityGroupReference osSecurityGroupReference;
 
     public DeploymentSpec(VirtualSystem virtualSystem, String region, String projectId, String managementNetworkId,

--- a/osc-rest-server/src/main/java/org/osc/core/broker/rest/server/api/ApplianceApis.java
+++ b/osc-rest-server/src/main/java/org/osc/core/broker/rest/server/api/ApplianceApis.java
@@ -39,6 +39,7 @@ import org.osc.core.broker.rest.server.ServerRestConstants;
 import org.osc.core.broker.rest.server.annotations.OscAuth;
 import org.osc.core.broker.rest.server.exception.VmidcRestServerException;
 import org.osc.core.broker.service.api.AddApplianceServiceApi;
+import org.osc.core.broker.service.api.AddApplianceSoftwareVersionServiceApi;
 import org.osc.core.broker.service.api.DeleteApplianceServiceApi;
 import org.osc.core.broker.service.api.DeleteApplianceSoftwareVersionServiceApi;
 import org.osc.core.broker.service.api.GetDtoFromEntityServiceApi;
@@ -98,6 +99,9 @@ public class ApplianceApis {
 
     @Reference
     AddApplianceServiceApi addApplianceService;
+
+    @Reference
+    AddApplianceSoftwareVersionServiceApi addApplianceSoftwareVersionService;
 
     @Reference
     private GetDtoFromEntityServiceFactoryApi getDtoFromEntityServiceFactory;
@@ -221,6 +225,23 @@ public class ApplianceApis {
 
         GetDtoFromEntityServiceApi<ApplianceSoftwareVersionDto> getDtoService = this.getDtoFromEntityServiceFactory.getService(ApplianceSoftwareVersionDto.class);
         return this.apiUtil.submitBaseRequestToService(getDtoService, getDtoRequest).getDto();
+    }
+
+    @ApiOperation(value = "Creates a new appliance software version for a software function model",
+            notes = "Creates a new appliance software version for a software function model",
+            response = BaseResponse.class)
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Successful operation"),
+            @ApiResponse(code = 400, message = "In case of any error", response = ErrorCodeDto.class) })
+    @Path("/{applianceId}/versions")
+    @POST
+    public Response createApplianceSoftwareVersion(@Context HttpHeaders headers,
+            @ApiParam(value = "Id of the Appliance Model", required = true) @PathParam("applianceId") Long applianceId, @ApiParam(required = true) ApplianceSoftwareVersionDto asvDto) {
+
+        logger.info("Creating an Appliance Software Version");
+        this.userContext.setUser(OscAuthFilter.getUsername(headers));
+        this.apiUtil.setIdAndParentIdOrThrow(asvDto, null, applianceId, "Appliance Sofftware Version");
+
+        return this.apiUtil.getResponseForBaseRequest(this.addApplianceSoftwareVersionService, new BaseRequest<ApplianceSoftwareVersionDto>(asvDto));
     }
 
     @ApiOperation(value = "Deletes a Security Function Software Version",

--- a/osc-server/src/main/java/org/osc/core/broker/rest/client/openstack/vmidc/notification/runner/OsDeploymentSpecNotificationRunner.java
+++ b/osc-server/src/main/java/org/osc/core/broker/rest/client/openstack/vmidc/notification/runner/OsDeploymentSpecNotificationRunner.java
@@ -60,7 +60,7 @@ import com.google.common.collect.Multimap;
  *
  */
 @Component(scope=ServiceScope.PROTOTYPE,
- service=OsDeploymentSpecNotificationRunner.class)
+service=OsDeploymentSpecNotificationRunner.class)
 public class OsDeploymentSpecNotificationRunner implements BroadcastListener {
     @Reference
     private NotificationListenerFactory notificationListenerFactory;
@@ -90,7 +90,9 @@ public class OsDeploymentSpecNotificationRunner implements BroadcastListener {
                 List<DeploymentSpec> dsList = dsEmgr.listAll();
 
                 for (DeploymentSpec ds : dsList) {
-                    addListener(ds);
+                    if (ds.getVirtualSystem().getVirtualizationConnector().getVirtualizationType().isOpenstack()) {
+                        addListener(ds);
+                    }
                 }
                 return null;
             });
@@ -126,7 +128,7 @@ public class OsDeploymentSpecNotificationRunner implements BroadcastListener {
                 EntityManager em = this.dbConnectionManager.getTransactionalEntityManager();
                 this.dbConnectionManager.getTransactionControl().required(() -> {
                     DeploymentSpec ds = DeploymentSpecEntityMgr.findById(em, msg.getEntityId());
-                    if (ds != null) {
+                    if (ds != null && ds.getVirtualSystem().getVirtualizationConnector().getVirtualizationType().isOpenstack()) {
                         // if DS is deleted after update notification was sent
                         if (msg.getEventType() == EventType.ADDED) {
                             addListener(ds);

--- a/osc-server/src/main/java/org/osc/core/broker/service/AddDeploymentSpecService.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/AddDeploymentSpecService.java
@@ -17,6 +17,7 @@
 package org.osc.core.broker.service;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import javax.persistence.EntityManager;
@@ -44,7 +45,7 @@ import org.osgi.service.component.annotations.Reference;
 
 @Component
 public class AddDeploymentSpecService extends BaseDeploymentSpecService<BaseRequest<DeploymentSpecDto>, BaseJobResponse>
-        implements AddDeploymentSpecServiceApi {
+implements AddDeploymentSpecServiceApi {
 
     @Reference
     private ConformService conformService;
@@ -60,33 +61,39 @@ public class AddDeploymentSpecService extends BaseDeploymentSpecService<BaseRequ
             DistributedAppliance da = this.vs.getDistributedAppliance();
             unlockTask = LockUtil.tryReadLockDA(da, da.getApplianceManagerConnector());
             unlockTask
-                    .addUnlockTask(LockUtil.tryLockVCObject(this.vs.getVirtualizationConnector(), LockType.READ_LOCK));
+            .addUnlockTask(LockUtil.tryLockVCObject(this.vs.getVirtualizationConnector(), LockType.READ_LOCK));
 
             DeploymentSpec ds = DeploymentSpecEntityMgr.createEntity(request.getDto(), this.vs);
             OSCEntityManager.create(em, ds, this.txBroadcastUtil);
-            ds.setAvailabilityZones(createAvailabilityZones(ds, request.getDto(), em));
-            ds.setHosts(createHosts(ds, request.getDto(), em));
-            ds.setHostAggregates(createHostAggregates(ds, request.getDto(), em));
+            // TODO emanoel: remove condition when DS sync is implemented.
+            if (this.vs.getVirtualizationConnector().getVirtualizationType().isOpenstack()) {
+                ds.setAvailabilityZones(createAvailabilityZones(ds, request.getDto(), em));
+                ds.setHosts(createHosts(ds, request.getDto(), em));
+                ds.setHostAggregates(createHostAggregates(ds, request.getDto(), em));
 
-            UnlockObjectMetaTask forLambda = unlockTask;
-            chain(() -> {
-                // Lock the deployment spec with a write lock and allow it to be unlocked at the end of the job.
-                try {
-                    BaseJobResponse response = new BaseJobResponse();
+                UnlockObjectMetaTask forLambda = unlockTask;
+                chain(() -> {
+                    // Lock the deployment spec with a write lock and allow it to be unlocked at the end of the job.
+                    try {
+                        BaseJobResponse response = new BaseJobResponse();
 
-                    forLambda.addUnlockTask(LockUtil.tryLockDSOnly(ds));
+                        forLambda.addUnlockTask(LockUtil.tryLockDSOnly(ds));
 
-                    Job job = this.conformService.startDsConformanceJob(em, ds, forLambda);
+                        Job job = this.conformService.startDsConformanceJob(em, ds, forLambda);
 
-                    response.setJobId(job.getId());
+                        response.setJobId(job.getId());
 
-                    return response;
-                } catch (Exception e) {
-                    LockUtil.releaseLocks(forLambda);
-                    throw e;
-                }
-            });
-
+                        return response;
+                    } catch (Exception e) {
+                        LockUtil.releaseLocks(forLambda);
+                        throw e;
+                    }
+                });
+            } else {
+                BaseJobResponse response = new BaseJobResponse();
+                response.setId(ds.getId());
+                LockUtil.releaseLocks(unlockTask);
+            }
         } catch (Exception e) {
             LockUtil.releaseLocks(unlockTask);
             throw e;
@@ -101,27 +108,33 @@ public class AddDeploymentSpecService extends BaseDeploymentSpecService<BaseRequ
             haSet.add(createHostAggregate(em, haDto, ds));
         }
         return haSet;
-
     }
 
     @Override
     protected void validate(EntityManager em, DeploymentSpecDto dto) throws Exception {
         super.validate(em, dto);
 
-        if(dto.getInspectionNetworkId().equals(dto.getManagementNetworkId())) {
-            throw new VmidcBrokerValidationException("Invalid Network Selection. Management and Inspection networks"
-                    + " cannot be the same.");
-        }
+        if (this.vs.getVirtualizationConnector().getVirtualizationType().isOpenstack()) {
+            if(dto.getInspectionNetworkId().equals(dto.getManagementNetworkId())) {
+                throw new VmidcBrokerValidationException("Invalid Network Selection. Management and Inspection networks"
+                        + " cannot be the same.");
+            }
 
-        DeploymentSpec existingDs = null;
-        existingDs = DeploymentSpecEntityMgr.findDeploymentSpecByVirtualSystemProjectAndRegion(em, this.vs,
-        				dto.getProjectId(), dto.getRegion());
-        if (existingDs != null) {
-            throw new VmidcBrokerValidationException("A Deployment Specification: " + existingDs.getName()
-                    + " Already exists for the combination of the specified virtual system, project and region. "
-                    + "Cannot add another Deployment Specification for the same combination.");
-        }
+            DeploymentSpec existingDs = null;
+            existingDs = DeploymentSpecEntityMgr.findDeploymentSpecByVirtualSystemProjectAndRegion(em, this.vs,
+                    dto.getProjectId(), dto.getRegion());
+            if (existingDs != null) {
+                throw new VmidcBrokerValidationException("A Deployment Specification: " + existingDs.getName()
+                + " Already exists for the combination of the specified virtual system, project and region. "
+                + "Cannot add another Deployment Specification for the same combination.");
+            }
+        } else if (this.vs.getVirtualizationConnector().getVirtualizationType().isKubernetes()){
+            List<DeploymentSpec> deploymentSpecs = DeploymentSpecEntityMgr.listDeploymentSpecByVirtualSystem(em, this.vs);
 
+            if (deploymentSpecs != null && !deploymentSpecs.isEmpty()) {
+                throw new VmidcBrokerValidationException("A deployment spec for the targed Kubernetes virtual system already exists.");
+            }
+        }
     };
 
     private Set<AvailabilityZone> createAvailabilityZones(DeploymentSpec ds, DeploymentSpecDto dto, EntityManager em) {
@@ -131,7 +144,6 @@ public class AddDeploymentSpecService extends BaseDeploymentSpecService<BaseRequ
             azSet.add(createAvailabilityZone(em, azDto, ds));
         }
         return azSet;
-
     }
 
     private Set<Host> createHosts(DeploymentSpec ds, DeploymentSpecDto dto, EntityManager em) {
@@ -141,6 +153,5 @@ public class AddDeploymentSpecService extends BaseDeploymentSpecService<BaseRequ
             hsSet.add(createHost(em, hsDto, ds));
         }
         return hsSet;
-
     }
 }

--- a/osc-server/src/main/java/org/osc/core/broker/service/UpdateDeploymentSpecService.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/UpdateDeploymentSpecService.java
@@ -47,8 +47,8 @@ import org.osgi.service.component.annotations.Reference;
 
 @Component
 public class UpdateDeploymentSpecService
-        extends BaseDeploymentSpecService<BaseRequest<DeploymentSpecDto>, BaseJobResponse>
-        implements UpdateDeploymentSpecServiceApi {
+extends BaseDeploymentSpecService<BaseRequest<DeploymentSpecDto>, BaseJobResponse>
+implements UpdateDeploymentSpecServiceApi {
 
     private static final Logger log = Logger.getLogger(UpdateDeploymentSpecService.class);
 
@@ -110,7 +110,7 @@ public class UpdateDeploymentSpecService
         this.ds = em.find(DeploymentSpec.class, dto.getId());
         if (this.ds == null) {
             throw new VmidcBrokerValidationException("Deployment Specification with Id: " + dto.getId()
-                    + "  is not found.");
+            + "  is not found.");
         }
 
         ValidateUtil.checkMarkedForDeletion(this.ds, this.ds.getName());
@@ -150,7 +150,6 @@ public class UpdateDeploymentSpecService
 
     private Set<HostAggregate> updateHostAggregates(EntityManager em, Set<HostAggregateDto> selectedHaDtoSet,
             DeploymentSpec ds) {
-
         // assuming nothing changed
         Set<HostAggregate> updatedHaSet = new HashSet<>();
         updatedHaSet.addAll(ds.getHostAggregates());
@@ -175,7 +174,6 @@ public class UpdateDeploymentSpecService
         }
 
         return updatedHaSet;
-
     }
 
     private boolean isEqual(HostAggregate hostAggrEntity, HostAggregateDto hostAggrDto) {
@@ -202,7 +200,6 @@ public class UpdateDeploymentSpecService
 
     private Set<AvailabilityZone> updateAvailabilityZones(EntityManager em, Set<AvailabilityZoneDto> selectedAZDtoSet,
             DeploymentSpec ds) {
-
         // assuming nothing changed
         Set<AvailabilityZone> updatedAzSet = new HashSet<>();
         updatedAzSet.addAll(ds.getAvailabilityZones());
@@ -252,7 +249,6 @@ public class UpdateDeploymentSpecService
     }
 
     private Set<Host> updateHosts(EntityManager em, Set<HostDto> selectedHostDtoSet, DeploymentSpec ds) {
-
         // assuming nothing changed
         Set<Host> updatedHostSet = new HashSet<>();
         updatedHostSet.addAll(ds.getHosts());

--- a/osc-server/src/main/java/org/osc/core/broker/service/appliance/AddApplianceSoftwareVersionService.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/appliance/AddApplianceSoftwareVersionService.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) Intel Corporation
+ * Copyright (c) 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.osc.core.broker.service.appliance;
+
+import javax.persistence.EntityManager;
+
+import org.osc.core.broker.model.entities.appliance.Appliance;
+import org.osc.core.broker.model.entities.appliance.ApplianceSoftwareVersion;
+import org.osc.core.broker.model.plugin.ApiFactoryService;
+import org.osc.core.broker.service.ServiceDispatcher;
+import org.osc.core.broker.service.api.AddApplianceSoftwareVersionServiceApi;
+import org.osc.core.broker.service.dto.ApplianceSoftwareVersionDto;
+import org.osc.core.broker.service.exceptions.VmidcBrokerValidationException;
+import org.osc.core.broker.service.persistence.ApplianceSoftwareVersionEntityMgr;
+import org.osc.core.broker.service.persistence.OSCEntityManager;
+import org.osc.core.broker.service.request.BaseRequest;
+import org.osc.core.broker.service.response.BaseResponse;
+import org.osc.core.broker.service.validator.ApplianceSoftwareVersionDtoValidator;
+import org.osc.core.broker.service.validator.DtoValidator;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+@Component(service = {AddApplianceSoftwareVersionServiceApi.class})
+public class AddApplianceSoftwareVersionService extends ServiceDispatcher<BaseRequest<ApplianceSoftwareVersionDto>, BaseResponse>
+implements AddApplianceSoftwareVersionServiceApi {
+    DtoValidator<ApplianceSoftwareVersionDto, ApplianceSoftwareVersion> validator;
+
+    @Reference
+    private ApiFactoryService apiFactoryService;
+
+    @Reference
+    private ApplianceSoftwareVersionDtoValidator validatorFactory;
+
+    @Override
+    public BaseResponse exec(BaseRequest<ApplianceSoftwareVersionDto> request, EntityManager em) throws Exception {
+        BaseResponse response = new BaseResponse();
+
+        ApplianceSoftwareVersionDto asvDto = request.getDto();
+
+        if (this.validator == null) {
+            this.validator = this.validatorFactory.create(em);
+        }
+
+        this.validator.validateForCreate(asvDto);
+
+        OSCEntityManager<Appliance> applianceEntityManager = new OSCEntityManager<Appliance>(Appliance.class, em, this.txBroadcastUtil);
+        Appliance appliance = applianceEntityManager.findByPrimaryKey(asvDto.getParentId());
+
+        if (appliance == null) {
+            throw new VmidcBrokerValidationException("An appliance was not found for the id: " + asvDto.getParentId());
+        }
+
+        OSCEntityManager<ApplianceSoftwareVersion> emgr = new OSCEntityManager<ApplianceSoftwareVersion>(
+                ApplianceSoftwareVersion.class, em, this.txBroadcastUtil);
+
+        ApplianceSoftwareVersion applianceSoftwareVersion = ApplianceSoftwareVersionEntityMgr.createEntity(em, asvDto, appliance);
+
+        applianceSoftwareVersion = emgr.create(applianceSoftwareVersion);
+
+        response.setId(applianceSoftwareVersion.getId());
+        return response;
+    }
+}

--- a/osc-server/src/main/java/org/osc/core/broker/service/persistence/ApplianceSoftwareVersionEntityMgr.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/persistence/ApplianceSoftwareVersionEntityMgr.java
@@ -38,17 +38,14 @@ import org.osc.core.common.virtualization.VirtualizationType;
 public class ApplianceSoftwareVersionEntityMgr {
 
     public static ApplianceSoftwareVersion createEntity(EntityManager em, ApplianceSoftwareVersionDto dto, Appliance a) {
-
         ApplianceSoftwareVersion av = new ApplianceSoftwareVersion(a);
 
         toEntity(av, dto);
 
         return av;
-
     }
 
     public static void toEntity(ApplianceSoftwareVersion av, ApplianceSoftwareVersionDto dto) {
-
         // transfrom from dto to entity
         av.setId(dto.getId());
         av.setApplianceSoftwareVersion(dto.getSwVersion());
@@ -65,7 +62,7 @@ public class ApplianceSoftwareVersionEntityMgr {
         av.setAdditionalNicForInspection(dto.isAdditionalNicForInspection());
         av.getImageProperties().putAll(dto.getImageProperties());
         av.getConfigProperties().putAll(dto.getConfigProperties());
-
+        av.setImagePullSecretName(dto.getImagePullSecretName());
     }
 
     public static void fromEntity(ApplianceSoftwareVersion av, ApplianceSoftwareVersionDto dto) {
@@ -82,6 +79,10 @@ public class ApplianceSoftwareVersionEntityMgr {
                 .map(t -> org.osc.sdk.controller.TagEncapsulationType.valueOf(t.name()))
                 .collect(Collectors.toList()));
         dto.setAdditionalNicForInspection(av.hasAdditionalNicForInspection());
+        dto.setImagePullSecretName(av.getImagePullSecretName());
+        dto.setDiskSizeInGb(av.getDiskSizeInGb());
+        dto.setMemoryInMb(av.getMemoryInMb());
+        dto.setMinCpus(av.getMinCpus());
     }
 
     public static ApplianceSoftwareVersion findByApplianceVersionVirtTypeAndVersion(EntityManager em, Long applianceId, String av,

--- a/osc-server/src/main/java/org/osc/core/broker/service/persistence/DeploymentSpecEntityMgr.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/persistence/DeploymentSpecEntityMgr.java
@@ -53,6 +53,7 @@ public class DeploymentSpecEntityMgr {
         ds.setProjectName(dto.getProjectName());
         ds.setInstanceCount(dto.getCount());
         ds.setShared(dto.isShared());
+        ds.setNamespace(dto.getNamespace());
     }
 
     public static void fromEntity(DeploymentSpec ds, DeploymentSpecDto dto) {
@@ -68,6 +69,7 @@ public class DeploymentSpecEntityMgr {
         dto.setInspectionNetworkName(ds.getInspectionNetworkName());
         dto.setInspectionNetworkId(ds.getInspectionNetworkId());
         dto.setCount(ds.getInstanceCount());
+        dto.setNamespace(ds.getNamespace());
         if (ds.getLastJob() != null) {
             dto.setLastJobStatus(ds.getLastJob().getStatus().name());
             dto.setLastJobState(ds.getLastJob().getState().name());
@@ -121,8 +123,8 @@ public class DeploymentSpecEntityMgr {
 
         query = query.select(root)
                 .where(cb.equal(root.get("projectId"), projectId),
-                       cb.equal(root.get("region"), region),
-                       cb.equal(root.get("virtualSystem"), vs));
+                        cb.equal(root.get("region"), region),
+                        cb.equal(root.get("virtualSystem"), vs));
 
         try {
             return em.createQuery(query).getSingleResult();
@@ -131,8 +133,8 @@ public class DeploymentSpecEntityMgr {
         }
     }
 
-	public static List<DeploymentSpec> findDeploymentSpecsByVirtualSystemProjectAndRegion(EntityManager em,
-			VirtualSystem vs, String projectId, String region) {
+    public static List<DeploymentSpec> findDeploymentSpecsByVirtualSystemProjectAndRegion(EntityManager em,
+            VirtualSystem vs, String projectId, String region) {
 
         CriteriaBuilder cb = em.getCriteriaBuilder();
 
@@ -142,11 +144,11 @@ public class DeploymentSpecEntityMgr {
 
         query = query.select(root).distinct(true)
                 .where(cb.equal(root.get("projectId"), projectId),
-                       cb.equal(root.get("region"), region),
-                       cb.equal(root.get("virtualSystem"), vs));
+                        cb.equal(root.get("region"), region),
+                        cb.equal(root.get("virtualSystem"), vs));
 
         return em.createQuery(query).getResultList();
-	}
+    }
 
     public static DeploymentSpec findById(EntityManager em, Long id) {
         return em.find(DeploymentSpec.class, id);

--- a/osc-server/src/main/java/org/osc/core/broker/service/persistence/DistributedApplianceInstanceEntityMgr.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/persistence/DistributedApplianceInstanceEntityMgr.java
@@ -70,6 +70,10 @@ public class DistributedApplianceInstanceEntityMgr {
         dto.setMgmtSubnetPrefixLength(dai.getMgmtSubnetPrefixLength());
         dto.setMgmtGateway(dai.getMgmtGateway());
 
+        dto.setExternalId(dai.getExternalId());
+        dto.setInspectionElementId(dai.getInspectionElementId());
+        dto.setInspectionElementParentId(dai.getInspectionElementParentId());
+
         return dto;
     }
 
@@ -244,7 +248,7 @@ public class DistributedApplianceInstanceEntityMgr {
 
         query = query.select(root).distinct(true)
                 .where(cb.equal(root.join("deploymentSpec").get("id"), dsId),
-                       cb.equal(root.get("osAvailabilityZone"), availabilityZone));
+                        cb.equal(root.get("osAvailabilityZone"), availabilityZone));
 
         List<DistributedApplianceInstance> list = em.createQuery(query).getResultList();
 
@@ -266,7 +270,7 @@ public class DistributedApplianceInstanceEntityMgr {
 
         query = query.select(root).distinct(true)
                 .where(cb.equal(root.get("deploymentSpec"), ds),
-                       cb.equal(root.get("osHostName"), hostName));
+                        cb.equal(root.get("osHostName"), hostName));
 
         List<DistributedApplianceInstance> list = em.createQuery(query).getResultList();
 
@@ -322,7 +326,7 @@ public class DistributedApplianceInstanceEntityMgr {
 
         query = query.select(root)
                 .where(cb.equal(root.join("virtualSystem").get("id"), vs.getId()),
-                       cb.equal(root.join("protectedPorts").get("id"), port.getId()));
+                        cb.equal(root.join("protectedPorts").get("id"), port.getId()));
 
         try {
             return em.createQuery(query).getSingleResult();

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/ForceDeleteDSTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/ForceDeleteDSTask.java
@@ -63,11 +63,13 @@ public class ForceDeleteDSTask extends TransactionalTask {
         }
 
         // remove the sg reference from database
-        boolean osSgCanBeDeleted = DeploymentSpecEntityMgr.findDeploymentSpecsByVirtualSystemProjectAndRegion(em,
-                this.ds.getVirtualSystem(), this.ds.getProjectId(), this.ds.getRegion()).size() <= 1;
+        if (this.ds.getVirtualSystem().getVirtualizationConnector().getVirtualizationType().isOpenstack()) {
+            boolean osSgCanBeDeleted = DeploymentSpecEntityMgr.findDeploymentSpecsByVirtualSystemProjectAndRegion(em,
+                    this.ds.getVirtualSystem(), this.ds.getProjectId(), this.ds.getRegion()).size() <= 1;
 
-        if (osSgCanBeDeleted) {
-            OSCEntityManager.delete(em, this.ds.getOsSecurityGroupReference(), this.txBroadcastUtil);
+            if (osSgCanBeDeleted) {
+                OSCEntityManager.delete(em, this.ds.getOsSecurityGroupReference(), this.txBroadcastUtil);
+            }
         }
 
         // delete DS from the database

--- a/osc-server/src/main/java/org/osc/core/broker/service/validator/ApplianceSoftwareVersionDtoValidator.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/validator/ApplianceSoftwareVersionDtoValidator.java
@@ -19,13 +19,49 @@ package org.osc.core.broker.service.validator;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.persistence.EntityManager;
+
+import org.osc.core.broker.model.entities.appliance.ApplianceSoftwareVersion;
 import org.osc.core.broker.service.dto.ApplianceSoftwareVersionDto;
+import org.osc.core.broker.service.exceptions.VmidcBrokerValidationException;
+import org.osc.core.broker.service.persistence.ApplianceSoftwareVersionEntityMgr;
 import org.osc.core.broker.util.ValidateUtil;
+import org.osgi.service.component.annotations.Component;
 
-public class ApplianceSoftwareVersionDtoValidator {
+@Component(service = ApplianceSoftwareVersionDtoValidator.class)
+public class ApplianceSoftwareVersionDtoValidator implements DtoValidator<ApplianceSoftwareVersionDto, ApplianceSoftwareVersion> {
+    private EntityManager em;
 
-    public static void checkForNullFields(ApplianceSoftwareVersionDto dto) throws Exception {
+    void setEntityManager(EntityManager em) {
+        this.em = em;
+    }
 
+    public ApplianceSoftwareVersionDtoValidator create(EntityManager em) {
+        ApplianceSoftwareVersionDtoValidator validator = new ApplianceSoftwareVersionDtoValidator();
+        validator.em = em;
+        return validator;
+    }
+
+    @Override
+    public void validateForCreate(ApplianceSoftwareVersionDto dto) throws Exception {
+        checkForNullFields(dto);
+
+        checkFieldLength(dto);
+
+        ApplianceSoftwareVersion asv = ApplianceSoftwareVersionEntityMgr.findByImageUrl(this.em, dto.getImageUrl());
+        if (asv != null) {
+            throw new VmidcBrokerValidationException("Image file: " + dto.getImageUrl()
+            + " already exists. Cannot add an image with the same name.");
+        }
+    }
+
+    @Override
+    public ApplianceSoftwareVersion validateForUpdate(ApplianceSoftwareVersionDto dto) throws Exception {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    private static void checkForNullFields(ApplianceSoftwareVersionDto dto) throws Exception {
         // build a map of (field,value) pairs to be checked for null/empty
         // values
         Map<String, Object> map = new HashMap<String, Object>();
@@ -39,7 +75,7 @@ public class ApplianceSoftwareVersionDtoValidator {
         ValidateUtil.checkForNullFields(map);
     }
 
-    public static void checkFieldLength(ApplianceSoftwareVersionDto dto) throws Exception {
+    private static void checkFieldLength(ApplianceSoftwareVersionDto dto) throws Exception {
 
         Map<String, String> map = new HashMap<String, String>();
 

--- a/osc-server/src/main/java/org/osc/core/broker/service/validator/DeploymentSpecDtoValidator.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/validator/DeploymentSpecDtoValidator.java
@@ -26,24 +26,10 @@ public class DeploymentSpecDtoValidator {
 
 
     public static void checkForNullFields(DeploymentSpecDto dto) throws Exception {
-
         // build a map of (field,value) pairs to be checked for null/empty
         // values
         Map<String, Object> map = new HashMap<String, Object>();
         map.put("Name", dto.getName());
-
-        map.put("Project Name", dto.getProjectName());
-        map.put("Project", dto.getProjectId());
-
-        map.put("Region", dto.getRegion());
-
-        map.put("Virtual System Id", dto.getParentId());
-
-        map.put("Management Network Name", dto.getManagementNetworkName());
-        map.put("Management Network Id", dto.getManagementNetworkId());
-
-        map.put("Inspection Network Name", dto.getInspectionNetworkName());
-        map.put("Inspection Network Id", dto.getInspectionNetworkId());
 
         map.put("Instance Count", dto.getCount());
 

--- a/osc-server/src/main/java/org/osc/core/broker/util/db/upgrade/Schema.java
+++ b/osc-server/src/main/java/org/osc/core/broker/util/db/upgrade/Schema.java
@@ -101,6 +101,7 @@ public class Schema {
                 "disk_in_gb int," +
                 "additional_nic_for_inspection bit not null default 0," +
                 "appliance_fk bigint not null," +
+                "image_pull_secret_name varchar(255)," +
                 "primary key (id)" +
             ");",
 
@@ -173,6 +174,9 @@ public class Schema {
                 "mgmt_gateway_address varchar(255)," +
                 "mgmt_subnet_prefix_length varchar(255)," +
                 "deployment_spec_fk bigint," +
+                "external_id varchar(255)," +
+                "inspection_element_id varchar(255)," +
+                "inspection_element_parent_id varchar(255)," +
                 "primary key (id)" +
             ");",
 
@@ -515,14 +519,16 @@ public class Schema {
                 "updated_timestamp timestamp," +
                 "version bigint," +
                 "name varchar(255) not null," +
-                "region varchar(255) not null," +
-                "project_name varchar(255) not null," +
-                "project_id varchar(255) not null," +
-                "management_network_name varchar(255) not null," +
-                "management_network_id varchar(255) not null," +
-                "inspection_network_name varchar(255) not null," +
-                "inspection_network_id varchar(255) not null," +
+                "region varchar(255)," +
+                "project_name varchar(255)," +
+                "project_id varchar(255)," +
+                "management_network_name varchar(255)," +
+                "management_network_id varchar(255)," +
+                "inspection_network_name varchar(255)," +
+                "inspection_network_id varchar(255)," +
                 "floating_pool_name varchar(255)," +
+                "namespace varchar(255)," +
+                "external_id varchar(255)," + 
                 "last_job_id_fk bigint," +
                 "instance_count bigint not null default 1," +
                 "shared bit not null default 0," +

--- a/osc-server/src/test/java/org/osc/core/broker/service/appliance/AddApplianceSoftwareVersionServiceTest.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/appliance/AddApplianceSoftwareVersionServiceTest.java
@@ -1,0 +1,183 @@
+/*******************************************************************************
+ * Copyright (c) Intel Corporation
+ * Copyright (c) 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.osc.core.broker.service.appliance;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import java.util.UUID;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityTransaction;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Answers;
+import org.mockito.ArgumentMatcher;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.osc.core.broker.model.entities.appliance.Appliance;
+import org.osc.core.broker.model.entities.appliance.ApplianceSoftwareVersion;
+import org.osc.core.broker.service.api.server.UserContextApi;
+import org.osc.core.broker.service.dto.ApplianceSoftwareVersionDto;
+import org.osc.core.broker.service.exceptions.VmidcBrokerValidationException;
+import org.osc.core.broker.service.request.BaseRequest;
+import org.osc.core.broker.service.response.BaseResponse;
+import org.osc.core.broker.service.validator.ApplianceSoftwareVersionDtoValidator;
+import org.osc.core.broker.util.TransactionalBroadcastUtil;
+import org.osc.core.broker.util.db.DBConnectionManager;
+import org.osc.core.common.virtualization.VirtualizationType;
+import org.osc.core.test.util.TestTransactionControl;
+import org.osc.sdk.controller.TagEncapsulationType;
+
+public class AddApplianceSoftwareVersionServiceTest {
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Mock
+    private EntityManager em;
+
+    @Mock
+    protected EntityTransaction tx;
+
+    @Mock(answer=Answers.CALLS_REAL_METHODS)
+    TestTransactionControl txControl;
+
+    @Mock
+    private ApplianceSoftwareVersionDtoValidator validatorMock;
+
+    @Mock
+    private UserContextApi userContext;
+
+    @Mock
+    DBConnectionManager dbMgr;
+
+    @Mock
+    private TransactionalBroadcastUtil txBroadcastUtil;
+
+    @InjectMocks
+    private AddApplianceSoftwareVersionService service;
+
+    @Before
+    public void testInitialize() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        this.service.validator = this.validatorMock;
+        when(this.em.getTransaction()).thenReturn(this.tx);
+
+        when(this.dbMgr.getTransactionalEntityManager()).thenReturn(this.em);
+        when(this.dbMgr.getTransactionControl()).thenReturn(this.txControl);
+
+        this.txControl.setEntityManager(this.em);
+    }
+
+    @Test
+    public void testDispatch_WithNullRequest_ThrowsNullPointerException() throws Exception {
+        // Arrange.
+        this.exception.expect(NullPointerException.class);
+
+        // Act.
+        this.service.dispatch(null);
+    }
+
+    @Test
+    public void testDispatch_WhenAsvValidationFails_ThrowsUnhandledException() throws Exception {
+        // Arrange.
+        ApplianceSoftwareVersionDto dto = new ApplianceSoftwareVersionDto();
+        BaseRequest<ApplianceSoftwareVersionDto> request = new BaseRequest<>(dto);
+
+        doThrow(VmidcBrokerValidationException.class).when(this.validatorMock).validateForCreate(dto);
+        this.exception.expect(VmidcBrokerValidationException.class);
+
+        // Act.
+        this.service.dispatch(request);
+    }
+
+    @Test
+    public void testDispatch_WhenAsvApplianceNotFound_ThrowsValidationException() throws Exception {
+        // Arrange.
+        Long applianceId = 101L;
+        ApplianceSoftwareVersionDto dto = new ApplianceSoftwareVersionDto();
+        dto.setParentId(applianceId);
+        BaseRequest<ApplianceSoftwareVersionDto> request = new BaseRequest<>(dto);
+
+        when(this.em.find(Appliance.class, applianceId)).thenReturn(null);
+        this.exception.expect(VmidcBrokerValidationException.class);
+
+        // Act.
+        this.service.dispatch(request);
+    }
+
+    @Test
+    public void testDispatch_WhenAsvValidationSucceeds_AsvIsPersisted() throws Exception {
+        // Arrange.
+        ApplianceSoftwareVersionDto dto = new ApplianceSoftwareVersionDto();
+        dto.setParentId(100L);
+        dto.setSwVersion(UUID.randomUUID().toString());
+        dto.setVirtualizationType(VirtualizationType.OPENSTACK);
+        dto.setEncapsulationTypes(Arrays.asList(TagEncapsulationType.VLAN));
+        dto.setMinCpus(1);
+        dto.setMemoryInMb(100);
+        dto.setDiskSizeInGb(100);
+
+        BaseRequest<ApplianceSoftwareVersionDto> request = new BaseRequest<>(dto);
+        Long asvId = 111L;
+
+        when(this.em.find(Appliance.class, dto.getParentId())).thenReturn(new Appliance());
+
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                ApplianceSoftwareVersion asv = invocation.getArgumentAt(0, ApplianceSoftwareVersion.class);
+                asv.setId(asvId);
+                return null;
+            }
+        }).when(this.em).persist(argThat(new ApplianceSoftwareVersionMatcher(dto.getSwVersion())));
+
+        // Act.
+        BaseResponse response = this.service.dispatch(request);
+
+        // Assert
+        assertNotNull("The returned response should not be null", response);
+        assertEquals("The returned asv id was different than expected", asvId, response.getId());
+    }
+
+    private class ApplianceSoftwareVersionMatcher extends ArgumentMatcher<Object> {
+        private String softwareVersion;
+
+        public ApplianceSoftwareVersionMatcher(String softwareVersion) {
+            this.softwareVersion = softwareVersion;
+        }
+
+        @Override
+        public boolean matches(Object object) {
+            if (object == null || !(object instanceof ApplianceSoftwareVersion)) {
+                return false;
+            }
+            ApplianceSoftwareVersion asv = (ApplianceSoftwareVersion)object;
+            return this.softwareVersion.equals(asv.getApplianceSoftwareVersion());
+        }
+    }
+}

--- a/osc-server/src/test/java/org/osc/core/broker/service/validator/ApplianceSoftwareVersionDtoValidatorTest.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/validator/ApplianceSoftwareVersionDtoValidatorTest.java
@@ -1,0 +1,220 @@
+/*******************************************************************************
+ * Copyright (c) Intel Corporation
+ * Copyright (c) 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.osc.core.broker.service.validator;
+
+import java.util.UUID;
+
+import javax.persistence.EntityManager;
+
+import org.apache.commons.lang.StringUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Answers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.osc.core.broker.model.entities.appliance.Appliance;
+import org.osc.core.broker.model.entities.appliance.ApplianceSoftwareVersion;
+import org.osc.core.broker.service.dto.ApplianceSoftwareVersionDto;
+import org.osc.core.broker.service.exceptions.VmidcBrokerInvalidEntryException;
+import org.osc.core.broker.service.exceptions.VmidcBrokerValidationException;
+import org.osc.core.broker.service.test.InMemDB;
+import org.osc.core.broker.util.TransactionalBroadcastUtil;
+import org.osc.core.broker.util.ValidateUtil;
+import org.osc.core.broker.util.db.DBConnectionManager;
+import org.osc.core.common.virtualization.VirtualizationType;
+import org.osc.core.test.util.TestTransactionControl;
+
+public class ApplianceSoftwareVersionDtoValidatorTest {
+    private EntityManager em;
+
+    @Mock(answer=Answers.CALLS_REAL_METHODS)
+    TestTransactionControl txControl;
+
+    @Mock
+    private DBConnectionManager dbMgr;
+
+    @Mock
+    private TransactionalBroadcastUtil txBroadcastUtil;
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @InjectMocks
+    private ApplianceSoftwareVersionDtoValidator validator;
+
+    private final static String NULL_FIELD_MESSAGE = "%s should not have an empty value.";
+
+    private final static String MAX_LEN_FIELD_MESSAGE = "%s length should not exceed %s characters. The provided field exceeds this limit by %s characters.";
+
+    private final static String EXISTING_IMAGE_URL = "existing-image-url";
+
+    @Before
+    public void testInitialize() {
+        MockitoAnnotations.initMocks(this);
+
+        this.em = InMemDB.getEntityManagerFactory().createEntityManager();
+
+        this.validator.setEntityManager(this.em);
+
+        this.txControl.setEntityManager(this.em);
+
+        Mockito.when(this.dbMgr.getTransactionalEntityManager()).thenReturn(this.em);
+        Mockito.when(this.dbMgr.getTransactionControl()).thenReturn(this.txControl);
+
+        populateDatabase();
+    }
+
+    @Test
+    public void testValidateforCreate_UsingNullImageUrl_ThrowsVmidcBrokerInvalidEntryException() throws Exception {
+        ApplianceSoftwareVersionDto dto = newApplianceSoftwareVersionDto();
+        dto.setImageUrl(null);
+        testValidateforCreate_UsingNullField_ThrowsVmidcBrokerInvalidEntryException(dto, "Image Url");
+    }
+
+    @Test
+    public void testValidateforCreate_UsingNullVirtualizationVersion_ThrowsVmidcBrokerInvalidEntryException() throws Exception {
+        ApplianceSoftwareVersionDto dto = newApplianceSoftwareVersionDto();
+        dto.setVirtualizationVersion(null);
+        testValidateforCreate_UsingNullField_ThrowsVmidcBrokerInvalidEntryException(dto, "Virtualization Version");
+    }
+
+    @Test
+    public void testValidateforCreate_UsingNullVirtualizationType_ThrowsVmidcBrokerInvalidEntryException() throws Exception {
+        ApplianceSoftwareVersionDto dto = newApplianceSoftwareVersionDto();
+        dto.setVirtualizationType(null);
+        testValidateforCreate_UsingNullField_ThrowsVmidcBrokerInvalidEntryException(dto, "Virtualization Type");
+    }
+
+    @Test
+    public void testValidateforCreate_UsingNullApplianceSoftwareVersion_ThrowsVmidcBrokerInvalidEntryException() throws Exception {
+        ApplianceSoftwareVersionDto dto = newApplianceSoftwareVersionDto();
+        dto.setSwVersion(null);
+        testValidateforCreate_UsingNullField_ThrowsVmidcBrokerInvalidEntryException(dto, "Appliance Software Version");
+    }
+
+    @Test
+    public void testValidateforCreate_UsingNullApplianceId_ThrowsVmidcBrokerInvalidEntryException() throws Exception {
+        ApplianceSoftwareVersionDto dto = newApplianceSoftwareVersionDto();
+        dto.setParentId(null);
+        testValidateforCreate_UsingNullField_ThrowsVmidcBrokerInvalidEntryException(dto, "Appliance Id");
+    }
+
+    @Test
+    public void testValidateforCreate_UsingApplianceImageUrlTooLong_ThrowsVmidcBrokerInvalidEntryException() throws Exception {
+        ApplianceSoftwareVersionDto dto = newApplianceSoftwareVersionDto();
+        dto.setImageUrl(StringUtils.rightPad("m", ValidateUtil.DEFAULT_MAX_LEN + 1, 'e'));
+        testValidateforCreate_UsingFieldTooLong_ThrowsVmidcBrokerInvalidEntryException(dto, "Image Url");
+    }
+
+    @Test
+    public void testValidateforCreate_UsingApplianceVirtualizationVersionTooLong_ThrowsVmidcBrokerInvalidEntryException() throws Exception {
+        ApplianceSoftwareVersionDto dto = newApplianceSoftwareVersionDto();
+        dto.setVirtualizationVersion(StringUtils.rightPad("m", ValidateUtil.DEFAULT_MAX_LEN + 1, 'e'));
+        testValidateforCreate_UsingFieldTooLong_ThrowsVmidcBrokerInvalidEntryException(dto, "Virtualization Version");
+    }
+
+    @Test
+    public void testValidateforCreate_UsingApplianceSoftwareVersionTooLong_ThrowsVmidcBrokerInvalidEntryException() throws Exception {
+        ApplianceSoftwareVersionDto dto = newApplianceSoftwareVersionDto();
+        dto.setSwVersion(StringUtils.rightPad("m", ValidateUtil.DEFAULT_MAX_LEN + 1, 'e'));
+        testValidateforCreate_UsingFieldTooLong_ThrowsVmidcBrokerInvalidEntryException(dto, "Appliance Software Version");
+    }
+
+    @Test
+    public void testValidateforCreate_UsingExistingImageUrl_ThrowsVmidcBrokerValidationException() throws Exception {
+        // Arrange.
+        ApplianceSoftwareVersionDto dto = newApplianceSoftwareVersionDto();
+        dto.setImageUrl(EXISTING_IMAGE_URL);
+
+        this.exception.expect(VmidcBrokerValidationException.class);
+        this.exception.expectMessage(String.format("Image file: %s already exists. Cannot add an image with the same name.", EXISTING_IMAGE_URL));
+
+        // Act.
+        this.validator.validateForCreate(dto);
+    }
+
+    @Test
+    public void testValidateforCreate_UsingValidNewImage_Suceeds() throws Exception {
+        // Arrange.
+        ApplianceSoftwareVersionDto dto = newApplianceSoftwareVersionDto();
+
+        // Act.
+        this.validator.validateForCreate(dto);
+    }
+
+    private void testValidateforCreate_UsingNullField_ThrowsVmidcBrokerInvalidEntryException(ApplianceSoftwareVersionDto dto, String fieldName) throws Exception {
+        // Arrange.
+        this.exception.expect(VmidcBrokerInvalidEntryException.class);
+        this.exception.expectMessage(String.format(NULL_FIELD_MESSAGE, fieldName));
+
+        // Act.
+        this.validator.validateForCreate(dto);
+    }
+
+    private void testValidateforCreate_UsingFieldTooLong_ThrowsVmidcBrokerInvalidEntryException(ApplianceSoftwareVersionDto dto, String fieldName) throws Exception {
+        // Arrange.
+        this.exception.expect(VmidcBrokerInvalidEntryException.class);
+        this.exception.expectMessage(String.format(MAX_LEN_FIELD_MESSAGE, fieldName, ValidateUtil.DEFAULT_MAX_LEN, 1));
+
+        // Act.
+        this.validator.validateForCreate(dto);
+    }
+
+    private ApplianceSoftwareVersionDto newApplianceSoftwareVersionDto() {
+        ApplianceSoftwareVersionDto dto = new ApplianceSoftwareVersionDto();
+        dto.setParentId(100L);
+        dto.setSwVersion("SwVersion");
+        dto.setVirtualizationType(VirtualizationType.OPENSTACK);
+        dto.setVirtualizationVersion("VirtualizationVersion");
+        dto.setImageUrl("ImageUrl");
+
+        return dto;
+    }
+
+    @After
+    public void testTearDown() {
+        InMemDB.shutdown();
+    }
+
+    private void populateDatabase() {
+        this.em.getTransaction().begin();
+
+        Appliance appliance = new Appliance();
+
+        appliance.setModel("Model");
+        appliance.setManagerSoftwareVersion(UUID.randomUUID().toString());
+        appliance.setManagerType(UUID.randomUUID().toString());
+
+        this.em.persist(appliance);
+
+        ApplianceSoftwareVersion asv = new ApplianceSoftwareVersion(appliance);
+        asv.setApplianceSoftwareVersion("SoftwareVersion");
+        asv.setVirtualizationType(VirtualizationType.OPENSTACK);
+        asv.setVirtualizarionSoftwareVersion("VirtualizationVersion");
+        asv.setImageUrl(EXISTING_IMAGE_URL);
+        asv.setAdditionalNicForInspection(false);
+
+        this.em.persist(asv);
+
+        this.em.getTransaction().commit();
+    }
+}

--- a/osc-service-api/src/main/java/org/osc/core/broker/service/api/AddApplianceSoftwareVersionServiceApi.java
+++ b/osc-service-api/src/main/java/org/osc/core/broker/service/api/AddApplianceSoftwareVersionServiceApi.java
@@ -16,14 +16,10 @@
  *******************************************************************************/
 package org.osc.core.broker.service.api;
 
-import java.sql.Connection;
-import java.sql.SQLException;
+import org.osc.core.broker.service.dto.ApplianceSoftwareVersionDto;
+import org.osc.core.broker.service.request.BaseRequest;
+import org.osc.core.broker.service.response.BaseResponse;
 
-public interface DBConnectionManagerApi {
-    /*
-     * TARGET_DB_VERSION will be manually changed to the real target db version to which we will upgrade
-     */
-    int TARGET_DB_VERSION = 87;
+public interface AddApplianceSoftwareVersionServiceApi extends ServiceDispatcherApi<BaseRequest<ApplianceSoftwareVersionDto>, BaseResponse> {
 
-    Connection getSQLConnection() throws SQLException;
 }

--- a/osc-service-api/src/main/java/org/osc/core/broker/service/dto/ApplianceSoftwareVersionDto.java
+++ b/osc-service-api/src/main/java/org/osc/core/broker/service/dto/ApplianceSoftwareVersionDto.java
@@ -51,6 +51,9 @@ public class ApplianceSoftwareVersionDto extends BaseDto {
     @ApiModelProperty(required=true)
     private String imageUrl = "";
 
+    @ApiModelProperty(required=false)
+    private String imagePullSecretName = "";
+
     @ApiModelProperty(value="Required for Openstack image. Defines the supported list of Encapsulation Types the "
             + "Service Function Image capable supporting.<br>"
             + "The Encapsulation Type used for Packet Metadata (Policy Tag and Packet Direction).<br>"
@@ -98,6 +101,14 @@ public class ApplianceSoftwareVersionDto extends BaseDto {
         this.swVersion = swVersion;
     }
 
+    public String getImagePullSecretName() {
+        return this.imagePullSecretName;
+    }
+
+    public void setImagePullSecretName(String imagePullSecretName) {
+        this.imagePullSecretName = imagePullSecretName;
+    }
+
     public VirtualizationType getVirtualizationType() {
         return this.virtualizationType;
     }
@@ -130,27 +141,27 @@ public class ApplianceSoftwareVersionDto extends BaseDto {
         this.encapsulationTypes = encapsulationType;
     }
 
-    public int getMinCpus() {
+    public Integer getMinCpus() {
         return this.minCpus;
     }
 
-    public void setMinCpus(int minCpus) {
+    public void setMinCpus(Integer minCpus) {
         this.minCpus = minCpus;
     }
 
-    public int getMemoryInMb() {
+    public Integer getMemoryInMb() {
         return this.memoryInMb;
     }
 
-    public void setMemoryInMb(int memoryInMb) {
+    public void setMemoryInMb(Integer memoryInMb) {
         this.memoryInMb = memoryInMb;
     }
 
-    public int getDiskSizeInGb() {
+    public Integer getDiskSizeInGb() {
         return this.diskSizeInGb;
     }
 
-    public void setDiskSizeInGb(int diskSizeInGb) {
+    public void setDiskSizeInGb(Integer diskSizeInGb) {
         this.diskSizeInGb = diskSizeInGb;
     }
 

--- a/osc-service-api/src/main/java/org/osc/core/broker/service/dto/DistributedApplianceInstanceDto.java
+++ b/osc-service-api/src/main/java/org/osc/core/broker/service/dto/DistributedApplianceInstanceDto.java
@@ -59,6 +59,15 @@ public class DistributedApplianceInstanceDto extends BaseDto {
     private String virtualConnectorName;
 
     @ApiModelProperty(readOnly = true)
+    private String externalId;
+
+    @ApiModelProperty(readOnly = true)
+    private String inspectionElementId;
+
+    @ApiModelProperty(readOnly = true)
+    private String inspectionElementParentId;
+
+    @ApiModelProperty(readOnly = true)
     private String hostname;
 
     @ApiModelProperty(
@@ -139,6 +148,30 @@ public class DistributedApplianceInstanceDto extends BaseDto {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public String getExternalId() {
+        return this.externalId;
+    }
+
+    public void setExternalId(String externalId) {
+        this.externalId = externalId;
+    }
+
+    public String getInspectionElementId() {
+        return this.inspectionElementId;
+    }
+
+    public void setInspectionElementId(String inspectionElementId) {
+        this.inspectionElementId = inspectionElementId;
+    }
+
+    public String getInspectionElementParentId() {
+        return this.inspectionElementParentId;
+    }
+
+    public void setInspectionElementParentId(String inspectionElementParentId) {
+        this.inspectionElementParentId = inspectionElementParentId;
     }
 
     public String getIpAddress() {

--- a/osc-service-api/src/main/java/org/osc/core/broker/service/dto/openstack/DeploymentSpecDto.java
+++ b/osc-service-api/src/main/java/org/osc/core/broker/service/dto/openstack/DeploymentSpecDto.java
@@ -39,40 +39,36 @@ public class DeploymentSpecDto extends BaseDto {
     private String name;
 
     @ApiModelProperty(value = "The id of the project on behalf of which the service function instances will be deployed",
-            required = true,
             readOnly = true)
     private String projectId;
 
+    @ApiModelProperty(value = "The virtualization environment namespace for the entities created by this deployment. For instance, a Kubernetes namespace.")
+    private String namespace;
+
     @ApiModelProperty(
             value = "The name of the project on behalf of which the service function instances will be deployed",
-            required = true,
             readOnly = true)
     private String projectName;
 
     @ApiModelProperty(value = "The region to which the service function instances will be deployed",
-            required = true,
             readOnly = true)
     private String region;
 
     @ApiModelProperty(
             value = "The name of the management network which the service function instances will be connected to",
-            required = true,
             readOnly = true)
     private String managementNetworkName;
 
     @ApiModelProperty(value = "The id of management network which the service function instances will be connected to",
-            required = true,
             readOnly = true)
     private String managementNetworkId;
 
     @ApiModelProperty(
             value = "The name of the inspection network which the service function instances will be connected to",
-            required = true,
             readOnly = true)
     private String inspectionNetworkName;
 
     @ApiModelProperty(value = "The id of inspection network which the service function instances will be connected to",
-            required = true,
             readOnly = true)
     private String inspectionNetworkId;
 
@@ -146,6 +142,14 @@ public class DeploymentSpecDto extends BaseDto {
 
     public void setRegion(String region) {
         this.region = region;
+    }
+
+    public String getNamespace() {
+        return this.namespace;
+    }
+
+    public void setNamespace(String namespace) {
+        this.namespace = namespace;
     }
 
     public String getManagementNetworkName() {


### PR DESCRIPTION
This PR implements:
1. All the code needed to create an appliance software version (entity changes, services, unit tests, rest API). see https://github.com/opensecuritycontroller/community/blob/master/designs/containers/vnf-deployment/vnf-deployment.md#appliance-software-version 

2. All the DB entity changes related to DS and DAIS for K8s, see https://github.com/opensecuritycontroller/community/blob/master/designs/containers/vnf-deployment/vnf-deployment.md#osc-entities 

3.  Makes the ASV integer field using `Integer` rather than `int`. Those fields were already optional but when not provided we had an NPE. This fixes that problem.

Note: Remaining changes to create a k8s DS will come later in a different PR
 