### PR TITLE
Integrate with neutron SFC Plugin

### DIFF
--- a/osc-export/pom.xml
+++ b/osc-export/pom.xml
@@ -316,6 +316,10 @@
                                         <copy tofile="${basedir}/plugins/NuageSdnControllerPlugin.bar">
                                             <fileset dir="${basedir}/../../osc-nuage-plugin/target/"
                                                 includes="NuageSdnControllerPlugin*.bar" />
+                                        </copy>
+                                        <copy tofile="${basedir}/plugins/NeutronSfcSdnControllerPlugin.bar">
+                                            <fileset dir="${basedir}/../../sdn-controller-nsfc-plugin/target/"
+                                                includes="NeutronSfcSdnControllerPlugin*.bar" /> 
                                         </copy>										
 									</tasks>
 								</configuration>

--- a/osc-server/src/main/java/org/osc/core/broker/model/plugin/ApiFactoryService.java
+++ b/osc-server/src/main/java/org/osc/core/broker/model/plugin/ApiFactoryService.java
@@ -188,5 +188,9 @@ public interface ApiFactoryService {
 
     Boolean supportsPortGroup(SecurityGroup sg) throws Exception;
 
+    Boolean supportsNeutronSFC(VirtualSystem vs) throws Exception;
+
+    Boolean supportsNeutronSFC(SecurityGroup sg) throws Exception;
+
 
 }

--- a/osc-server/src/main/java/org/osc/core/broker/model/plugin/ApiFactoryServiceImpl.java
+++ b/osc-server/src/main/java/org/osc/core/broker/model/plugin/ApiFactoryServiceImpl.java
@@ -656,13 +656,27 @@ public class ApiFactoryServiceImpl implements ApiFactoryService, PluginService {
         return supportsPortGroup(vs.getVirtualizationConnector().getControllerType());
     }
 
+    @Override
+    public Boolean supportsPortGroup(SecurityGroup sg) throws Exception {
+        return supportsPortGroup(sg.getVirtualizationConnector().getControllerType());
+    }
+
     private Boolean supportsPortGroup(String controllerType) throws Exception {
         return (Boolean) getControllerPluginProperty(controllerType, SUPPORT_PORT_GROUP);
     }
 
     @Override
-    public Boolean supportsPortGroup(SecurityGroup sg) throws Exception {
-        return supportsPortGroup(sg.getVirtualizationConnector().getControllerType());
+    public Boolean supportsNeutronSFC(VirtualSystem vs) throws Exception {
+        return supportsNeutronSFC(vs.getVirtualizationConnector().getControllerType());
+    }
+
+    @Override
+    public Boolean supportsNeutronSFC(SecurityGroup sg) throws Exception {
+        return supportsNeutronSFC(sg.getVirtualizationConnector().getControllerType());
+    }
+
+    private Boolean supportsNeutronSFC(String controllerType) throws Exception {
+        return (Boolean) getControllerPluginProperty(controllerType, SUPPORT_NEUTRON_SFC);
     }
 
 }

--- a/osc-server/src/main/java/org/osc/core/broker/model/plugin/sdncontroller/NetworkElementImpl.java
+++ b/osc-server/src/main/java/org/osc/core/broker/model/plugin/sdncontroller/NetworkElementImpl.java
@@ -52,4 +52,9 @@ public class NetworkElementImpl implements NetworkElement {
     public void setParentId(String parentId) {
         this.vmPort.setParentId(parentId);
     }
+
+    @Override
+    public String toString() {
+        return "NetworkElementImpl [vmPort=" + this.vmPort + "]";
+    }
 }

--- a/osc-server/src/main/java/org/osc/core/broker/service/persistence/DeploymentSpecEntityMgr.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/persistence/DeploymentSpecEntityMgr.java
@@ -68,6 +68,7 @@ public class DeploymentSpecEntityMgr {
         dto.setManagementNetworkId(ds.getManagementNetworkId());
         dto.setInspectionNetworkName(ds.getInspectionNetworkName());
         dto.setInspectionNetworkId(ds.getInspectionNetworkId());
+        dto.setPortGroupId(ds.getPortGroupId());
         dto.setCount(ds.getInstanceCount());
         dto.setNamespace(ds.getNamespace());
         if (ds.getLastJob() != null) {

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OsSvaServerCreateTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OsSvaServerCreateTask.java
@@ -189,11 +189,11 @@ public class OsSvaServerCreateTask extends TransactionalTask {
 
                     ingressPort.setParentId(domainId);
                     egressPort.setParentId(domainId);
-                }
 
-                //Element object in DefaultInspectionport is not used at this point, hence null
-                controller.registerInspectionPort(
-                        new DefaultInspectionPort(ingressPort, egressPort, null));
+                  //Element object in DefaultInspectionport is not used at this point, hence null
+                    controller.registerInspectionPort(
+                            new DefaultInspectionPort(ingressPort, egressPort, null));
+                }
             }
         }
 

--- a/osc-service-api/src/main/java/org/osc/core/broker/service/dto/openstack/DeploymentSpecDto.java
+++ b/osc-service-api/src/main/java/org/osc/core/broker/service/dto/openstack/DeploymentSpecDto.java
@@ -72,6 +72,10 @@ public class DeploymentSpecDto extends BaseDto {
             readOnly = true)
     private String inspectionNetworkId;
 
+    @ApiModelProperty(value = "The port group under which all the distributed appliance instances are registered under.",
+            readOnly = true)
+    private String portGroupId;
+
     @ApiModelProperty(
             value = "The floating ip pool from which floating ips will be allocated in case of NAT'ed environments",
             readOnly = true)
@@ -230,6 +234,14 @@ public class DeploymentSpecDto extends BaseDto {
 
     public void setInspectionNetworkId(String inspectionNetworkId) {
         this.inspectionNetworkId = inspectionNetworkId;
+    }
+
+    public String getPortGroupId() {
+        return this.portGroupId;
+    }
+
+    public void setPortGroupId(String portGroupId) {
+        this.portGroupId = portGroupId;
     }
 
     public String getFloatingIpPoolName() {

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,7 @@
 				<module>../security-mgr-api</module>
 
                 <module>../sdn-controller-nsc-plugin</module>
+                <module>../sdn-controller-nsfc-plugin</module>
                 <module>../security-mgr-sample-plugin</module>
                 
                 <module>../osc-nuage-plugin</module>


### PR DESCRIPTION
Integrate with neutron SFC plugin.

Updated API's to use the "Inspection port grouping" functionality provided by neutron sfc.
Note that SFC does not support "Inspected port grouping" which is the property exposed by the SDN controller API plugin SUPPORT_PORT_GROUP