### PR TITLE
Adding tasks and metatasks to conform DAIs for Kubernetes

### DIFF
--- a/osc-domain/src/main/java/org/osc/core/broker/model/entities/appliance/DistributedApplianceInstance.java
+++ b/osc-domain/src/main/java/org/osc/core/broker/model/entities/appliance/DistributedApplianceInstance.java
@@ -79,11 +79,9 @@ public class DistributedApplianceInstance extends BaseEntity {
     private String osHostName;
     @Column(name = "os_availability_zone_name")
     private String osAvailabilityZone;
-    @Column(name = "os_server_id")
-    private String osServerId;
-
     @Column(name = "external_id")
     private String externalId;
+
     @Column(name = "inspection_element_id")
     private String inspectionElementId;
     @Column(name = "inspection_element_parent_id")
@@ -165,14 +163,6 @@ public class DistributedApplianceInstance extends BaseEntity {
 
     public void setIpAddress(String ipAddress) {
         this.ipAddress = ipAddress;
-    }
-
-    public String getExternalId() {
-        return this.externalId;
-    }
-
-    public void setExternalId(String externalId) {
-        this.externalId = externalId;
     }
 
     public String getInspectionElementId() {
@@ -259,12 +249,12 @@ public class DistributedApplianceInstance extends BaseEntity {
         this.deploymentSpec = deploymentSpec;
     }
 
-    public String getOsServerId() {
-        return this.osServerId;
+    public String getExternalId() {
+        return this.externalId;
     }
 
-    public void setOsServerId(String osServerId) {
-        this.osServerId = osServerId;
+    public void setExternalId(String externalId) {
+        this.externalId = externalId;
     }
 
     public String getOsAvailabilityZone() {
@@ -391,7 +381,7 @@ public class DistributedApplianceInstance extends BaseEntity {
      * Resets all the discovered attributes for the Appliance instance.
      */
     public void resetAllDiscoveredAttributes() {
-        this.osServerId = null;
+        this.externalId = null;
         this.inspectionIngressMacAddress = null;
         this.inspectionOsIngressPortId = null;
         this.inspectionEgressMacAddress = null;
@@ -403,7 +393,7 @@ public class DistributedApplianceInstance extends BaseEntity {
     public void updateDaiOpenstackSvaInfo(String serverId,
             String ingressMacAddr, String ingressPortId, String egressMacAddr,
             String egressPortId) {
-        this.osServerId = serverId;
+        this.externalId = serverId;
         this.inspectionIngressMacAddress = ingressMacAddr;
         this.inspectionOsIngressPortId = ingressPortId;
         this.inspectionEgressMacAddress = egressMacAddr;

--- a/osc-server/src/main/java/org/osc/core/broker/rest/client/k8s/KubernetesDeploymentApi.java
+++ b/osc-server/src/main/java/org/osc/core/broker/rest/client/k8s/KubernetesDeploymentApi.java
@@ -199,7 +199,8 @@ public class KubernetesDeploymentApi extends KubernetesApi {
                         deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getImage(),
                         deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getImagePullPolicy());
                 resultDeployment.setDeploymentResource(deployment);
-                resultDeployment.setAvailableReplicaCount(deployment.getStatus().getAvailableReplicas());
+                Integer availableReplicas = deployment.getStatus().getAvailableReplicas();
+                resultDeployment.setAvailableReplicaCount(availableReplicas == null ? 0 : availableReplicas.intValue());
             }
 
         } catch (KubernetesClientException e) {

--- a/osc-server/src/main/java/org/osc/core/broker/rest/client/k8s/KubernetesDeploymentApi.java
+++ b/osc-server/src/main/java/org/osc/core/broker/rest/client/k8s/KubernetesDeploymentApi.java
@@ -180,7 +180,7 @@ public class KubernetesDeploymentApi extends KubernetesApi {
             return result.getMetadata().getUid();
 
         } catch (KubernetesClientException e) {
-            throw new VmidcException("Failed to create a deployment");
+            throw new VmidcException(String.format("Failed to create a deployment %s", e));
         }
     }
 
@@ -199,6 +199,7 @@ public class KubernetesDeploymentApi extends KubernetesApi {
                         deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getImage(),
                         deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getImagePullPolicy());
                 resultDeployment.setDeploymentResource(deployment);
+                resultDeployment.setAvailableReplicaCount(deployment.getStatus().getAvailableReplicas());
             }
 
         } catch (KubernetesClientException e) {

--- a/osc-server/src/main/java/org/osc/core/broker/rest/client/k8s/KubernetesDeploymentApi.java
+++ b/osc-server/src/main/java/org/osc/core/broker/rest/client/k8s/KubernetesDeploymentApi.java
@@ -28,7 +28,7 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
  * osc-core components.
  */
 public class KubernetesDeploymentApi extends KubernetesApi {
-    private final static String OSC_DEPLOYMENT_LABEL_NAME = "osc-deployment";
+    public final static String OSC_DEPLOYMENT_LABEL_NAME = "osc-deployment";
 
     private static final Logger LOG = Logger.getLogger(KubernetesDeploymentApi.class);
 

--- a/osc-server/src/main/java/org/osc/core/broker/rest/client/k8s/KubernetesEntity.java
+++ b/osc-server/src/main/java/org/osc/core/broker/rest/client/k8s/KubernetesEntity.java
@@ -32,4 +32,42 @@ public abstract class KubernetesEntity {
     public String getUid() {
         return this.uid;
     }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((this.name == null) ? 0 : this.name.hashCode());
+        result = prime * result + ((this.uid == null) ? 0 : this.uid.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        KubernetesEntity other = (KubernetesEntity) obj;
+        if (this.name == null) {
+            if (other.name != null) {
+                return false;
+            }
+        } else if (!this.name.equals(other.name)) {
+            return false;
+        }
+        if (this.uid == null) {
+            if (other.uid != null) {
+                return false;
+            }
+        } else if (!this.uid.equals(other.uid)) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/osc-server/src/main/java/org/osc/core/broker/rest/client/k8s/KubernetesPod.java
+++ b/osc-server/src/main/java/org/osc/core/broker/rest/client/k8s/KubernetesPod.java
@@ -20,7 +20,7 @@ public class KubernetesPod extends KubernetesEntity {
     private String namespace;
     private String node;
 
-    KubernetesPod(String name, String namespace, String uid, String node) {
+    public KubernetesPod(String name, String namespace, String uid, String node) {
         super(name, uid);
         this.node = node;
         this.namespace = namespace;
@@ -32,6 +32,50 @@ public class KubernetesPod extends KubernetesEntity {
 
     public String getNamespace() {
         return this.namespace;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + ((this.namespace == null) ? 0 : this.namespace.hashCode());
+        result = prime * result + ((this.node == null) ? 0 : this.node.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!super.equals(obj)) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        KubernetesPod other = (KubernetesPod) obj;
+        if (this.namespace == null) {
+            if (other.namespace != null) {
+                return false;
+            }
+        } else if (!this.namespace.equals(other.namespace)) {
+            return false;
+        }
+        if (this.node == null) {
+            if (other.node != null) {
+                return false;
+            }
+        } else if (!this.node.equals(other.node)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "KubernetesPod [namespace=" + this.namespace + ", node=" + this.node + ", getName()=" + getName() + ", getUid()="
+                + getUid() + "]";
     }
 }
 

--- a/osc-server/src/main/java/org/osc/core/broker/rest/client/openstack/vmidc/notification/runner/OsDeploymentSpecNotificationRunner.java
+++ b/osc-server/src/main/java/org/osc/core/broker/rest/client/openstack/vmidc/notification/runner/OsDeploymentSpecNotificationRunner.java
@@ -189,8 +189,8 @@ public class OsDeploymentSpecNotificationRunner implements BroadcastListener {
         ArrayList<String> svaIdList = new ArrayList<>();
         if (!ds.getDistributedApplianceInstances().isEmpty()) {
             for (DistributedApplianceInstance dai : ds.getDistributedApplianceInstances()) {
-                if (!dai.getMarkedForDeletion() && dai.getOsServerId() != null) {
-                    svaIdList.add(dai.getOsServerId().toString());
+                if (!dai.getMarkedForDeletion() && dai.getExternalId() != null) {
+                    svaIdList.add(dai.getExternalId().toString());
                 }
             }
         }

--- a/osc-server/src/main/java/org/osc/core/broker/service/SyncDeploymentSpecService.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/SyncDeploymentSpecService.java
@@ -34,8 +34,8 @@ import org.osgi.service.component.annotations.Reference;
 
 @Component
 public class SyncDeploymentSpecService
-        extends BaseDeploymentSpecService<BaseRequest<DeploymentSpecDto>, BaseJobResponse>
-        implements SyncDeploymentSpecServiceApi {
+extends BaseDeploymentSpecService<BaseRequest<DeploymentSpecDto>, BaseJobResponse>
+implements SyncDeploymentSpecServiceApi {
 
     @Reference
     private ConformService conformService;
@@ -44,14 +44,12 @@ public class SyncDeploymentSpecService
 
     @Override
     public BaseJobResponse exec(BaseRequest<DeploymentSpecDto> request, EntityManager em) throws Exception {
-
         BaseJobResponse response = new BaseJobResponse();
 
         UnlockObjectMetaTask unlockTask = null;
         validate(em, request.getDto());
 
         try {
-
             DistributedAppliance da = this.ds.getVirtualSystem().getDistributedAppliance();
             unlockTask = LockUtil.tryReadLockDA(da, da.getApplianceManagerConnector());
             unlockTask.addUnlockTask(LockUtil.tryLockVCObject(this.ds.getVirtualSystem().getVirtualizationConnector(),
@@ -75,7 +73,7 @@ public class SyncDeploymentSpecService
         this.ds = em.find(DeploymentSpec.class, dto.getId());
         if (this.ds == null) {
             throw new VmidcBrokerValidationException("Deployment Specification with Id: " + dto.getId()
-                    + "  is not found.");
+            + "  is not found.");
         }
 
         ValidateUtil.checkMarkedForDeletion(this.ds, this.ds.getName());

--- a/osc-server/src/main/java/org/osc/core/broker/service/UpdateDeploymentSpecService.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/UpdateDeploymentSpecService.java
@@ -120,18 +120,21 @@ implements UpdateDeploymentSpecServiceApi {
 
         if (!dto.getParentId().equals(this.ds.getVirtualSystem().getId())) {
             throwInvalidUpdateActionException("Virtual System", this.ds.getName());
-        } else if (!dto.getProjectId().equals(this.ds.getProjectId())) {
-            throwInvalidUpdateActionException("Project", this.ds.getName());
-        } else if (dto.isShared() != this.ds.isShared()) {
-            throwInvalidUpdateActionException("Shared", this.ds.getName());
-        } else if (!dto.getRegion().equals(this.ds.getRegion())) {
-            throwInvalidUpdateActionException("Region", this.ds.getName());
-        } else if (!dto.getManagementNetworkId().equals(this.ds.getManagementNetworkId())) {
-            throwInvalidUpdateActionException("Management Network Id", this.ds.getName());
-        } else if (!dto.getInspectionNetworkId().equals(this.ds.getInspectionNetworkId())) {
-            throwInvalidUpdateActionException("Inspection Network Id", this.ds.getName());
-        } else if (isFloatingIpUpdated(dto)) {
-            throwInvalidUpdateActionException("Floating Ip Pool", this.ds.getName());
+        }
+        if (this.ds.getVirtualSystem().getVirtualizationConnector().getVirtualizationType().isOpenstack()) {
+            if (!dto.getProjectId().equals(this.ds.getProjectId())) {
+                throwInvalidUpdateActionException("Project", this.ds.getName());
+            } else if (dto.isShared() != this.ds.isShared()) {
+                throwInvalidUpdateActionException("Shared", this.ds.getName());
+            } else if (!dto.getRegion().equals(this.ds.getRegion())) {
+                throwInvalidUpdateActionException("Region", this.ds.getName());
+            } else if (!dto.getManagementNetworkId().equals(this.ds.getManagementNetworkId())) {
+                throwInvalidUpdateActionException("Management Network Id", this.ds.getName());
+            } else if (!dto.getInspectionNetworkId().equals(this.ds.getInspectionNetworkId())) {
+                throwInvalidUpdateActionException("Inspection Network Id", this.ds.getName());
+            } else if (isFloatingIpUpdated(dto)) {
+                throwInvalidUpdateActionException("Floating Ip Pool", this.ds.getName());
+            }
         }
     }
 

--- a/osc-server/src/main/java/org/osc/core/broker/service/UpdateDeploymentSpecService.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/UpdateDeploymentSpecService.java
@@ -86,24 +86,16 @@ implements UpdateDeploymentSpecServiceApi {
                 }
             }
             OSCEntityManager.update(em, this.ds, this.txBroadcastUtil);
-            // TODO emanoel: remove this condition when DS sync is implemented
-            if (this.vs.getVirtualizationConnector().getVirtualizationType().isOpenstack()) {
-                UnlockObjectMetaTask forLambda = dsUnlock;
-                chain(() -> {
-                    try {
-                        Job job = this.conformService.startDsConformanceJob(em, this.ds, forLambda);
-                        return new BaseJobResponse(this.ds.getId(), job.getId());
-                    } catch (Exception e) {
-                        LockUtil.releaseLocks(forLambda);
-                        throw e;
-                    }
-                });
-            } else {
-                BaseJobResponse response = new BaseJobResponse();
-                response.setId(this.ds.getId());
-                LockUtil.releaseLocks(dsUnlock);
-                return response;
-            }
+            UnlockObjectMetaTask forLambda = dsUnlock;
+            chain(() -> {
+                try {
+                    Job job = this.conformService.startDsConformanceJob(em, this.ds, forLambda);
+                    return new BaseJobResponse(this.ds.getId(), job.getId());
+                } catch (Exception e) {
+                    LockUtil.releaseLocks(forLambda);
+                    throw e;
+                }
+            });
         } catch (Exception e) {
             LockUtil.releaseLocks(dsUnlock);
             throw e;

--- a/osc-server/src/main/java/org/osc/core/broker/service/persistence/DeploymentSpecEntityMgr.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/persistence/DeploymentSpecEntityMgr.java
@@ -54,7 +54,6 @@ public class DeploymentSpecEntityMgr {
         ds.setInstanceCount(dto.getCount());
         ds.setShared(dto.isShared());
         ds.setNamespace(dto.getNamespace());
-        ds.setExternalId(dto.getExternalId());
     }
 
     public static void fromEntity(DeploymentSpec ds, DeploymentSpecDto dto) {

--- a/osc-server/src/main/java/org/osc/core/broker/service/persistence/DistributedApplianceInstanceEntityMgr.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/persistence/DistributedApplianceInstanceEntityMgr.java
@@ -180,7 +180,7 @@ public class DistributedApplianceInstanceEntityMgr {
 
         Root<DistributedApplianceInstance> from = query.from(DistributedApplianceInstance.class);
 
-        query = query.select(from.get("osServerId")).distinct(true).where(
+        query = query.select(from.get("external_id")).distinct(true).where(
                 cb.equal(from.join("virtualSystem").join("virtualizationConnector")
                         .get("id"), vcId));
 
@@ -305,7 +305,7 @@ public class DistributedApplianceInstanceEntityMgr {
         Root<DistributedApplianceInstance> root = query.from(DistributedApplianceInstance.class);
 
         query = query.select(root)
-                .where(cb.equal(root.get("osServerId"), osServerId));
+                .where(cb.equal(root.get("external_id"), osServerId));
 
         List<DistributedApplianceInstance> list = em.createQuery(query).getResultList();
 

--- a/osc-server/src/main/java/org/osc/core/broker/service/persistence/DistributedApplianceInstanceEntityMgr.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/persistence/DistributedApplianceInstanceEntityMgr.java
@@ -59,7 +59,7 @@ public class DistributedApplianceInstanceEntityMgr {
                 .getApplianceManagerConnector().getName());
         dto.setVirtualConnectorName(dai.getVirtualSystem().getVirtualizationConnector().getName());
 
-        dto.setOsVmId(dai.getOsServerId());
+        dto.setExternalId(dai.getExternalId());
         dto.setOsHostname(dai.getOsHostName());
         dto.setOsInspectionIngressPortId(dai.getInspectionOsIngressPortId());
         dto.setOsInspectionIngressMacAddress(dai.getInspectionIngressMacAddress());

--- a/osc-server/src/main/java/org/osc/core/broker/service/persistence/DistributedApplianceInstanceEntityMgr.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/persistence/DistributedApplianceInstanceEntityMgr.java
@@ -180,7 +180,7 @@ public class DistributedApplianceInstanceEntityMgr {
 
         Root<DistributedApplianceInstance> from = query.from(DistributedApplianceInstance.class);
 
-        query = query.select(from.get("external_id")).distinct(true).where(
+        query = query.select(from.get("externalId")).distinct(true).where(
                 cb.equal(from.join("virtualSystem").join("virtualizationConnector")
                         .get("id"), vcId));
 
@@ -305,7 +305,7 @@ public class DistributedApplianceInstanceEntityMgr {
         Root<DistributedApplianceInstance> root = query.from(DistributedApplianceInstance.class);
 
         query = query.select(root)
-                .where(cb.equal(root.get("external_id"), osServerId));
+                .where(cb.equal(root.get("externalId"), osServerId));
 
         List<DistributedApplianceInstance> list = em.createQuery(query).getResultList();
 

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/CheckK8sDeploymentStateTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/CheckK8sDeploymentStateTask.java
@@ -23,6 +23,11 @@ import javax.persistence.EntityManager;
 import org.apache.log4j.Logger;
 import org.osc.core.broker.job.lock.LockObjectReference;
 import org.osc.core.broker.model.entities.virtualization.openstack.DeploymentSpec;
+import org.osc.core.broker.rest.client.k8s.KubernetesClient;
+import org.osc.core.broker.rest.client.k8s.KubernetesDeployment;
+import org.osc.core.broker.rest.client.k8s.KubernetesDeploymentApi;
+import org.osc.core.broker.service.exceptions.VmidcException;
+import org.osc.core.broker.service.persistence.OSCEntityManager;
 import org.osc.core.broker.service.tasks.TransactionalTask;
 import org.osgi.service.component.annotations.Component;
 
@@ -32,15 +37,71 @@ public class CheckK8sDeploymentStateTask extends TransactionalTask {
 
     private DeploymentSpec ds;
 
-    public CheckK8sDeploymentStateTask create(DeploymentSpec ds) {
+    private KubernetesDeploymentApi k8sDeploymentApi;
+
+    int MAX_RETRIES = 30;
+
+    int RETRY_INTERVAL__MILLISECONDS = 10000;
+
+    CheckK8sDeploymentStateTask create(DeploymentSpec ds, KubernetesDeploymentApi k8sDeploymentApi) {
         CheckK8sDeploymentStateTask task = new CheckK8sDeploymentStateTask();
+        task.dbConnectionManager = this.dbConnectionManager;
+        task.txBroadcastUtil = this.txBroadcastUtil;
         task.ds = ds;
+        task.k8sDeploymentApi = k8sDeploymentApi;
 
         return task;
     }
 
+    public CheckK8sDeploymentStateTask create(DeploymentSpec ds) {
+        return create(ds, null);
+    }
+
     @Override
     public void executeTransaction(EntityManager em) throws Exception {
+        OSCEntityManager<DeploymentSpec> dsEmgr = new OSCEntityManager<DeploymentSpec>(DeploymentSpec.class, em, this.txBroadcastUtil);
+        this.ds = dsEmgr.findByPrimaryKey(this.ds.getId());
+
+        try (KubernetesClient client = new KubernetesClient(this.ds.getVirtualSystem().getVirtualizationConnector())) {
+            if (this.k8sDeploymentApi == null) {
+                this.k8sDeploymentApi = new KubernetesDeploymentApi(client);
+            } else {
+                this.k8sDeploymentApi.setKubernetesClient(client);
+            }
+
+            int attemptCount = 0;
+            for (; attemptCount < this.MAX_RETRIES; attemptCount++) {
+                KubernetesDeployment k8sDeployment = this.k8sDeploymentApi.getDeploymentById(
+                        this.ds.getExternalId(),
+                        this.ds.getNamespace(),
+                        K8sUtil.getK8sName(this.ds));
+
+                if (k8sDeployment == null) {
+                    throw new VmidcException(String.format(
+                            "Kubernetes returned a null deployment for id %s, name %s, namespace %s",
+                            this.ds.getExternalId(),
+                            this.ds.getNamespace(),
+                            K8sUtil.getK8sName(this.ds)));
+                }
+
+                if (k8sDeployment.getAvailableReplicaCount() != this.ds.getInstanceCount()) {
+                    LOG.info(String.format("Kubernetes returned the deployment id %s, namespace %s and name %s with %s available count, the desired count is %s",
+                            this.ds.getExternalId(),
+                            this.ds.getNamespace(),
+                            K8sUtil.getK8sName(this.ds),
+                            k8sDeployment.getAvailableReplicaCount(),
+                            this.ds.getInstanceCount()));
+                } else {
+                    break;
+                }
+
+                Thread.sleep(this.RETRY_INTERVAL__MILLISECONDS);
+            }
+
+            if (attemptCount == this.MAX_RETRIES) {
+                throw new VmidcException("The Kubernetes deployment failed to reach the desired replica count.");
+            }
+        }
     }
 
     @Override

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/ConformK8sDeploymentPodsMetaTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/ConformK8sDeploymentPodsMetaTask.java
@@ -118,7 +118,7 @@ public class ConformK8sDeploymentPodsMetaTask extends TransactionalMetaTask {
         }
 
         for (DistributedApplianceInstance daiForDeletion : daisForDeletion) {
-            this.tg.addTask(this.deleteOrCleanK8sDAITask.create(this.ds, daiForDeletion));
+            this.tg.addTask(this.deleteOrCleanK8sDAITask.create(daiForDeletion));
         }
 
         this.tg.appendTask(this.conformK8sInspectionPortMetaTask.create(this.ds), TaskGuard.ALL_PREDECESSORS_COMPLETED);

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/ConformK8sDeploymentPodsMetaTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/ConformK8sDeploymentPodsMetaTask.java
@@ -16,38 +16,115 @@
  *******************************************************************************/
 package org.osc.core.broker.service.tasks.conformance.k8s.deploymentspec;
 
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.persistence.EntityManager;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.osc.core.broker.job.TaskGraph;
 import org.osc.core.broker.job.lock.LockObjectReference;
+import org.osc.core.broker.model.entities.appliance.DistributedApplianceInstance;
 import org.osc.core.broker.model.entities.virtualization.openstack.DeploymentSpec;
+import org.osc.core.broker.rest.client.k8s.KubernetesClient;
+import org.osc.core.broker.rest.client.k8s.KubernetesDeploymentApi;
+import org.osc.core.broker.rest.client.k8s.KubernetesPod;
+import org.osc.core.broker.rest.client.k8s.KubernetesPodApi;
+import org.osc.core.broker.service.persistence.OSCEntityManager;
 import org.osc.core.broker.service.tasks.TransactionalMetaTask;
+import org.osc.core.broker.service.tasks.conformance.manager.MgrCheckDevicesMetaTask;
+import org.osc.core.common.job.TaskGuard;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * Conforms the deployment pods for a Kubernetes deployment.
- *
  */
 @Component(service = ConformK8sDeploymentPodsMetaTask.class)
 public class ConformK8sDeploymentPodsMetaTask extends TransactionalMetaTask {
+    @Reference
+    DeleteOrCleanK8sDAITask deleteOrCleanK8sDAITask;
 
+    @Reference
+    CreateOrUpdateK8sDAITask createOrUpdateK8sDAITask;
+
+    @Reference
+    ConformK8sInspectionPortMetaTask conformK8sInspectionPortMetaTask;
+
+    @Reference
+    MgrCheckDevicesMetaTask managerCheckDevicesMetaTask;
+
+    private KubernetesPodApi k8sPodApi;
 
     private DeploymentSpec ds;
     private TaskGraph tg;
 
-    public ConformK8sDeploymentPodsMetaTask create(DeploymentSpec ds) {
+    public ConformK8sDeploymentPodsMetaTask create(DeploymentSpec ds, KubernetesPodApi k8sPodApi) {
         ConformK8sDeploymentPodsMetaTask task = new ConformK8sDeploymentPodsMetaTask();
+        task.deleteOrCleanK8sDAITask = this.deleteOrCleanK8sDAITask;
+        task.createOrUpdateK8sDAITask = this.createOrUpdateK8sDAITask;
+        task.conformK8sInspectionPortMetaTask = this.conformK8sInspectionPortMetaTask;
+        task.managerCheckDevicesMetaTask = this.managerCheckDevicesMetaTask;
+
         task.ds = ds;
+        task.k8sPodApi = this.k8sPodApi;
+
+        task.dbConnectionManager = this.dbConnectionManager;
+        task.txBroadcastUtil = this.txBroadcastUtil;
 
         return task;
+    }
+
+    public ConformK8sDeploymentPodsMetaTask create(DeploymentSpec ds) {
+        return create(ds, null);
     }
 
     @Override
     public void executeTransaction(EntityManager em) throws Exception {
         this.tg = new TaskGraph();
+        OSCEntityManager<DeploymentSpec> dsEmgr = new OSCEntityManager<DeploymentSpec>(DeploymentSpec.class, em, this.txBroadcastUtil);
+        this.ds = dsEmgr.findByPrimaryKey(this.ds.getId());
+
+        List<KubernetesPod> k8sPods = null;
+
+        if (this.ds.getExternalId() != null) {
+            try (KubernetesClient client = new KubernetesClient(this.ds.getVirtualSystem().getVirtualizationConnector())) {
+                if (this.k8sPodApi == null) {
+                    this.k8sPodApi = new KubernetesPodApi(client);
+                } else {
+                    this.k8sPodApi.setKubernetesClient(client);
+                }
+
+                k8sPods = this.k8sPodApi.getPodsByLabel(KubernetesDeploymentApi.OSC_DEPLOYMENT_LABEL_NAME + "=" + K8sUtil.getK8sName(this.ds));
+            }
+        }
+
+        final List<String> existingPodIdsInOSC =
+                CollectionUtils.emptyIfNull(this.ds.getDistributedApplianceInstances())
+                .stream().map(DistributedApplianceInstance::getExternalId).collect(Collectors.toList());
+
+        final List<String> existingPodIdsInK8s =
+                CollectionUtils.emptyIfNull(k8sPods)
+                .stream().map(KubernetesPod::getUid).collect(Collectors.toList());
+
+        List<KubernetesPod> podsForDAICreation = CollectionUtils.emptyIfNull(k8sPods).stream().filter(pod -> !existingPodIdsInOSC.contains(pod.getUid())).collect(Collectors.toList());
+
+        List<DistributedApplianceInstance> daisForDeletion =
+                CollectionUtils.emptyIfNull(this.ds.getDistributedApplianceInstances()).stream().filter(dai -> !existingPodIdsInK8s.contains(dai.getExternalId())).collect(Collectors.toList());
+
+        for (KubernetesPod podForDaiCreation : podsForDAICreation) {
+            this.tg.addTask(this.createOrUpdateK8sDAITask.create(this.ds, podForDaiCreation));
+        }
+
+        for (DistributedApplianceInstance daiForDeletion : daisForDeletion) {
+            this.tg.addTask(this.deleteOrCleanK8sDAITask.create(this.ds, daiForDeletion));
+        }
+
+        this.tg.appendTask(this.conformK8sInspectionPortMetaTask.create(this.ds), TaskGuard.ALL_PREDECESSORS_COMPLETED);
+        this.tg.appendTask(this.managerCheckDevicesMetaTask.create(this.ds.getVirtualSystem()), TaskGuard.ALL_PREDECESSORS_COMPLETED);
     }
+
 
     @Override
     public String getName() {

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/ConformK8sInspectionPortMetaTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/ConformK8sInspectionPortMetaTask.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) Intel Corporation
+ * Copyright (c) 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.osc.core.broker.service.tasks.conformance.k8s.deploymentspec;
+
+import java.util.Set;
+
+import javax.persistence.EntityManager;
+
+import org.osc.core.broker.job.TaskGraph;
+import org.osc.core.broker.job.lock.LockObjectReference;
+import org.osc.core.broker.model.entities.virtualization.openstack.DeploymentSpec;
+import org.osc.core.broker.service.tasks.TransactionalMetaTask;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * Conforms the deployment pods for a Kubernetes deployment.
+ *
+ */
+@Component(service = ConformK8sInspectionPortMetaTask.class)
+public class ConformK8sInspectionPortMetaTask extends TransactionalMetaTask {
+    private DeploymentSpec ds;
+    private TaskGraph tg;
+
+    public ConformK8sInspectionPortMetaTask create(DeploymentSpec ds) {
+        ConformK8sInspectionPortMetaTask task = new ConformK8sInspectionPortMetaTask();
+        task.ds = ds;
+
+        return task;
+    }
+
+    @Override
+    public void executeTransaction(EntityManager em) throws Exception {
+        this.tg = new TaskGraph();
+    }
+
+    @Override
+    public String getName() {
+        return String.format("Conforming the K8s pods for the deployment spec '%s'", this.ds.getName());
+    }
+
+    @Override
+    public TaskGraph getTaskGraph() {
+        return this.tg;
+    }
+
+    @Override
+    public Set<LockObjectReference> getObjects() {
+        return LockObjectReference.getObjectReferences(this.ds);
+    }
+}

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/ConformK8sInspectionPortMetaTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/ConformK8sInspectionPortMetaTask.java
@@ -38,7 +38,8 @@ public class ConformK8sInspectionPortMetaTask extends TransactionalMetaTask {
     public ConformK8sInspectionPortMetaTask create(DeploymentSpec ds) {
         ConformK8sInspectionPortMetaTask task = new ConformK8sInspectionPortMetaTask();
         task.ds = ds;
-
+        task.dbConnectionManager = this.dbConnectionManager;
+        task.txBroadcastUtil = this.txBroadcastUtil;
         return task;
     }
 
@@ -49,7 +50,7 @@ public class ConformK8sInspectionPortMetaTask extends TransactionalMetaTask {
 
     @Override
     public String getName() {
-        return String.format("Conforming the K8s pods for the deployment spec '%s'", this.ds.getName());
+        return String.format("Conforming the K8s inspection ports for the deployment spec '%s'", this.ds.getName());
     }
 
     @Override

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/CreateK8sDeploymentTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/CreateK8sDeploymentTask.java
@@ -58,7 +58,7 @@ public class CreateK8sDeploymentTask extends TransactionalTask {
         this.ds = dsEmgr.findByPrimaryKey(this.ds.getId());
 
         KubernetesDeployment k8sDeployment = new KubernetesDeployment(
-                getK8sName(this.ds),
+                K8sUtil.getK8sName(this.ds),
                 this.ds.getNamespace(),
                 null,
                 this.ds.getInstanceCount(),
@@ -90,9 +90,5 @@ public class CreateK8sDeploymentTask extends TransactionalTask {
     @Override
     public Set<LockObjectReference> getObjects() {
         return LockObjectReference.getObjectReferences(this.ds);
-    }
-
-    static String getK8sName(DeploymentSpec ds) {
-        return ds.getName() + "_" + ds.getId();
     }
 }

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/CreateOrUpdateK8sDAITask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/CreateOrUpdateK8sDAITask.java
@@ -16,18 +16,25 @@
  *******************************************************************************/
 package org.osc.core.broker.service.tasks.conformance.k8s.deploymentspec;
 
+import java.util.Optional;
 import java.util.Set;
 
 import javax.persistence.EntityManager;
 
 import org.apache.log4j.Logger;
 import org.osc.core.broker.job.lock.LockObjectReference;
+import org.osc.core.broker.model.entities.appliance.DistributedApplianceInstance;
 import org.osc.core.broker.model.entities.virtualization.openstack.DeploymentSpec;
+import org.osc.core.broker.model.plugin.ApiFactoryService;
 import org.osc.core.broker.rest.client.k8s.KubernetesDeploymentApi;
 import org.osc.core.broker.rest.client.k8s.KubernetesPod;
+import org.osc.core.broker.service.exceptions.VmidcException;
 import org.osc.core.broker.service.persistence.OSCEntityManager;
 import org.osc.core.broker.service.tasks.TransactionalTask;
+import org.osc.sdk.controller.api.SdnRedirectionApi;
+import org.osc.sdk.controller.element.NetworkElement;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * This task is responsible for persisting a DAI in the OSC database for a newly found pod VNF.
@@ -41,7 +48,8 @@ public class CreateOrUpdateK8sDAITask extends TransactionalTask {
 
     private KubernetesPod k8sPod;
 
-    private KubernetesDeploymentApi k8sDeploymentApi;
+    @Reference
+    private ApiFactoryService apiFactoryService;
 
     public CreateOrUpdateK8sDAITask create(DeploymentSpec ds, KubernetesPod k8sPod) {
         return create(ds, k8sPod, null);
@@ -51,9 +59,9 @@ public class CreateOrUpdateK8sDAITask extends TransactionalTask {
         CreateOrUpdateK8sDAITask task = new CreateOrUpdateK8sDAITask();
         task.dbConnectionManager = this.dbConnectionManager;
         task.txBroadcastUtil = this.txBroadcastUtil;
+        task.apiFactoryService = this.apiFactoryService;
         task.ds = ds;
         task.k8sPod = k8sPod;
-        task.k8sDeploymentApi = k8sDeploymentApi;
 
         return task;
     }
@@ -62,11 +70,55 @@ public class CreateOrUpdateK8sDAITask extends TransactionalTask {
     public void executeTransaction(EntityManager em) throws Exception {
         OSCEntityManager<DeploymentSpec> dsEmgr = new OSCEntityManager<DeploymentSpec>(DeploymentSpec.class, em, this.txBroadcastUtil);
         this.ds = dsEmgr.findByPrimaryKey(this.ds.getId());
+
+        NetworkElement portElement;
+
+        try (SdnRedirectionApi redirection = this.apiFactoryService.createNetworkRedirectionApi(this.ds.getVirtualSystem())) {
+            // TODO emanoel: Replace this id workaround with the pod UID once Nuage supports the look up by PodUID.
+            String deviceOwnerId = this.k8sPod.getNamespace() + ":" + this.k8sPod.getName();
+            portElement = redirection.getNetworkElementByDeviceOwnerId(deviceOwnerId);
+            if (portElement == null) {
+                throw new VmidcException(String.format("The SDN controller did not return a network element for the device id %s" , deviceOwnerId));
+            }
+        }
+
+        // Trying to retrieve a dai that is assigned to an inspection element on the SDN
+        // but does not have an associated port (previously deleted pod)
+        Optional<DistributedApplianceInstance> orphanDai =
+                this.ds.getDistributedApplianceInstances()
+                .stream()
+                .filter(dai -> (dai.getInspectionElementId() != null && dai.getInspectionOsIngressPortId() == null)).findFirst();
+
+        if (orphanDai.isPresent()) {
+            LOG.info(String.format("Found orphan dai with id %s and name %s and inspection element %s",
+                    orphanDai.get().getId(),
+                    orphanDai.get().getName(),
+                    orphanDai.get().getInspectionElementId()));
+        }
+
+        DistributedApplianceInstance dai = new DistributedApplianceInstance(this.ds.getVirtualSystem());
+        dai.setOsHostName(this.k8sPod.getNode());
+        dai.setDeploymentSpec(this.ds);
+        dai.setName(this.k8sPod.getNamespace() + "-" + this.k8sPod.getName());
+        dai.setExternalId(this.k8sPod.getUid());
+        // Creating the new DAI with the existing/orphan DAI inspection element id
+        dai.setInspectionElementId(orphanDai.isPresent() ? orphanDai.get().getInspectionElementId() : null);
+        dai.setInspectionElementParentId(orphanDai.isPresent() ? orphanDai.get().getInspectionElementParentId() : null);
+        dai.setInspectionOsIngressPortId(portElement.getElementId());
+        dai.setInspectionIngressMacAddress(portElement.getMacAddresses().get(0));
+        dai.setIpAddress(portElement.getPortIPs().get(0));
+        dai = OSCEntityManager.create(em, dai, this.txBroadcastUtil);
+        LOG.info(String.format("Created dai %s.", dai.getName()));
+
+        if (orphanDai.isPresent()) {
+            OSCEntityManager.delete(em, orphanDai.get(), this.txBroadcastUtil);
+            LOG.info(String.format("Deleted orphan dai with id %s and name %s", orphanDai.get().getId(), orphanDai.get().getName()));
+        }
     }
 
     @Override
     public String getName() {
-        return String.format("Creating the K8s deployment spec %s and pod %s", this.ds.getName(), this.k8sPod.getUid());
+        return String.format("Creating the K8s dai for deployment spec %s and pod %s", this.ds.getName(), this.k8sPod.getUid());
     }
 
     @Override

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/CreateOrUpdateK8sDAITask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/CreateOrUpdateK8sDAITask.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) Intel Corporation
+ * Copyright (c) 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.osc.core.broker.service.tasks.conformance.k8s.deploymentspec;
+
+import java.util.Set;
+
+import javax.persistence.EntityManager;
+
+import org.apache.log4j.Logger;
+import org.osc.core.broker.job.lock.LockObjectReference;
+import org.osc.core.broker.model.entities.virtualization.openstack.DeploymentSpec;
+import org.osc.core.broker.rest.client.k8s.KubernetesDeploymentApi;
+import org.osc.core.broker.rest.client.k8s.KubernetesPod;
+import org.osc.core.broker.service.persistence.OSCEntityManager;
+import org.osc.core.broker.service.tasks.TransactionalTask;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * This task is responsible for persisting a DAI in the OSC database for a newly found pod VNF.
+ *
+ */
+@Component(service = CreateOrUpdateK8sDAITask.class)
+public class CreateOrUpdateK8sDAITask extends TransactionalTask {
+    private static final Logger LOG = Logger.getLogger(CreateOrUpdateK8sDAITask.class);
+
+    private DeploymentSpec ds;
+
+    private KubernetesPod k8sPod;
+
+    private KubernetesDeploymentApi k8sDeploymentApi;
+
+    public CreateOrUpdateK8sDAITask create(DeploymentSpec ds, KubernetesPod k8sPod) {
+        return create(ds, k8sPod, null);
+    }
+
+    CreateOrUpdateK8sDAITask create(DeploymentSpec ds, KubernetesPod k8sPod, KubernetesDeploymentApi k8sDeploymentApi) {
+        CreateOrUpdateK8sDAITask task = new CreateOrUpdateK8sDAITask();
+        task.dbConnectionManager = this.dbConnectionManager;
+        task.txBroadcastUtil = this.txBroadcastUtil;
+        task.ds = ds;
+        task.k8sPod = k8sPod;
+        task.k8sDeploymentApi = k8sDeploymentApi;
+
+        return task;
+    }
+
+    @Override
+    public void executeTransaction(EntityManager em) throws Exception {
+        OSCEntityManager<DeploymentSpec> dsEmgr = new OSCEntityManager<DeploymentSpec>(DeploymentSpec.class, em, this.txBroadcastUtil);
+        this.ds = dsEmgr.findByPrimaryKey(this.ds.getId());
+    }
+
+    @Override
+    public String getName() {
+        return String.format("Creating the K8s deployment spec %s and pod %s", this.ds.getName(), this.k8sPod.getUid());
+    }
+
+    @Override
+    public Set<LockObjectReference> getObjects() {
+        return LockObjectReference.getObjectReferences(this.ds);
+    }
+}

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/CreateOrUpdateK8sDAITask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/CreateOrUpdateK8sDAITask.java
@@ -38,7 +38,6 @@ import org.osgi.service.component.annotations.Reference;
 
 /**
  * This task is responsible for persisting a DAI in the OSC database for a newly found pod VNF.
- *
  */
 @Component(service = CreateOrUpdateK8sDAITask.class)
 public class CreateOrUpdateK8sDAITask extends TransactionalTask {

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/CreateOrUpdateK8sDeploymentSpecMetaTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/CreateOrUpdateK8sDeploymentSpecMetaTask.java
@@ -114,7 +114,7 @@ public class CreateOrUpdateK8sDeploymentSpecMetaTask extends TransactionalMetaTa
 
     @Override
     public String getName() {
-        return String.format("Creating or updating the Kubernetes deployment spec %s", this.ds.getName());
+        return String.format("Creating or updating the Kubernetes deployment spec %s and pod %s", this.ds.getName());
     }
 
     @Override

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/CreateOrUpdateK8sDeploymentSpecMetaTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/CreateOrUpdateK8sDeploymentSpecMetaTask.java
@@ -96,20 +96,14 @@ public class CreateOrUpdateK8sDeploymentSpecMetaTask extends TransactionalMetaTa
             }
         }
 
-        boolean updateOrDelete = false;
-
         if (deployment == null) {
             this.tg.appendTask(this.createK8sDeploymentTask.create(this.ds));
-            updateOrDelete = true;
         } else if (deployment.getDesiredReplicaCount() != this.ds.getInstanceCount()){
             this.tg.appendTask(this.updateK8sDeploymentTask.create(this.ds));
-            updateOrDelete = true;
         }
 
-        if (updateOrDelete) {
-            this.tg.appendTask(this.checkK8sDeploymentStateTask.create(this.ds));
-            this.tg.appendTask(this.conformK8sDeploymentPodsMetaTask.create(this.ds));
-        }
+        this.tg.appendTask(this.checkK8sDeploymentStateTask.create(this.ds));
+        this.tg.appendTask(this.conformK8sDeploymentPodsMetaTask.create(this.ds));
     }
 
     @Override

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/CreateOrUpdateK8sDeploymentSpecMetaTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/CreateOrUpdateK8sDeploymentSpecMetaTask.java
@@ -114,7 +114,7 @@ public class CreateOrUpdateK8sDeploymentSpecMetaTask extends TransactionalMetaTa
 
     @Override
     public String getName() {
-        return String.format("Creating or updating the Kubernetes deployment spec %s and pod %s", this.ds.getName());
+        return String.format("Creating or updating the Kubernetes deployment spec %s.", this.ds.getName());
     }
 
     @Override

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/CreateOrUpdateK8sDeploymentSpecMetaTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/CreateOrUpdateK8sDeploymentSpecMetaTask.java
@@ -92,7 +92,7 @@ public class CreateOrUpdateK8sDeploymentSpecMetaTask extends TransactionalMetaTa
                 deployment = this.k8sDeploymentApi.getDeploymentById(
                         this.ds.getExternalId(),
                         this.ds.getNamespace(),
-                        CreateK8sDeploymentTask.getK8sName(this.ds));
+                        K8sUtil.getK8sName(this.ds));
             }
         }
 

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/DeleteK8sDeploymentTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/DeleteK8sDeploymentTask.java
@@ -20,7 +20,6 @@ import java.util.Set;
 
 import javax.persistence.EntityManager;
 
-import org.apache.log4j.Logger;
 import org.osc.core.broker.job.lock.LockObjectReference;
 import org.osc.core.broker.model.entities.virtualization.openstack.DeploymentSpec;
 import org.osc.core.broker.service.tasks.TransactionalTask;
@@ -28,7 +27,7 @@ import org.osgi.service.component.annotations.Component;
 
 @Component(service = DeleteK8sDeploymentTask.class)
 public class DeleteK8sDeploymentTask extends TransactionalTask {
-    private static final Logger LOG = Logger.getLogger(DeleteK8sDeploymentTask.class);
+    //private static final Logger LOG = Logger.getLogger(DeleteK8sDeploymentTask.class);
 
     private DeploymentSpec ds;
 

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/DeleteK8sDeploymentTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/DeleteK8sDeploymentTask.java
@@ -52,5 +52,4 @@ public class DeleteK8sDeploymentTask extends TransactionalTask {
     public Set<LockObjectReference> getObjects() {
         return LockObjectReference.getObjectReferences(this.ds);
     }
-
 }

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/DeleteOrCleanK8sDAITask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/DeleteOrCleanK8sDAITask.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) Intel Corporation
+ * Copyright (c) 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.osc.core.broker.service.tasks.conformance.k8s.deploymentspec;
+
+import java.util.Set;
+
+import javax.persistence.EntityManager;
+
+import org.apache.log4j.Logger;
+import org.osc.core.broker.job.lock.LockObjectReference;
+import org.osc.core.broker.model.entities.appliance.DistributedApplianceInstance;
+import org.osc.core.broker.model.entities.virtualization.openstack.DeploymentSpec;
+import org.osc.core.broker.rest.client.k8s.KubernetesDeploymentApi;
+import org.osc.core.broker.service.persistence.OSCEntityManager;
+import org.osc.core.broker.service.tasks.TransactionalTask;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * This task is responsible for deleting or cleaning up a DAI in the OSC database for a deleted pod.
+ */
+@Component(service = DeleteOrCleanK8sDAITask.class)
+public class DeleteOrCleanK8sDAITask extends TransactionalTask {
+    private static final Logger LOG = Logger.getLogger(DeleteOrCleanK8sDAITask.class);
+
+    private DeploymentSpec ds;
+
+    private DistributedApplianceInstance daiForDeletion;
+
+    private KubernetesDeploymentApi k8sDeploymentApi;
+
+    public DeleteOrCleanK8sDAITask create(DeploymentSpec ds, DistributedApplianceInstance daiForDeletion) {
+        return create(ds, daiForDeletion, null);
+    }
+
+    DeleteOrCleanK8sDAITask create(DeploymentSpec ds, DistributedApplianceInstance daiForDeletion, KubernetesDeploymentApi k8sDeploymentApi) {
+        DeleteOrCleanK8sDAITask task = new DeleteOrCleanK8sDAITask();
+        task.dbConnectionManager = this.dbConnectionManager;
+        task.txBroadcastUtil = this.txBroadcastUtil;
+        task.ds = ds;
+        task.daiForDeletion = daiForDeletion;
+        task.k8sDeploymentApi = k8sDeploymentApi;
+
+        return task;
+    }
+
+    @Override
+    public void executeTransaction(EntityManager em) throws Exception {
+        OSCEntityManager<DeploymentSpec> dsEmgr = new OSCEntityManager<DeploymentSpec>(DeploymentSpec.class, em, this.txBroadcastUtil);
+        this.ds = dsEmgr.findByPrimaryKey(this.ds.getId());
+    }
+
+    @Override
+    public String getName() {
+        return String.format("Deleting the K8s deployment spec %s and dai %s", this.ds.getName(), this.daiForDeletion.getId());
+    }
+
+    @Override
+    public Set<LockObjectReference> getObjects() {
+        return LockObjectReference.getObjectReferences(this.ds);
+    }
+}

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/K8sUtil.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/K8sUtil.java
@@ -1,3 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) Intel Corporation
+ * Copyright (c) 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
 package org.osc.core.broker.service.tasks.conformance.k8s.deploymentspec;
 
 import org.osc.core.broker.model.entities.virtualization.openstack.DeploymentSpec;

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/K8sUtil.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/K8sUtil.java
@@ -1,0 +1,10 @@
+package org.osc.core.broker.service.tasks.conformance.k8s.deploymentspec;
+
+import org.osc.core.broker.model.entities.virtualization.openstack.DeploymentSpec;
+
+class K8sUtil {
+
+    static String getK8sName(DeploymentSpec ds) {
+        return ds.getName() + "_" + ds.getId();
+    }
+}

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/K8sUtil.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/K8sUtil.java
@@ -21,6 +21,6 @@ import org.osc.core.broker.model.entities.virtualization.openstack.DeploymentSpe
 class K8sUtil {
 
     static String getK8sName(DeploymentSpec ds) {
-        return ds.getName() + "_" + ds.getId();
+        return ds.getName() + "-" + ds.getId();
     }
 }

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/UpdateK8sDeploymentTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/UpdateK8sDeploymentTask.java
@@ -66,7 +66,7 @@ public class UpdateK8sDeploymentTask extends TransactionalTask {
             this.k8sDeploymentApi.updateDeploymentReplicaCount(
                     this.ds.getExternalId(),
                     this.ds.getNamespace(),
-                    CreateK8sDeploymentTask.getK8sName(this.ds),
+                    K8sUtil.getK8sName(this.ds),
                     this.ds.getInstanceCount());
 
             LOG.info(String.format("Updated the deployment in kubernetes with the K8s id %s.", this.ds.getExternalId()));

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/DeleteSvaServerTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/DeleteSvaServerTask.java
@@ -70,10 +70,10 @@ public class DeleteSvaServerTask extends TransactionalTask {
         try (Openstack4JNova nova = new Openstack4JNova(osEndPoint);
              Openstack4JNeutron neutron = new Openstack4JNeutron(osEndPoint)) {
             Server sva = null;
-            String serverId = this.dai.getOsServerId();
+            String serverId = this.dai.getExternalId();
 
             if (serverId != null) {
-                sva = nova.getServer(this.region, this.dai.getOsServerId());
+                sva = nova.getServer(this.region, this.dai.getExternalId());
             }
 
             if (sva == null) {

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OsDAIConformanceCheckMetaTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OsDAIConformanceCheckMetaTask.java
@@ -161,8 +161,8 @@ public class OsDAIConformanceCheckMetaTask extends TransactionalMetaTask {
         try (Openstack4JNova nova = new Openstack4JNova(endPoint)) {
 
             Server sva = null;
-            if (this.dai.getOsServerId() != null) {
-                sva = nova.getServer(ds.getRegion(), this.dai.getOsServerId());
+            if (this.dai.getExternalId() != null) {
+                sva = nova.getServer(ds.getRegion(), this.dai.getExternalId());
             }
 
             // Attempt to lookup SVA by name

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OsSvaCheckFloatingIpTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OsSvaCheckFloatingIpTask.java
@@ -82,7 +82,7 @@ public class OsSvaCheckFloatingIpTask extends TransactionalMetaTask {
                 Network floatingPoolNetwork = neutron.getNetworkByName(ds.getRegion(), ds.getFloatingIpPoolName());
                 // Floating ip is invalid or has never been assigned to this sva for some reason, try adding it now.
                 NetFloatingIP allocatedFloatingIp = neutron.createFloatingIp(ds.getRegion(),
-                        floatingPoolNetwork.getId(), this.dai.getOsServerId(), this.dai.getMgmtOsPortId());
+                        floatingPoolNetwork.getId(), this.dai.getExternalId(), this.dai.getMgmtOsPortId());
                 this.dai.setIpAddress(allocatedFloatingIp.getFloatingIpAddress());
                 this.dai.setFloatingIpId(allocatedFloatingIp.getId());
                 this.log.info("Dai: " + this.dai + " Ip Address set to: " + allocatedFloatingIp);

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OsSvaCheckNetworkInfoTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OsSvaCheckNetworkInfoTask.java
@@ -121,7 +121,7 @@ public class OsSvaCheckNetworkInfoTask extends TransactionalMetaTask {
     private Port getMgmtPort(DeploymentSpec ds, Network mgmgNetwork, Subnet mgmtSubnet, DistributedApplianceInstance dai, Openstack4JNeutron neutron) {
         List<Port> ports = neutron.listPortsBySubnet(ds.getRegion(), ds.getProjectId(), mgmgNetwork.getId(), mgmtSubnet.getId(), false);
         for (Port port : ports) {
-            if (port.getDeviceId().equals(dai.getOsServerId())) {
+            if (port.getDeviceId().equals(dai.getExternalId())) {
                 return port;
             }
         }

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OsSvaEnsureActiveTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OsSvaEnsureActiveTask.java
@@ -51,7 +51,7 @@ public class OsSvaEnsureActiveTask extends TransactionalTask {
     public void executeTransaction(EntityManager em) throws Exception {
         this.dai = DistributedApplianceInstanceEntityMgr.findById(em, this.dai.getId());
 
-        String osServerId = this.dai.getOsServerId();
+        String osServerId = this.dai.getExternalId();
         DeploymentSpec ds = this.dai.getDeploymentSpec();
         VirtualizationConnector vc = ds.getVirtualSystem().getVirtualizationConnector();
 

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OsSvaServerCreateTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OsSvaServerCreateTask.java
@@ -197,7 +197,7 @@ public class OsSvaServerCreateTask extends TransactionalTask {
             }
         }
 
-        this.log.info("Dai: " + this.dai + " Server Id set to: " + this.dai.getOsServerId());
+        this.log.info("Dai: " + this.dai + " Server Id set to: " + this.dai.getExternalId());
 
         OSCEntityManager.update(em, this.dai, this.txBroadcastUtil);
     }

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OsSvaStateCheckTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OsSvaStateCheckTask.java
@@ -53,10 +53,10 @@ public class OsSvaStateCheckTask extends TransactionalTask {
 
         Endpoint endPoint = new Endpoint(ds);
         try (Openstack4JNova nova = new Openstack4JNova(endPoint)) {
-            Server serverDAI = nova.getServer(ds.getRegion(), this.dai.getOsServerId());
+            Server serverDAI = nova.getServer(ds.getRegion(), this.dai.getExternalId());
             // Check is SVA is Shut off
             if (serverDAI.getStatus().equals(Server.Status.SHUTOFF)) {
-                boolean isStarted = nova.startServer(ds.getRegion(), this.dai.getOsServerId());
+                boolean isStarted = nova.startServer(ds.getRegion(), this.dai.getExternalId());
                 this.log.info("SVA found in SHUTOFF state we will try to start it ... Is SVA started successfully: " + isStarted);
             }
         }

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/VmPortHookCheckTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/VmPortHookCheckTask.java
@@ -186,7 +186,7 @@ public class VmPortHookCheckTask extends TransactionalMetaTask {
             }
 
             this.vdc.discover(assignedRedirectedDai.getDeploymentSpec().getRegion(),
-                    assignedRedirectedDai.getOsServerId());
+                    assignedRedirectedDai.getExternalId());
 
             this.log.info("Checking Inspection Hook for Security group Member: " + this.sgm.getMemberName());
 

--- a/osc-server/src/main/java/org/osc/core/broker/util/db/upgrade/ReleaseUpgradeMgr.java
+++ b/osc-server/src/main/java/org/osc/core/broker/util/db/upgrade/ReleaseUpgradeMgr.java
@@ -243,6 +243,8 @@ public class ReleaseUpgradeMgr {
                 upgrade86to87(stmt);
             case 87:
                 upgrade87to88(stmt);
+            case 88:
+                upgrade88to89(stmt);
             case TARGET_DB_VERSION:
                 if (curDbVer < TARGET_DB_VERSION) {
                     execSql(stmt, "UPDATE RELEASE_INFO SET db_version = " + TARGET_DB_VERSION + " WHERE id = 1;");
@@ -254,7 +256,11 @@ public class ReleaseUpgradeMgr {
         }
     }
 
-
+    private static void upgrade88to89(Statement stmt) throws SQLException {
+        execSql(stmt, "alter table DISTRIBUTED_APPLIANCE_INSTANCE DROP COLUMN IF EXISTS external_id;");
+        execSql(stmt, "alter table DISTRIBUTED_APPLIANCE_INSTANCE alter column os_server_id RENAME TO " + "external_id;");
+    }
+    
     private static void upgrade87to88(Statement stmt) throws SQLException {
         execSql(stmt, "alter table DEPLOYMENT_SPEC add column port_group_id varchar(255) " +
                       "after inspection_network_id;");

--- a/osc-server/src/main/java/org/osc/core/broker/util/db/upgrade/Schema.java
+++ b/osc-server/src/main/java/org/osc/core/broker/util/db/upgrade/Schema.java
@@ -162,7 +162,6 @@ public class Schema {
                 "virtual_system_fk bigint not null," +
                 "os_host_name varchar(255)," +
                 "os_availability_zone_name varchar(255)," +
-                "os_server_id varchar(255)," +
                 "inspection_os_ingress_port_id varchar(255)," +
                 "inspection_ingress_mac_address varchar(255)," +
                 "inspection_os_egress_port_id varchar(255)," +

--- a/osc-server/src/test/java/org/osc/core/broker/rest/client/k8s/KubernetesDeploymentApiTest.java
+++ b/osc-server/src/test/java/org/osc/core/broker/rest/client/k8s/KubernetesDeploymentApiTest.java
@@ -46,6 +46,7 @@ import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.extensions.Deployment;
 import io.fabric8.kubernetes.api.model.extensions.DeploymentList;
 import io.fabric8.kubernetes.api.model.extensions.DeploymentSpec;
+import io.fabric8.kubernetes.api.model.extensions.DeploymentStatus;
 import io.fabric8.kubernetes.api.model.extensions.DoneableDeployment;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
@@ -383,6 +384,10 @@ public class KubernetesDeploymentApiTest {
         deployment.setMetadata(objMeta);
         deployment.setSpec(spec);
 
+        DeploymentStatus deploymentStatus = new DeploymentStatus();
+        deploymentStatus.setAvailableReplicas(3);
+        deployment.setStatus(deploymentStatus);
+
         return deployment;
     }
 
@@ -391,6 +396,7 @@ public class KubernetesDeploymentApiTest {
         assertEquals("The deployment namespace was different than the expected.", expectedDeployment.getMetadata().getNamespace(), actualDeployment.getNamespace());
         assertEquals("The deployment uid was different than the expected.", expectedDeployment.getMetadata().getUid(), actualDeployment.getUid());
         assertEquals("The deployment replica count was different than the expected.", (int) expectedDeployment.getSpec().getReplicas(), actualDeployment.getDesiredReplicaCount());
+        assertEquals("The deployment available replica count was different than the expected.", (int) expectedDeployment.getStatus().getAvailableReplicas(), actualDeployment.getAvailableReplicaCount());
     }
 
     private enum DeploymentOperation  {

--- a/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/CheckK8sDeploymentStateTaskTest.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/CheckK8sDeploymentStateTaskTest.java
@@ -196,7 +196,7 @@ public class CheckK8sDeploymentStateTaskTest  {
                                     return unavailableK8sDeployment;
                                 }
                             }
-                        });;
+                        });
     }
 
     private DeploymentSpec createDS() {

--- a/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/CheckK8sDeploymentStateTaskTest.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/CheckK8sDeploymentStateTaskTest.java
@@ -1,0 +1,223 @@
+/*******************************************************************************
+ * Copyright (c) Intel Corporation
+ * Copyright (c) 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.osc.core.broker.service.tasks.conformance.k8s.deploymentspec;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+
+import java.util.UUID;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityTransaction;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Answers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.osc.core.broker.model.entities.appliance.ApplianceSoftwareVersion;
+import org.osc.core.broker.model.entities.appliance.VirtualSystem;
+import org.osc.core.broker.model.entities.virtualization.VirtualizationConnector;
+import org.osc.core.broker.model.entities.virtualization.openstack.DeploymentSpec;
+import org.osc.core.broker.rest.client.k8s.KubernetesDeployment;
+import org.osc.core.broker.rest.client.k8s.KubernetesDeploymentApi;
+import org.osc.core.broker.service.exceptions.VmidcException;
+import org.osc.core.broker.util.TransactionalBroadcastUtil;
+import org.osc.core.broker.util.db.DBConnectionManager;
+import org.osc.core.test.util.TestTransactionControl;
+
+public class CheckK8sDeploymentStateTaskTest  {
+    @Mock
+    protected EntityManager em;
+
+    @Mock
+    protected EntityTransaction tx;
+
+    @Mock(answer = Answers.CALLS_REAL_METHODS)
+    TestTransactionControl txControl;
+
+    @Mock
+    DBConnectionManager dbMgr;
+
+    @Mock
+    TransactionalBroadcastUtil txBroadcastUtil;
+
+    @Mock
+    private KubernetesDeploymentApi k8sDeploymentApi;
+
+    @InjectMocks
+    CheckK8sDeploymentStateTask factory;
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Before
+    public void testInitialize() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        when(this.em.getTransaction()).thenReturn(this.tx);
+
+        this.txControl.setEntityManager(this.em);
+
+        Mockito.when(this.dbMgr.getTransactionalEntityManager()).thenReturn(this.em);
+        Mockito.when(this.dbMgr.getTransactionControl()).thenReturn(this.txControl);
+    }
+
+    @Test
+    public void testExecute_WhenGetDeploymentReturnsNull_ThrowsVmidcException() throws Exception {
+        // Arrange.
+        DeploymentSpec ds = createDS();
+        when(this.em.find(DeploymentSpec.class, ds.getId())).thenReturn(ds);
+        registerKubernetesDeployment(ds, null);
+
+        CheckK8sDeploymentStateTask task = this.factory.create(ds, this.k8sDeploymentApi);
+        this.exception.expect(VmidcException.class);
+        this.exception.expectMessage("Kubernetes returned a null deployment");
+
+        // Act.
+        task.execute();
+    }
+
+    @Test
+    public void testExecute_WhenGetDeploymentNeverReturnsExpectedInstanceCount_ThrowsVmidcException() throws Exception {
+        // Arrange.
+        DeploymentSpec ds = createDS();
+        when(this.em.find(DeploymentSpec.class, ds.getId())).thenReturn(ds);
+
+        KubernetesDeployment k8sDeployment = Mockito.mock(KubernetesDeployment.class);
+        when(k8sDeployment.getAvailableReplicaCount()).thenReturn(ds.getInstanceCount() - 1);
+
+        registerKubernetesDeployment(ds, k8sDeployment);
+        int numberOfRetries = 4;
+        int retryInterval = 1;
+
+        CheckK8sDeploymentStateTask task = this.factory.create(ds, this.k8sDeploymentApi);
+        task.MAX_RETRIES = numberOfRetries;
+        task.RETRY_INTERVAL__MILLISECONDS = retryInterval;
+        this.exception.expect(VmidcException.class);
+        this.exception.expectMessage("The Kubernetes deployment failed to reach the desired replica count");
+
+        // Act.
+        task.execute();
+
+        // Assert.
+        verify(this.k8sDeploymentApi.getDeploymentById(anyString(), anyString(), anyString()), times(numberOfRetries));
+    }
+
+    @Test
+    public void testExecute_WhenGetDeploymentReturnsExpectedCount_SucceedsInFirstAttempt() throws Exception {
+        // Arrange.
+        DeploymentSpec ds = createDS();
+        when(this.em.find(DeploymentSpec.class, ds.getId())).thenReturn(ds);
+
+        KubernetesDeployment k8sDeployment = Mockito.mock(KubernetesDeployment.class);
+        when(k8sDeployment.getAvailableReplicaCount()).thenReturn(ds.getInstanceCount());
+
+        registerKubernetesDeployment(ds, k8sDeployment);
+
+        CheckK8sDeploymentStateTask task = this.factory.create(ds, this.k8sDeploymentApi);
+
+        // Act.
+        task.execute();
+
+        // Assert.
+        verify(this.k8sDeploymentApi, times(1)).getDeploymentById(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    public void testExecute_WhenGetDeploymentReturnsExpectedLastAttempt_SucceedsInLastAttempt() throws Exception {
+        // Arrange.
+        DeploymentSpec ds = createDS();
+        when(this.em.find(DeploymentSpec.class, ds.getId())).thenReturn(ds);
+        int numberOfRetries = 4;
+        int retryInterval = 1;
+
+        registerAvailableKubernetesDeploymentAfterCount(ds, numberOfRetries - 1);
+
+        CheckK8sDeploymentStateTask task = this.factory.create(ds, this.k8sDeploymentApi);
+        task.MAX_RETRIES = numberOfRetries;
+        task.RETRY_INTERVAL__MILLISECONDS = retryInterval;
+
+        // Act.
+        task.execute();
+
+        // Assert.
+        verify(this.k8sDeploymentApi, times(numberOfRetries)).getDeploymentById(anyString(), anyString(), anyString());
+    }
+
+    private void registerKubernetesDeployment(DeploymentSpec ds, KubernetesDeployment k8sDeployment) throws VmidcException {
+        when(this.k8sDeploymentApi
+                .getDeploymentById(
+                        ds.getExternalId(),
+                        ds.getNamespace(),
+                        K8sUtil.getK8sName(ds))).thenReturn(k8sDeployment);
+    }
+
+    private void registerAvailableKubernetesDeploymentAfterCount(DeploymentSpec ds, int count) throws VmidcException {
+        KubernetesDeployment unavailableK8sDeployment = Mockito.mock(KubernetesDeployment.class);
+        when(unavailableK8sDeployment.getAvailableReplicaCount())
+        .thenReturn(ds.getInstanceCount() - 1);
+
+        KubernetesDeployment availableK8sDeployment = Mockito.mock(KubernetesDeployment.class);
+        when(availableK8sDeployment.getAvailableReplicaCount())
+        .thenReturn(ds.getInstanceCount());
+
+        when(this.k8sDeploymentApi
+                .getDeploymentById(
+                        ds.getExternalId(),
+                        ds.getNamespace(),
+                        K8sUtil.getK8sName(ds))).thenAnswer(new Answer<KubernetesDeployment>() {
+                            private int i = 0;
+
+                            @Override
+                            public KubernetesDeployment answer(InvocationOnMock invocation) {
+                                if (this.i++ == count) {
+                                    return availableK8sDeployment;
+                                } else {
+                                    return unavailableK8sDeployment;
+                                }
+                            }
+                        });;
+    }
+
+    private DeploymentSpec createDS() {
+        VirtualizationConnector vc = new VirtualizationConnector();
+        vc.setProviderIpAddress("1.1.1.1");
+        VirtualSystem vs = new VirtualSystem(null);
+        vs.setVirtualizationConnector(vc);
+        vs.setId(102L);
+
+        ApplianceSoftwareVersion avs = new ApplianceSoftwareVersion();
+        avs.setImageUrl("ds-image-url");
+        avs.setImagePullSecretName("ds-pull-secret-name");
+
+        vs.setApplianceSoftwareVersion(avs);
+        DeploymentSpec ds = new DeploymentSpec(vs, null, null, null, null, null);
+        ds.setId(101L);
+        ds.setName(UUID.randomUUID().toString());
+        ds.setNamespace(UUID.randomUUID().toString());
+        ds.setExternalId(UUID.randomUUID().toString());
+        ds.setInstanceCount(5);
+
+        return ds;
+    }
+}

--- a/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/ConformK8sDeploymentPodsMetaTaskTest.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/ConformK8sDeploymentPodsMetaTaskTest.java
@@ -1,0 +1,162 @@
+/*******************************************************************************
+ * Copyright (c) Intel Corporation
+ * Copyright (c) 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.osc.core.broker.service.tasks.conformance.k8s.deploymentspec;
+
+import static org.osc.core.broker.service.tasks.conformance.k8s.deploymentspec.ConformK8sDeploymentPodsMetaTaskTestData.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import javax.persistence.EntityManager;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.mockito.Answers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.osc.core.broker.job.TaskGraph;
+import org.osc.core.broker.model.entities.appliance.DistributedApplianceInstance;
+import org.osc.core.broker.model.entities.virtualization.openstack.DeploymentSpec;
+import org.osc.core.broker.rest.client.k8s.KubernetesDeploymentApi;
+import org.osc.core.broker.rest.client.k8s.KubernetesPod;
+import org.osc.core.broker.rest.client.k8s.KubernetesPodApi;
+import org.osc.core.broker.service.exceptions.VmidcException;
+import org.osc.core.broker.service.tasks.conformance.manager.MgrCheckDevicesMetaTask;
+import org.osc.core.broker.service.test.InMemDB;
+import org.osc.core.broker.util.TransactionalBroadcastUtil;
+import org.osc.core.broker.util.db.DBConnectionManager;
+import org.osc.core.test.util.TaskGraphHelper;
+import org.osc.core.test.util.TestTransactionControl;
+
+@RunWith(Parameterized.class)
+public class ConformK8sDeploymentPodsMetaTaskTest {
+    public EntityManager em;
+
+    @Mock(answer = Answers.CALLS_REAL_METHODS)
+    private TestTransactionControl txControl;
+
+    @Mock
+    DBConnectionManager dbMgr;
+
+    @Mock
+    TransactionalBroadcastUtil txBroadcastUtil;
+
+    @InjectMocks
+    ConformK8sDeploymentPodsMetaTask factoryTask;
+
+    @Mock
+    private KubernetesPodApi k8sPodApi;
+
+    private DeploymentSpec ds;
+
+    private TaskGraph expectedGraph;
+
+    public ConformK8sDeploymentPodsMetaTaskTest(DeploymentSpec ds, TaskGraph tg) {
+        this.ds = ds;
+        this.expectedGraph = tg;
+    }
+
+    @Before
+    public void testInitialize() throws Exception{
+        MockitoAnnotations.initMocks(this);
+
+        this.em = InMemDB.getEntityManagerFactory().createEntityManager();
+
+        this.txControl.setEntityManager(this.em);
+
+        Mockito.when(this.dbMgr.getTransactionalEntityManager()).thenReturn(this.em);
+        Mockito.when(this.dbMgr.getTransactionControl()).thenReturn(this.txControl);
+
+        populateDatabase();
+
+        registerKubernetesPods(DS_NO_DAI_ORPHAN_PODS, ORPHAN_PODS);
+        registerKubernetesPods(DS_ORPHAN_DAIS_NO_PODS, new ArrayList<>());
+        List<KubernetesPod> mixedPods = new ArrayList<>();
+        mixedPods.addAll(ORPHAN_PODS);
+        mixedPods.addAll(MATCHING_PODS);
+        registerKubernetesPods(DS_SOME_ORPHAN_DAIS_SOME_ORPHAN_PODS, mixedPods);
+        registerKubernetesPods(DS_DAIS_PODS_MATCHING, MATCHING_PODS);
+    }
+
+    @After
+    public void testTearDown() {
+        InMemDB.shutdown();
+    }
+
+    private void populateDatabase() {
+        this.em.getTransaction().begin();
+
+        this.em.persist(this.ds.getVirtualSystem()
+                .getVirtualizationConnector());
+        this.em.persist(this.ds.getVirtualSystem()
+                .getDistributedAppliance().getApplianceManagerConnector());
+        this.em.persist(this.ds.getVirtualSystem()
+                .getDistributedAppliance().getAppliance());
+        this.em.persist(this.ds.getVirtualSystem().getDistributedAppliance());
+        this.em.persist(this.ds.getVirtualSystem().getApplianceSoftwareVersion());
+        this.em.persist(this.ds.getVirtualSystem().getDomain());
+        this.em.persist(this.ds.getVirtualSystem());
+        for(DistributedApplianceInstance dai : this.ds.getDistributedApplianceInstances()) {
+            this.em.persist(dai);
+        }
+
+        this.em.persist(this.ds);
+
+        this.em.getTransaction().commit();
+    }
+
+    @Test
+    public void testExecuteTransaction_WithVariousDeploymentSpecs_ExpectsCorrectTaskGraph() throws Exception {
+        // Arrange.
+        this.factoryTask.deleteOrCleanK8sDAITask = new DeleteOrCleanK8sDAITask();
+        this.factoryTask.createOrUpdateK8sDAITask = new CreateOrUpdateK8sDAITask();
+        this.factoryTask.conformK8sInspectionPortMetaTask = new ConformK8sInspectionPortMetaTask();
+        this.factoryTask.managerCheckDevicesMetaTask = new MgrCheckDevicesMetaTask();
+
+        ConformK8sDeploymentPodsMetaTask task = this.factoryTask.create(this.ds, this.k8sPodApi);
+
+        // Act.
+        task.execute();
+
+        // Assert.
+        TaskGraphHelper.validateTaskGraph(task, this.expectedGraph);
+    }
+
+    @Parameters()
+    public static Collection<Object[]> getTestData() {
+        return Arrays.asList(new Object[][] {
+            {DS_NO_DAI_ORPHAN_PODS, conformOrphanK8sPodsAsDaisGraph(DS_NO_DAI_ORPHAN_PODS)},
+            {DS_ORPHAN_DAIS_NO_PODS, conformOrphanDaisGraph(DS_ORPHAN_DAIS_NO_PODS)},
+            {DS_SOME_ORPHAN_DAIS_SOME_ORPHAN_PODS, conformOrphanDaisAndOrphanPodsGraph(DS_SOME_ORPHAN_DAIS_SOME_ORPHAN_PODS)},
+            {DS_DAIS_PODS_MATCHING, conformDaisMatchingPodsGraph(DS_DAIS_PODS_MATCHING)},
+        });
+    }
+
+    private void registerKubernetesPods(DeploymentSpec ds, List<KubernetesPod> k8sPods) throws VmidcException {
+        Mockito
+        .when(this.k8sPodApi.getPodsByLabel(KubernetesDeploymentApi.OSC_DEPLOYMENT_LABEL_NAME + "=" + K8sUtil.getK8sName(ds)))
+        .thenReturn(k8sPods);
+    }
+}

--- a/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/ConformK8sDeploymentPodsMetaTaskTestData.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/ConformK8sDeploymentPodsMetaTaskTestData.java
@@ -1,0 +1,207 @@
+/*******************************************************************************
+ * Copyright (c) Intel Corporation
+ * Copyright (c) 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.osc.core.broker.service.tasks.conformance.k8s.deploymentspec;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import org.osc.core.broker.job.TaskGraph;
+import org.osc.core.broker.model.entities.appliance.Appliance;
+import org.osc.core.broker.model.entities.appliance.ApplianceSoftwareVersion;
+import org.osc.core.broker.model.entities.appliance.DistributedAppliance;
+import org.osc.core.broker.model.entities.appliance.DistributedApplianceInstance;
+import org.osc.core.broker.model.entities.appliance.VirtualSystem;
+import org.osc.core.broker.model.entities.management.ApplianceManagerConnector;
+import org.osc.core.broker.model.entities.management.Domain;
+import org.osc.core.broker.model.entities.virtualization.VirtualizationConnector;
+import org.osc.core.broker.model.entities.virtualization.openstack.DeploymentSpec;
+import org.osc.core.broker.rest.client.k8s.KubernetesPod;
+import org.osc.core.broker.service.tasks.conformance.manager.MgrCheckDevicesMetaTask;
+import org.osc.core.common.job.TaskGuard;
+import org.osc.core.common.virtualization.VirtualizationType;
+
+public class ConformK8sDeploymentPodsMetaTaskTestData {
+    public static List<DeploymentSpec> TEST_DEPLOYMENT_SPECS = new ArrayList<>();
+
+    private static List<String> KNOWN_POD_IDS = Arrays.asList(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+
+    public static List<KubernetesPod> ORPHAN_PODS = Arrays.asList(createKubernetesPod(), createKubernetesPod(), createKubernetesPod());
+
+    public static List<KubernetesPod> MATCHING_PODS = Arrays.asList(createKubernetesPod(KNOWN_POD_IDS.get(0)), createKubernetesPod(KNOWN_POD_IDS.get(1)));
+
+    public static DeploymentSpec DS_NO_DAI_ORPHAN_PODS =
+            createDS("DS_NO_DAI_ORPHAN_PODS");
+
+    public static DeploymentSpec DS_ORPHAN_DAIS_NO_PODS =
+            createDSWithDAIs("DS_ORPHAN_DAIS_NO_PODS", 3, false);
+
+    public static DeploymentSpec DS_SOME_ORPHAN_DAIS_SOME_ORPHAN_PODS =
+            createDSWithDAIs("DS_SOME_ORPHAN_DAIS_SOME_ORPHAN_PODS", 2, true);
+
+    public static DeploymentSpec DS_DAIS_PODS_MATCHING =
+            createDSWithDAIs("DS_DAIS_PODS_MATCHING", 0, true);
+
+    public static TaskGraph conformOrphanK8sPodsAsDaisGraph(DeploymentSpec ds) {
+        TaskGraph expectedGraph = new TaskGraph();
+
+        for(KubernetesPod pod : ORPHAN_PODS) {
+            expectedGraph.addTask(new CreateOrUpdateK8sDAITask().create(ds, pod));
+        }
+
+        expectedGraph.appendTask(new ConformK8sInspectionPortMetaTask().create(ds), TaskGuard.ALL_PREDECESSORS_COMPLETED);
+        expectedGraph.appendTask(new MgrCheckDevicesMetaTask().create(ds.getVirtualSystem()), TaskGuard.ALL_PREDECESSORS_COMPLETED);
+
+        return expectedGraph;
+    }
+
+    public static TaskGraph conformOrphanDaisGraph(DeploymentSpec ds) {
+        TaskGraph expectedGraph = new TaskGraph();
+
+        for(DistributedApplianceInstance dai : ds.getDistributedApplianceInstances()) {
+            expectedGraph.addTask(new DeleteOrCleanK8sDAITask().create(ds, dai));
+        }
+
+        expectedGraph.appendTask(new ConformK8sInspectionPortMetaTask().create(ds), TaskGuard.ALL_PREDECESSORS_COMPLETED);
+        expectedGraph.appendTask(new MgrCheckDevicesMetaTask().create(ds.getVirtualSystem()), TaskGuard.ALL_PREDECESSORS_COMPLETED);
+
+        return expectedGraph;
+    }
+
+    public static TaskGraph conformOrphanDaisAndOrphanPodsGraph(DeploymentSpec ds) {
+        TaskGraph expectedGraph = new TaskGraph();
+
+        for(KubernetesPod pod : ORPHAN_PODS) {
+            expectedGraph.addTask(new CreateOrUpdateK8sDAITask().create(ds, pod));
+        }
+
+        for(DistributedApplianceInstance dai : ds.getDistributedApplianceInstances()) {
+            if (!KNOWN_POD_IDS.contains(dai.getExternalId())) {
+                expectedGraph.addTask(new DeleteOrCleanK8sDAITask().create(ds, dai));
+            }
+        }
+
+        expectedGraph.appendTask(new ConformK8sInspectionPortMetaTask().create(ds), TaskGuard.ALL_PREDECESSORS_COMPLETED);
+        expectedGraph.appendTask(new MgrCheckDevicesMetaTask().create(ds.getVirtualSystem()), TaskGuard.ALL_PREDECESSORS_COMPLETED);
+
+        return expectedGraph;
+    }
+
+    public static TaskGraph conformDaisMatchingPodsGraph(DeploymentSpec ds) {
+        TaskGraph expectedGraph = new TaskGraph();
+
+        expectedGraph.appendTask(new ConformK8sInspectionPortMetaTask().create(ds), TaskGuard.ALL_PREDECESSORS_COMPLETED);
+        expectedGraph.appendTask(new MgrCheckDevicesMetaTask().create(ds.getVirtualSystem()), TaskGuard.ALL_PREDECESSORS_COMPLETED);
+
+        return expectedGraph;
+    }
+
+    public static TaskGraph emptyDSGraph() {
+        TaskGraph expectedGraph = new TaskGraph();
+        return expectedGraph;
+    }
+
+    private static KubernetesPod createKubernetesPod() {
+        return createKubernetesPod(null);
+    }
+
+    private static KubernetesPod createKubernetesPod(String podId) {
+        KubernetesPod k8sPod = new KubernetesPod("name", "namespace", podId == null ? UUID.randomUUID().toString() : podId, "node");
+        return k8sPod;
+    }
+
+    private static void addDAIToDS(DeploymentSpec ds, String baseName, String externalId) {
+        DistributedApplianceInstance dai = new DistributedApplianceInstance(ds.getVirtualSystem());
+        dai.setDeploymentSpec(ds);
+        dai.setExternalId(externalId == null ? UUID.randomUUID().toString() : externalId);
+        dai.setName(baseName + "_DAI" + dai.getExternalId());
+
+        Set<DistributedApplianceInstance> dais = ds.getDistributedApplianceInstances();
+        dais.add(dai);
+
+        ds.setDistributedApplianceInstances(dais);
+    }
+
+    private static DeploymentSpec createDSWithDAIs(String baseName, int countOrphanDais, boolean includeMatchingDais) {
+        DeploymentSpec ds = createDS(baseName);
+
+        for (;countOrphanDais > 0; countOrphanDais--) {
+            addDAIToDS(ds, baseName, null);
+        }
+
+        if (includeMatchingDais) {
+            for (String KNOWN_POD_ID : KNOWN_POD_IDS) {
+                addDAIToDS(ds, baseName, KNOWN_POD_ID);
+            }
+        }
+
+        return ds;
+    }
+
+    private static DeploymentSpec createDS(String baseName) {
+        VirtualizationConnector vc = new VirtualizationConnector();
+        vc.setName(baseName + "_vc");
+        vc.setVirtualizationType(VirtualizationType.KUBERNETES);
+        vc.setVirtualizationSoftwareVersion("vcSoftwareVersion");
+        vc.setProviderIpAddress(baseName + "_providerIp");
+        vc.setProviderUsername("Natasha");
+        vc.setProviderPassword("********");
+
+        ApplianceManagerConnector mc = new ApplianceManagerConnector();
+        mc.setIpAddress(baseName + "_mcIp");
+        mc.setName(baseName + "_mc");
+        mc.setServiceType("foobar");
+        mc.setManagerType("buzz");
+
+        Domain domain = new Domain(mc);
+        domain.setName(baseName + "_domain");
+
+        Appliance app = new Appliance();
+        app.setManagerSoftwareVersion("fizz");
+        app.setManagerType("buzz");
+        app.setModel(baseName + "_model");
+
+        ApplianceSoftwareVersion asv = new ApplianceSoftwareVersion(app);
+        asv.setApplianceSoftwareVersion("softwareVersion");
+        asv.setImageUrl(baseName + "_image");
+        asv.setVirtualizarionSoftwareVersion(vc.getVirtualizationSoftwareVersion());
+        asv.setVirtualizationType(vc.getVirtualizationType());
+
+        DistributedAppliance da = new DistributedAppliance(mc);
+        da.setName(baseName + "_da");
+        da.setApplianceVersion("foo");
+        da.setAppliance(app);
+
+        VirtualSystem vs = new VirtualSystem(da);
+        vs.setApplianceSoftwareVersion(asv);
+        vs.setDomain(domain);
+        vs.setVirtualizationConnector(vc);
+        vs.setMarkedForDeletion(false);
+        vs.setName(baseName + "_vs");
+        vs.setMgrId(baseName + "_mgrId");
+
+        DeploymentSpec ds = new DeploymentSpec(vs, null, null, null, null, null);
+        ds.setName(baseName + "_ds");
+        ds.setNamespace(UUID.randomUUID().toString());
+        ds.setExternalId(UUID.randomUUID().toString());
+
+        TEST_DEPLOYMENT_SPECS.add(ds);
+        return ds;
+    }
+}

--- a/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/ConformK8sDeploymentPodsMetaTaskTestData.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/ConformK8sDeploymentPodsMetaTaskTestData.java
@@ -75,7 +75,7 @@ public class ConformK8sDeploymentPodsMetaTaskTestData {
         TaskGraph expectedGraph = new TaskGraph();
 
         for(DistributedApplianceInstance dai : ds.getDistributedApplianceInstances()) {
-            expectedGraph.addTask(new DeleteOrCleanK8sDAITask().create(ds, dai));
+            expectedGraph.addTask(new DeleteOrCleanK8sDAITask().create(dai));
         }
 
         expectedGraph.appendTask(new ConformK8sInspectionPortMetaTask().create(ds), TaskGuard.ALL_PREDECESSORS_COMPLETED);
@@ -93,7 +93,7 @@ public class ConformK8sDeploymentPodsMetaTaskTestData {
 
         for(DistributedApplianceInstance dai : ds.getDistributedApplianceInstances()) {
             if (!KNOWN_POD_IDS.contains(dai.getExternalId())) {
-                expectedGraph.addTask(new DeleteOrCleanK8sDAITask().create(ds, dai));
+                expectedGraph.addTask(new DeleteOrCleanK8sDAITask().create(dai));
             }
         }
 

--- a/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/CreateK8sDeploymentTaskTest.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/CreateK8sDeploymentTaskTest.java
@@ -114,7 +114,7 @@ public class CreateK8sDeploymentTaskTest  {
     }
 
     private void mockCreateK8sDeployment(DeploymentSpec ds, String k8sDeploymentId) throws Exception {
-        when(this.k8sDeploymentApi.createDeployment(argThat(new KubernetesDeploymentMatcher(CreateK8sDeploymentTask.getK8sName(ds),
+        when(this.k8sDeploymentApi.createDeployment(argThat(new KubernetesDeploymentMatcher(K8sUtil.getK8sName(ds),
                 ds.getNamespace(),
                 ds.getInstanceCount(),
                 ds.getVirtualSystem().getApplianceSoftwareVersion().getImageUrl(),

--- a/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/CreateOrUpdateK8sDAITaskTest.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/CreateOrUpdateK8sDAITaskTest.java
@@ -1,0 +1,232 @@
+/*******************************************************************************
+ * Copyright (c) Intel Corporation
+ * Copyright (c) 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.osc.core.broker.service.tasks.conformance.k8s.deploymentspec;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityTransaction;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Answers;
+import org.mockito.ArgumentMatcher;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.osc.core.broker.model.entities.appliance.ApplianceSoftwareVersion;
+import org.osc.core.broker.model.entities.appliance.DistributedApplianceInstance;
+import org.osc.core.broker.model.entities.appliance.VirtualSystem;
+import org.osc.core.broker.model.entities.virtualization.VirtualizationConnector;
+import org.osc.core.broker.model.entities.virtualization.openstack.DeploymentSpec;
+import org.osc.core.broker.model.plugin.ApiFactoryService;
+import org.osc.core.broker.rest.client.k8s.KubernetesPod;
+import org.osc.core.broker.service.exceptions.VmidcException;
+import org.osc.core.broker.util.TransactionalBroadcastUtil;
+import org.osc.core.broker.util.db.DBConnectionManager;
+import org.osc.core.test.util.TestTransactionControl;
+import org.osc.sdk.controller.DefaultNetworkPort;
+import org.osc.sdk.controller.api.SdnRedirectionApi;
+import org.osc.sdk.controller.element.NetworkElement;
+
+public class CreateOrUpdateK8sDAITaskTest  {
+    @Mock
+    protected EntityManager em;
+
+    @Mock
+    protected EntityTransaction tx;
+
+    @Mock(answer = Answers.CALLS_REAL_METHODS)
+    TestTransactionControl txControl;
+
+    @Mock
+    DBConnectionManager dbMgr;
+
+    @Mock
+    TransactionalBroadcastUtil txBroadcastUtil;
+
+    @Mock
+    public ApiFactoryService apiFactoryServiceMock;
+
+    @InjectMocks
+    CreateOrUpdateK8sDAITask factory;
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Before
+    public void testInitialize() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        when(this.em.getTransaction()).thenReturn(this.tx);
+
+        this.txControl.setEntityManager(this.em);
+
+        Mockito.when(this.dbMgr.getTransactionalEntityManager()).thenReturn(this.em);
+        Mockito.when(this.dbMgr.getTransactionControl()).thenReturn(this.txControl);
+    }
+
+    @Test
+    public void testExecute_WhenSDNReturnsNetworkElement_NoOrphanDAI_DAICreatedWithoutInspectionElementId() throws Exception {
+        // Arrange.
+        KubernetesPod k8sPod = createKubernetesPod();
+        NetworkElement podPort = createNetworkElement();
+        DeploymentSpec ds = createAndRegisterDeploymentSpec(null);
+
+        registerNetworkElement(ds, podPort, k8sPod);
+
+        CreateOrUpdateK8sDAITask task = this.factory.create(ds, k8sPod);
+
+        // Act.
+        task.execute();
+
+        // Assert.
+        verify(this.em, Mockito.times(1)).persist(Mockito.argThat(new DAIMatcher(podPort, k8sPod, null, null)));
+        verify(this.em, Mockito.never()).remove(Mockito.any(DistributedApplianceInstance.class));
+    }
+
+    @Test
+    public void testExecute_WhenSDNReturnsNetworkElement_OrphanDAI_DAICreatedWithInspectionElementId() throws Exception {
+        // Arrange.
+        KubernetesPod k8sPod = createKubernetesPod();
+        NetworkElement podPort = createNetworkElement();
+        DistributedApplianceInstance dai = new DistributedApplianceInstance();
+        dai.setInspectionElementId(UUID.randomUUID().toString());
+        dai.setInspectionElementParentId(UUID.randomUUID().toString());
+        dai.setId(101L);
+
+        DeploymentSpec ds = createAndRegisterDeploymentSpec(dai);
+
+        registerNetworkElement(ds, podPort, k8sPod);
+
+        CreateOrUpdateK8sDAITask task = this.factory.create(ds, k8sPod);
+
+        // Act.
+        task.execute();
+
+        // Assert.
+        verify(this.em, Mockito.times(1)).persist(Mockito.argThat(new DAIMatcher(podPort, k8sPod, dai.getInspectionElementId(), dai.getInspectionElementParentId())));
+        verify(this.em, Mockito.times(1)).remove(dai);
+    }
+
+    @Test
+    public void testExecute_WhenSDNReturnsNullNetworkElement_ThrowsVmidcException() throws Exception {
+        // Arrange.
+        KubernetesPod k8sPod = createKubernetesPod();
+        DeploymentSpec ds = createAndRegisterDeploymentSpec(null);
+
+        registerNetworkElement(ds, null, k8sPod);
+
+        CreateOrUpdateK8sDAITask task = this.factory.create(ds, k8sPod);
+        this.exception.expect(VmidcException.class);
+        this.exception.expectMessage("The SDN controller did not return a network element");
+
+        // Act.
+        task.execute();
+    }
+
+    private class DAIMatcher extends ArgumentMatcher<DistributedApplianceInstance> {
+        NetworkElement networkElement;
+        KubernetesPod k8sPod;
+        String inspElementId;
+        String inspElementParentId;
+
+        public DAIMatcher(NetworkElement networkElement, KubernetesPod k8sPod, String inspElementId, String inspElementParentId) {
+            this.networkElement = networkElement;
+            this.k8sPod = k8sPod;
+            this.inspElementId = inspElementId;
+            this.inspElementParentId = inspElementParentId;
+        }
+
+        @Override
+        public boolean matches(Object object) {
+            if (object == null || !(object instanceof DistributedApplianceInstance)) {
+                return false;
+            }
+
+            DistributedApplianceInstance dai = (DistributedApplianceInstance) object;
+            return dai.getOsHostName().equals(this.k8sPod.getNode()) &&
+                    dai.getName().equals(this.k8sPod.getNamespace() + "-" + this.k8sPod.getName()) &&
+                    dai.getExternalId().equals(this.k8sPod.getUid()) &&
+                    ((dai.getInspectionElementId() == null && this.inspElementId == null) ||
+                            dai.getInspectionElementId().equals(this.inspElementId)) &&
+                    ((dai.getInspectionElementParentId() == null && this.inspElementParentId == null) ||
+                            dai.getInspectionElementParentId().equals(this.inspElementParentId)) &&
+                    dai.getInspectionOsIngressPortId().equals(this.networkElement.getElementId()) &&
+                    dai.getInspectionIngressMacAddress().equals(this.networkElement.getMacAddresses().get(0)) &&
+                    dai.getIpAddress().equals(this.networkElement.getPortIPs().get(0));
+        }
+    }
+
+    private void registerNetworkElement(DeploymentSpec ds, NetworkElement networkElement, KubernetesPod k8sPod) throws Exception {
+        SdnRedirectionApi redirectionApi = Mockito.mock(SdnRedirectionApi.class);
+        when(redirectionApi.getNetworkElementByDeviceOwnerId(k8sPod.getNamespace() + ":" + k8sPod.getName())).thenReturn(networkElement);
+        when(this.apiFactoryServiceMock.createNetworkRedirectionApi(ds.getVirtualSystem())).thenReturn(redirectionApi);
+    }
+
+    private DeploymentSpec createAndRegisterDeploymentSpec(DistributedApplianceInstance dai) {
+        VirtualizationConnector vc = new VirtualizationConnector();
+        vc.setProviderIpAddress("1.1.1.1");
+        VirtualSystem vs = new VirtualSystem(null);
+        vs.setVirtualizationConnector(vc);
+        vs.setId(102L);
+
+        ApplianceSoftwareVersion avs = new ApplianceSoftwareVersion();
+        avs.setImageUrl("ds-image-url");
+        avs.setImagePullSecretName("ds-pull-secret-name");
+
+        vs.setApplianceSoftwareVersion(avs);
+        DeploymentSpec ds = new DeploymentSpec(vs, null, null, null, null, null);
+        ds.setId(101L);
+        ds.setName(UUID.randomUUID().toString());
+        ds.setNamespace("ds-namespace");
+        ds.setInstanceCount(5);
+        Set<DistributedApplianceInstance> dais = new HashSet<>();
+        if (dai!= null) {
+            dai.setDeploymentSpec(ds);
+            dais.add(dai);
+        }
+
+        ds.setDistributedApplianceInstances(dais);
+
+        when(this.em.find(DeploymentSpec.class, ds.getId())).thenReturn(ds);
+
+        return ds;
+    }
+
+    private NetworkElement createNetworkElement() {
+        DefaultNetworkPort networkPort = new DefaultNetworkPort(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        networkPort.setPortIPs(Arrays.asList(UUID.randomUUID().toString()));
+        return networkPort;
+    }
+
+    private KubernetesPod createKubernetesPod() {
+        return new KubernetesPod(
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString());
+    }
+}

--- a/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/CreateOrUpdateK8sDeploymentSpecMetaTaskTest.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/CreateOrUpdateK8sDeploymentSpecMetaTaskTest.java
@@ -146,7 +146,7 @@ public class CreateOrUpdateK8sDeploymentSpecMetaTaskTest {
             {CREATE_DS_NO_EXTERNAL_ID, createDSGraph(CREATE_DS_NO_EXTERNAL_ID)},
             {CREATE_DS_NO_K8S_DEPLOYMENT, createDSGraph(CREATE_DS_NO_K8S_DEPLOYMENT)},
             {UPDATE_DS_NEW_INSTANCE_COUNT, updateDSGraph(UPDATE_DS_NEW_INSTANCE_COUNT)},
-            {NOOP_DS_SAME_INSTANCE_COUNT, emptyDSGraph()},
+            {NOOP_DS_SAME_INSTANCE_COUNT, emptyDSGraph(NOOP_DS_SAME_INSTANCE_COUNT)},
         });
     }
 

--- a/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/CreateOrUpdateK8sDeploymentSpecMetaTaskTest.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/CreateOrUpdateK8sDeploymentSpecMetaTaskTest.java
@@ -155,6 +155,6 @@ public class CreateOrUpdateK8sDeploymentSpecMetaTaskTest {
                 .getDeploymentById(
                         ds.getExternalId(),
                         ds.getNamespace(),
-                        CreateK8sDeploymentTask.getK8sName(ds))).thenReturn(k8sDeployment);
+                        K8sUtil.getK8sName(ds))).thenReturn(k8sDeployment);
     }
 }

--- a/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/CreateOrUpdateK8sDeploymentSpecMetaTaskTestData.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/CreateOrUpdateK8sDeploymentSpecMetaTaskTestData.java
@@ -74,8 +74,10 @@ public class CreateOrUpdateK8sDeploymentSpecMetaTaskTestData {
         return expectedGraph;
     }
 
-    public static TaskGraph emptyDSGraph() {
+    public static TaskGraph emptyDSGraph(DeploymentSpec ds) {
         TaskGraph expectedGraph = new TaskGraph();
+        expectedGraph.appendTask(new CheckK8sDeploymentStateTask().create(ds));
+        expectedGraph.appendTask(new ConformK8sDeploymentPodsMetaTask().create(ds));
         return expectedGraph;
     }
 

--- a/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/DeleteOrcleanK8sDAITaskTest.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/DeleteOrcleanK8sDAITaskTest.java
@@ -1,0 +1,128 @@
+/*******************************************************************************
+ * Copyright (c) Intel Corporation
+ * Copyright (c) 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.osc.core.broker.service.tasks.conformance.k8s.deploymentspec;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityTransaction;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Answers;
+import org.mockito.ArgumentMatcher;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.osc.core.broker.model.entities.appliance.DistributedApplianceInstance;
+import org.osc.core.broker.util.TransactionalBroadcastUtil;
+import org.osc.core.broker.util.db.DBConnectionManager;
+import org.osc.core.test.util.TestTransactionControl;
+
+public class DeleteOrcleanK8sDAITaskTest  {
+    @Mock
+    protected EntityManager em;
+
+    @Mock
+    protected EntityTransaction tx;
+
+    @Mock(answer = Answers.CALLS_REAL_METHODS)
+    TestTransactionControl txControl;
+
+    @Mock
+    DBConnectionManager dbMgr;
+
+    @Mock
+    TransactionalBroadcastUtil txBroadcastUtil;
+
+    @InjectMocks
+    DeleteOrCleanK8sDAITask factory;
+
+    @Before
+    public void testInitialize() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        when(this.em.getTransaction()).thenReturn(this.tx);
+
+        this.txControl.setEntityManager(this.em);
+
+        Mockito.when(this.dbMgr.getTransactionalEntityManager()).thenReturn(this.em);
+        Mockito.when(this.dbMgr.getTransactionControl()).thenReturn(this.txControl);
+    }
+
+    @Test
+    public void testExecute_WithDAIAssignedToInspectionElement_DAICleanedOfNetworkInformation() throws Exception {
+        // Arrange.
+        DistributedApplianceInstance dai = createAndRegisterDAI(true, 100L);
+
+        DeleteOrCleanK8sDAITask task = this.factory.create(dai);
+
+        // Act.
+        task.execute();
+
+        // Assert.
+        verify(this.em, Mockito.times(1)).merge(Mockito.argThat(new CleanNetworkInfoDAIMatcher()));
+        verify(this.em, Mockito.never()).remove(Mockito.any(DistributedApplianceInstance.class));
+    }
+
+    @Test
+    public void testExecute_WithDAINotAssignedToInspectionElement_DAIDeleted() throws Exception {
+        // Arrange.
+        DistributedApplianceInstance dai = createAndRegisterDAI(false, 101L);
+
+        DeleteOrCleanK8sDAITask task = this.factory.create(dai);
+
+        // Act.
+        task.execute();
+
+        // Assert.
+        verify(this.em, Mockito.times(1)).remove(dai);
+    }
+
+    private class CleanNetworkInfoDAIMatcher extends ArgumentMatcher<DistributedApplianceInstance> {
+        @Override
+        public boolean matches(Object object) {
+            if (object == null || !(object instanceof DistributedApplianceInstance)) {
+                return false;
+            }
+
+            DistributedApplianceInstance dai = (DistributedApplianceInstance) object;
+            return dai.getInspectionOsIngressPortId() == null &&
+                    dai.getInspectionIngressMacAddress() == null &&
+                    dai.getInspectionEgressMacAddress() == null &&
+                    dai.getInspectionOsEgressPortId() == null;
+        }
+    }
+
+    private DistributedApplianceInstance createAndRegisterDAI(boolean withInspectionElement, long id) {
+        DistributedApplianceInstance dai = new DistributedApplianceInstance();
+        dai.setInspectionElementId(withInspectionElement ? UUID.randomUUID().toString() : null);
+        dai.setInspectionElementParentId(withInspectionElement ? UUID.randomUUID().toString() : null);
+        dai.setInspectionIngressMacAddress(UUID.randomUUID().toString());
+        dai.setInspectionOsIngressPortId(UUID.randomUUID().toString());
+        dai.setInspectionOsEgressPortId(UUID.randomUUID().toString());
+        dai.setInspectionEgressMacAddress(UUID.randomUUID().toString());
+        dai.setId(id);;
+
+        when(this.em.find(DistributedApplianceInstance.class, dai.getId())).thenReturn(dai);
+
+        return dai;
+    }
+}

--- a/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/DeleteOrcleanK8sDAITaskTest.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/DeleteOrcleanK8sDAITaskTest.java
@@ -119,7 +119,7 @@ public class DeleteOrcleanK8sDAITaskTest  {
         dai.setInspectionOsIngressPortId(UUID.randomUUID().toString());
         dai.setInspectionOsEgressPortId(UUID.randomUUID().toString());
         dai.setInspectionEgressMacAddress(UUID.randomUUID().toString());
-        dai.setId(id);;
+        dai.setId(id);
 
         when(this.em.find(DistributedApplianceInstance.class, dai.getId())).thenReturn(dai);
 

--- a/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/UpdateK8sDeploymentTaskTest.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/UpdateK8sDeploymentTaskTest.java
@@ -96,7 +96,6 @@ public class UpdateK8sDeploymentTaskTest  {
 
         when(this.em.find(DeploymentSpec.class, ds.getId())).thenReturn(ds);
 
-
         UpdateK8sDeploymentTask task = this.factory.create(ds, this.k8sDeploymentApi);
 
         // Act.
@@ -106,7 +105,7 @@ public class UpdateK8sDeploymentTaskTest  {
         verify(this.k8sDeploymentApi, Mockito.times(1)).updateDeploymentReplicaCount(
                 ds.getExternalId(),
                 ds.getNamespace(),
-                CreateK8sDeploymentTask.getK8sName(ds),
+                K8sUtil.getK8sName(ds),
                 ds.getInstanceCount());
     }
 }

--- a/osc-service-api/src/main/java/org/osc/core/broker/service/api/DBConnectionManagerApi.java
+++ b/osc-service-api/src/main/java/org/osc/core/broker/service/api/DBConnectionManagerApi.java
@@ -23,7 +23,7 @@ public interface DBConnectionManagerApi {
     /*
      * TARGET_DB_VERSION will be manually changed to the real target db version to which we will upgrade
      */
-    int TARGET_DB_VERSION = 88;
+    int TARGET_DB_VERSION = 89;
 
     Connection getSQLConnection() throws SQLException;
 }

--- a/osc-service-api/src/main/java/org/osc/core/broker/service/dto/DistributedApplianceInstanceDto.java
+++ b/osc-service-api/src/main/java/org/osc/core/broker/service/dto/DistributedApplianceInstanceDto.java
@@ -59,9 +59,6 @@ public class DistributedApplianceInstanceDto extends BaseDto {
     private String virtualConnectorName;
 
     @ApiModelProperty(readOnly = true)
-    private String externalId;
-
-    @ApiModelProperty(readOnly = true)
     private String inspectionElementId;
 
     @ApiModelProperty(readOnly = true)
@@ -85,9 +82,9 @@ public class DistributedApplianceInstanceDto extends BaseDto {
             readOnly = true)
     private String inspectionReady;
 
-    @ApiModelProperty(value = "The Id of the corresponding server instance on openstack.(Openstack Only)",
+    @ApiModelProperty(value = "The Id of the corresponding VNF instance deployed in the virtualization environment.",
             readOnly = true)
-    private String osVmId;
+    private String externalId;
 
     @ApiModelProperty(
             value = "The Hypervisor Host name where the server instance is running on openstack.(Openstack Only)",
@@ -148,14 +145,6 @@ public class DistributedApplianceInstanceDto extends BaseDto {
 
     public void setName(String name) {
         this.name = name;
-    }
-
-    public String getExternalId() {
-        return this.externalId;
-    }
-
-    public void setExternalId(String externalId) {
-        this.externalId = externalId;
     }
 
     public String getInspectionElementId() {
@@ -242,12 +231,12 @@ public class DistributedApplianceInstanceDto extends BaseDto {
         return this.inspectionReady;
     }
 
-    public String getOsVmId() {
-        return this.osVmId;
+    public String getExternalId() {
+        return this.externalId;
     }
 
-    public void setOsVmId(String osVmId) {
-        this.osVmId = osVmId;
+    public void setExternalId(String externalId) {
+        this.externalId = externalId;
     }
 
     public String getOsHostname() {
@@ -308,7 +297,7 @@ public class DistributedApplianceInstanceDto extends BaseDto {
                 + this.applianceManagerConnectorName + ", virtualConnectorName=" + this.virtualConnectorName
                 + ", hostname=" + this.hostname + ", lastStatus="
                 + this.lastStatus + ", discovered=" + this.discovered + ", inspectionReady=" + this.inspectionReady
-                + ", osVmId=" + this.osVmId + ", osHostname=" + this.osHostname + ", osInspectionIngressPortId="
+                + ", osVmId=" + this.externalId + ", osHostname=" + this.osHostname + ", osInspectionIngressPortId="
                 + this.osInspectionIngressPortId + ", osInspectionIngressMacAddress="
                 + this.osInspectionIngressMacAddress + ", osInspectionEgressPortId=" + this.osInspectionEgressPortId
                 + ", osInspectionEgressMacAddress=" + this.osInspectionEgressMacAddress + ", mgmtIpAddress="


### PR DESCRIPTION
1. Tasks and MetaTasks for synchronizing K8s DAIS. See https://github.com/opensecuritycontroller/community/blob/master/designs/containers/vnf-deployment/vnf-deployment.md#osc-synchronization-tasks  
2. Enables the synchronization of the DS when one is created and updated.
3. Adds a DS sync API.
4. Rename the current DAI column osserverid to externalid and drops the previous external id column. 