### PR TITLE
Update OSC code for SDN controller API changes

### DIFF
--- a/osc-domain/src/main/java/org/osc/core/broker/model/entities/virtualization/SecurityGroupMember.java
+++ b/osc-domain/src/main/java/org/osc/core/broker/model/entities/virtualization/SecurityGroupMember.java
@@ -157,7 +157,7 @@ public class SecurityGroupMember extends BaseEntity {
         }
     }
 
-    public Set<VMPort> getPorts() {
+    public Set<VMPort> getVmPorts() {
         Set<VMPort> ports = new HashSet<>();
         if (this.type == SecurityGroupMemberType.VM) {
             ports = this.vm.getPorts();

--- a/osc-domain/src/main/java/org/osc/core/broker/model/entities/virtualization/SecurityGroupMember.java
+++ b/osc-domain/src/main/java/org/osc/core/broker/model/entities/virtualization/SecurityGroupMember.java
@@ -18,6 +18,9 @@ package org.osc.core.broker.model.entities.virtualization;
 
 import static org.osc.core.broker.model.entities.virtualization.SecurityGroupMemberType.*;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -35,6 +38,7 @@ import org.osc.core.broker.model.entities.virtualization.openstack.Network;
 import org.osc.core.broker.model.entities.virtualization.openstack.OsProtectionEntity;
 import org.osc.core.broker.model.entities.virtualization.openstack.Subnet;
 import org.osc.core.broker.model.entities.virtualization.openstack.VM;
+import org.osc.core.broker.model.entities.virtualization.openstack.VMPort;
 
 @SuppressWarnings("serial")
 @Entity
@@ -151,5 +155,19 @@ public class SecurityGroupMember extends BaseEntity {
         default:
             return null;
         }
+    }
+
+    public Set<VMPort> getPorts() {
+        Set<VMPort> ports = new HashSet<>();
+        if (this.type == SecurityGroupMemberType.VM) {
+            ports = this.vm.getPorts();
+        } else if (this.type == SecurityGroupMemberType.NETWORK) {
+            ports = this.network.getPorts();
+        } else if (this.type == SecurityGroupMemberType.SUBNET) {
+            ports = this.subnet.getPorts();
+        } else {
+            throw new IllegalArgumentException("VMPorts are only applicable to VM, Network and Subnet types!");
+        }
+        return ports;
     }
 }

--- a/osc-domain/src/main/java/org/osc/core/broker/model/entities/virtualization/openstack/VMPort.java
+++ b/osc-domain/src/main/java/org/osc/core/broker/model/entities/virtualization/openstack/VMPort.java
@@ -50,6 +50,9 @@ public class VMPort extends BaseEntity {
     @Column(name = "mac_address", nullable = false, unique = true)
     private String macAddress;
 
+    @Column(name = "inspection_hook_id", nullable = true)
+    private String inspectionHookId;
+
     @ElementCollection(fetch = FetchType.LAZY)
     @Column(name = "ip_address")
     @CollectionTable(name = "VM_PORT_IP_ADDRESS", joinColumns = @JoinColumn(name = "vm_port_fk"),
@@ -134,6 +137,14 @@ public class VMPort extends BaseEntity {
 
     void setMacAddress(String macAddress) {
         this.macAddress = macAddress;
+    }
+
+    public String getInspectionHookId() {
+        return this.inspectionHookId;
+    }
+
+    public void setInspectionHookId(String inspectionHookId) {
+        this.inspectionHookId = inspectionHookId;
     }
 
     public void setVm(VM vm) {

--- a/osc-server/src/main/java/org/osc/core/broker/service/persistence/SecurityGroupMemberEntityMgr.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/persistence/SecurityGroupMemberEntityMgr.java
@@ -98,7 +98,7 @@ public class SecurityGroupMemberEntityMgr {
             PortDto portDto = new PortDto(portEntity.getId(),
                     portEntity.getOpenstackId(),
                     portEntity.getMacAddresses().get(0),
-                    portEntity.getPortIPs());
+                    portEntity.getPortIPs(), portEntity.getInspectionHookId());
             portDtos.add(portDto);
         }
 

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OpenstackUtil.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OpenstackUtil.java
@@ -43,7 +43,6 @@ import org.osc.core.broker.model.entities.appliance.VirtualSystem;
 import org.osc.core.broker.model.entities.events.SystemFailureType;
 import org.osc.core.broker.model.entities.virtualization.SecurityGroup;
 import org.osc.core.broker.model.entities.virtualization.SecurityGroupMember;
-import org.osc.core.broker.model.entities.virtualization.SecurityGroupMemberType;
 import org.osc.core.broker.model.entities.virtualization.VirtualizationConnector;
 import org.osc.core.broker.model.entities.virtualization.openstack.DeploymentSpec;
 import org.osc.core.broker.model.entities.virtualization.openstack.VM;
@@ -108,13 +107,7 @@ public class OpenstackUtil {
 
     public static VMPort getAnyProtectedPort(SecurityGroup sg) {
         for (SecurityGroupMember sgm : sg.getSecurityGroupMembers()) {
-            if (sgm.getType() == SecurityGroupMemberType.VM) {
-                return sgm.getVm().getPorts().iterator().next();
-            } else if (sgm.getType() == SecurityGroupMemberType.NETWORK) {
-                return sgm.getNetwork().getPorts().iterator().next();
-            } else if (sgm.getType() == SecurityGroupMemberType.SUBNET) {
-                return sgm.getSubnet().getPorts().iterator().next();
-            }
+            return sgm.getPorts().iterator().next();
         }
 
         return null;
@@ -251,20 +244,7 @@ public class OpenstackUtil {
 
     public static List<NetworkElement> getPorts(SecurityGroupMember sgm) throws VmidcBrokerValidationException {
 
-        Set<VMPort> ports;
-        switch (sgm.getType()) {
-            case VM:
-                ports = sgm.getVm().getPorts();
-                break;
-            case NETWORK:
-                ports = sgm.getNetwork().getPorts();
-                break;
-            case SUBNET:
-                ports = sgm.getSubnet().getPorts();
-                break;
-            default:
-                throw new VmidcBrokerValidationException("Region is not applicable for Members of type '" + sgm.getType() + "'");
-        }
+        Set<VMPort> ports = sgm.getPorts();
 
         return ports.stream()
                 .map(NetworkElementImpl::new)

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OpenstackUtil.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OpenstackUtil.java
@@ -107,7 +107,7 @@ public class OpenstackUtil {
 
     public static VMPort getAnyProtectedPort(SecurityGroup sg) {
         for (SecurityGroupMember sgm : sg.getSecurityGroupMembers()) {
-            return sgm.getPorts().iterator().next();
+            return sgm.getVmPorts().iterator().next();
         }
 
         return null;
@@ -244,7 +244,7 @@ public class OpenstackUtil {
 
     public static List<NetworkElement> getPorts(SecurityGroupMember sgm) throws VmidcBrokerValidationException {
 
-        Set<VMPort> ports = sgm.getPorts();
+        Set<VMPort> ports = sgm.getVmPorts();
 
         return ports.stream()
                 .map(NetworkElementImpl::new)

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/CheckPortGroupHookMetaTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/CheckPortGroupHookMetaTask.java
@@ -154,7 +154,7 @@ public final class CheckPortGroupHookMetaTask extends TransactionalMetaTask {
         for (SecurityGroupMember sgm : this.sgi.getSecurityGroup().getSecurityGroupMembers()) {
             // If SGM is marked for deletion, previous tasks should have removed the hooks and deleted the member from D.
             if (!sgm.getMarkedForDeletion()) {
-                return sgm.getPorts().iterator().next();
+                return sgm.getVmPorts().iterator().next();
             }
         }
 

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/CheckPortGroupHookMetaTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/CheckPortGroupHookMetaTask.java
@@ -154,13 +154,7 @@ public final class CheckPortGroupHookMetaTask extends TransactionalMetaTask {
         for (SecurityGroupMember sgm : this.sgi.getSecurityGroup().getSecurityGroupMembers()) {
             // If SGM is marked for deletion, previous tasks should have removed the hooks and deleted the member from D.
             if (!sgm.getMarkedForDeletion()) {
-                if (sgm.getType() == SecurityGroupMemberType.VM) {
-                    return sgm.getVm().getPorts().iterator().next();
-                } else if (sgm.getType() == SecurityGroupMemberType.NETWORK) {
-                    return sgm.getNetwork().getPorts().iterator().next();
-                } else if (sgm.getType() == SecurityGroupMemberType.SUBNET) {
-                    return sgm.getSubnet().getPorts().iterator().next();
-                }
+                return sgm.getPorts().iterator().next();
             }
         }
 

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/CreatePortGroupHookTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/CreatePortGroupHookTask.java
@@ -16,8 +16,6 @@
  *******************************************************************************/
 package org.osc.core.broker.service.tasks.conformance.openstack.securitygroup;
 
-import java.util.Arrays;
-
 import javax.persistence.EntityManager;
 
 import org.apache.log4j.Logger;
@@ -55,6 +53,7 @@ public final class CreatePortGroupHookTask extends BasePortGroupHookTask {
         super(sgi, dai);
     }
 
+    @Override
     public CreatePortGroupHookTask create(SecurityGroupInterface sgi, DistributedApplianceInstance dai){
         CreatePortGroupHookTask task = new CreatePortGroupHookTask(sgi, dai);
 
@@ -71,7 +70,7 @@ public final class CreatePortGroupHookTask extends BasePortGroupHookTask {
         String inspectionHookId = null;
         //Element object in DefaultInspectionPort is not used , hence null
         try (SdnRedirectionApi redirection = this.apiFactoryService.createNetworkRedirectionApi(getSGI().getVirtualSystem())) {
-            inspectionHookId = redirection.installInspectionHook(Arrays.asList(getPortGroup()),
+            inspectionHookId = redirection.installInspectionHook(getPortGroup(),
                     new DefaultInspectionPort(getIngressPort(), getEgressPort(), null),
                     getSGI().getTagValue(), null,
                     getSGI().getOrder(), null);

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/CreatePortGroupTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/CreatePortGroupTask.java
@@ -69,19 +69,19 @@ public class CreatePortGroupTask extends TransactionalTask {
                     this.securityGroup.getProjectName(), this.securityGroup.getName()));
         }
 
-        SdnRedirectionApi controller = this.apiFactoryService.createNetworkRedirectionApi(
-                this.securityGroup.getVirtualizationConnector());
-        if (CollectionUtils.isNotEmpty(protectedPorts)) {
-            for (NetworkElement vmPort : protectedPorts) {
-                ((NetworkElementImpl) vmPort).setParentId(domainId);
+        try (SdnRedirectionApi controller = this.apiFactoryService
+                .createNetworkRedirectionApi(this.securityGroup.getVirtualizationConnector())) {
+            if (CollectionUtils.isNotEmpty(protectedPorts)) {
+                for (NetworkElement vmPort : protectedPorts) {
+                    ((NetworkElementImpl) vmPort).setParentId(domainId);
+                }
+                NetworkElement portGp = controller.registerNetworkElement(protectedPorts);
+                if (portGp == null) {
+                    throw new Exception("RegisterNetworkElement failed to return PortGroup");
+                }
+                this.securityGroup.setNetworkElementId(portGp.getElementId());
+                em.merge(this.securityGroup);
             }
-            NetworkElement portGp = controller.registerNetworkElement(protectedPorts);
-            if (portGp == null) {
-                throw new Exception("RegisterNetworkElement failed to return PortGroup");
-            }
-            this.securityGroup.setNetworkElementId(portGp.getElementId());
-            em.merge(this.securityGroup);
-
         }
     }
 

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/SecurityGroupMemberAllHooksRemoveTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/SecurityGroupMemberAllHooksRemoveTask.java
@@ -61,7 +61,7 @@ public class SecurityGroupMemberAllHooksRemoveTask extends TransactionalTask {
     public void executeTransaction(EntityManager em) throws Exception {
         this.sgm = em.find(SecurityGroupMember.class, this.sgm.getId());
 
-        Set<VMPort> ports = this.sgm.getPorts();
+        Set<VMPort> ports = this.sgm.getVmPorts();
 
         this.log.info(String.format("Removing Inspection Hooks for stale %s Security Group Member '%s'",
                 this.sgm.getType(), this.sgm.getMemberName()));

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/SecurityGroupMemberHookCheckTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/SecurityGroupMemberHookCheckTask.java
@@ -85,7 +85,7 @@ public class SecurityGroupMemberHookCheckTask extends TransactionalMetaTask {
 
         this.log.info("Checking Inspection Hooks for Security group Member: " + this.sgm.getMemberName());
 
-        Set<VMPort> ports = this.sgm.getPorts();
+        Set<VMPort> ports = this.sgm.getVmPorts();
 
         boolean supportsNeutronSFC = this.apiFactoryService.supportsNeutronSFC(sg);
         for (VMPort port : ports) {

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/SecurityGroupMemberHookCheckTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/SecurityGroupMemberHookCheckTask.java
@@ -94,7 +94,7 @@ public class SecurityGroupMemberHookCheckTask extends TransactionalMetaTask {
                 this.tg.appendTask(this.vmPortAllHooksRemoveTask.create(this.sgm, port));
                 this.tg.appendTask(this.vmPortDeleteFromDbTask.create(this.sgm, port));
             } else if (supportsNeutronSFC) {
-                // Install inspection hook for each port, using sfc id. Dont need to iterate through SGI.
+                // Install/update inspection hook for each port, using sfc id. Dont need to iterate through SGI.
             } else {
                 for (SecurityGroupInterface sgi : sg.getSecurityGroupInterfaces()) {
                     if (!sgi.getMarkedForDeletion()) {

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/SecurityGroupMemberHookCheckTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/SecurityGroupMemberHookCheckTask.java
@@ -16,7 +16,6 @@
  *******************************************************************************/
 package org.osc.core.broker.service.tasks.conformance.openstack.securitygroup;
 
-import java.util.HashSet;
 import java.util.Set;
 
 import javax.persistence.EntityManager;
@@ -26,7 +25,6 @@ import org.osc.core.broker.job.TaskGraph;
 import org.osc.core.broker.model.entities.virtualization.SecurityGroup;
 import org.osc.core.broker.model.entities.virtualization.SecurityGroupInterface;
 import org.osc.core.broker.model.entities.virtualization.SecurityGroupMember;
-import org.osc.core.broker.model.entities.virtualization.SecurityGroupMemberType;
 import org.osc.core.broker.model.entities.virtualization.openstack.VMPort;
 import org.osc.core.broker.model.plugin.ApiFactoryService;
 import org.osc.core.broker.rest.client.openstack.discovery.VmDiscoveryCache;
@@ -87,23 +85,19 @@ public class SecurityGroupMemberHookCheckTask extends TransactionalMetaTask {
 
         this.log.info("Checking Inspection Hooks for Security group Member: " + this.sgm.getMemberName());
 
-        Set<VMPort> ports = new HashSet<>();
+        Set<VMPort> ports = this.sgm.getPorts();
 
-        if (this.sgm.getType() == SecurityGroupMemberType.VM) {
-            ports = this.sgm.getVm().getPorts();
-        } else if (this.sgm.getType() == SecurityGroupMemberType.NETWORK) {
-            ports = this.sgm.getNetwork().getPorts();
-        } else if (this.sgm.getType() == SecurityGroupMemberType.SUBNET) {
-            ports = this.sgm.getSubnet().getPorts();
-        }
-
+        boolean supportsNeutronSFC = this.apiFactoryService.supportsNeutronSFC(sg);
         for (VMPort port : ports) {
             if (port.getMarkedForDeletion()) {
+                // if all SGI's are marked for deletion and supportsNeutronSFC, remove all hooks else just install hook
                 this.tg.appendTask(this.vmPortAllHooksRemoveTask.create(this.sgm, port));
                 this.tg.appendTask(this.vmPortDeleteFromDbTask.create(this.sgm, port));
+            } else if (supportsNeutronSFC) {
+                // Install inspection hook for each port, using sfc id. Dont need to iterate through SGI.
             } else {
                 for (SecurityGroupInterface sgi : sg.getSecurityGroupInterfaces()) {
-                    if (!sgi.getMarkedForDeletion() && !this.apiFactoryService.supportsPortGroup(this.sgm.getSecurityGroup())) {
+                    if (!sgi.getMarkedForDeletion()) {
                         this.tg.appendTask(this.vmPortHookCheckTask.create(this.sgm, sgi, port, this.vdc),
                                 TaskGuard.ALL_PREDECESSORS_COMPLETED);
                     }

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/SecurityGroupUpdateOrDeleteMetaTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/SecurityGroupUpdateOrDeleteMetaTask.java
@@ -18,7 +18,6 @@ package org.osc.core.broker.service.tasks.conformance.openstack.securitygroup;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -236,14 +235,15 @@ public class SecurityGroupUpdateOrDeleteMetaTask extends TransactionalMetaTask {
         VmDiscoveryCache vdc = new VmDiscoveryCache(this.sg.getVirtualizationConnector(),
                 this.sg.getVirtualizationConnector().getProviderAdminProjectName());
 
+        // in case of neutron sfc, make sure the SFC is upto date and SFC has the id set.
+
         // SGM Member sync with no task deferred
         addSGMemberSyncJob(em, isDeleteTg, vdc);
 
-        if (this.sg.getVirtualizationConnector().isControllerDefined()) {
-            if (this.apiFactoryService.supportsPortGroup(this.sg)) {
-                this.tg.appendTask(this.portGroupCheckMetaTask.create(this.sg, isDeleteTg, domainId),
-                        TaskGuard.ALL_PREDECESSORS_COMPLETED);
-            }
+        if (this.sg.getVirtualizationConnector().isControllerDefined()
+                && this.apiFactoryService.supportsPortGroup(this.sg)) {
+            this.tg.appendTask(this.portGroupCheckMetaTask.create(this.sg, isDeleteTg, domainId),
+                    TaskGuard.ALL_PREDECESSORS_COMPLETED);
         }
 
         for (SecurityGroupInterface sgi : this.sg.getSecurityGroupInterfaces()) {
@@ -257,17 +257,23 @@ public class SecurityGroupUpdateOrDeleteMetaTask extends TransactionalMetaTask {
             if (sgi.getMarkedForDeletion() || isDeleteTg) {
                 VirtualSystem vs = sgi.getVirtualSystem();
                 if (this.apiFactoryService.syncsSecurityGroup(vs)) {
-                    ManagerSecurityGroupApi mgrSgApi = this.apiFactoryService.createManagerSecurityGroupApi(vs);
-                    ManagerSecurityGroupElement mepg = mgrSgApi.getSecurityGroupById(this.sg.getMgrId());
-                    if (mepg != null) {
-                        DeleteMgrSecurityGroupTask mgrSecurityGroupDelTask = this.deleteMgrSecurityGroupTask.create(vs,
-                                mepg);
-                        this.tg.appendTask(mgrSecurityGroupDelTask);
-                        tasksToSucceedToDeleteSGI.add(mgrSecurityGroupDelTask);
+                    try (ManagerSecurityGroupApi mgrSgApi = this.apiFactoryService.createManagerSecurityGroupApi(vs)) {
+                        ManagerSecurityGroupElement mepg = mgrSgApi.getSecurityGroupById(this.sg.getMgrId());
+                        if (mepg != null) {
+                            DeleteMgrSecurityGroupTask mgrSecurityGroupDelTask = this.deleteMgrSecurityGroupTask
+                                    .create(vs, mepg);
+                            this.tg.appendTask(mgrSecurityGroupDelTask);
+                            tasksToSucceedToDeleteSGI.add(mgrSecurityGroupDelTask);
+                        }
                     }
                 }
 
-                if (!this.apiFactoryService.supportsPortGroup(this.sg)) {
+                // Mostly applies only when SGI marked for deletion(not delete tg case) In delete tg case, the members
+                // are already deleted and this essentially a no op. The tasks SecurityGroupMemberVmCheckTask etc
+                // need to make sure hooks are removed in case of delete tg.
+                boolean shouldRemoveHooks = !this.apiFactoryService.supportsPortGroup(this.sg)
+                        || !this.apiFactoryService.supportsNeutronSFC(this.sg);
+                if (shouldRemoveHooks) {
                     tasksToSucceedToDeleteSGI.addAll(addSGMemberRemoveHooksTask(em, sgi));
                 }
 
@@ -313,14 +319,7 @@ public class SecurityGroupUpdateOrDeleteMetaTask extends TransactionalMetaTask {
             // If SGM is marked for deletion, previous tasks should have removed the hooks and deleted the member
             // from DB
             if (!sgm.getMarkedForDeletion()) {
-                Set<VMPort> ports = new HashSet<>();
-                if (sgm.getType() == SecurityGroupMemberType.VM) {
-                    ports = sgm.getVm().getPorts();
-                } else if (sgm.getType() == SecurityGroupMemberType.NETWORK) {
-                    ports = sgm.getNetwork().getPorts();
-                } else if (sgm.getType() == SecurityGroupMemberType.SUBNET) {
-                    ports = sgm.getSubnet().getPorts();
-                }
+                Set<VMPort> ports = sgm.getPorts();
                 for (VMPort port : ports) {
                     DistributedApplianceInstance assignedRedirectedDai = DistributedApplianceInstanceEntityMgr
                             .findByVirtualSystemAndPort(em, vs, port);

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/SecurityGroupUpdateOrDeleteMetaTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/SecurityGroupUpdateOrDeleteMetaTask.java
@@ -319,7 +319,7 @@ public class SecurityGroupUpdateOrDeleteMetaTask extends TransactionalMetaTask {
             // If SGM is marked for deletion, previous tasks should have removed the hooks and deleted the member
             // from DB
             if (!sgm.getMarkedForDeletion()) {
-                Set<VMPort> ports = sgm.getPorts();
+                Set<VMPort> ports = sgm.getVmPorts();
                 for (VMPort port : ports) {
                     DistributedApplianceInstance assignedRedirectedDai = DistributedApplianceInstanceEntityMgr
                             .findByVirtualSystemAndPort(em, vs, port);

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/UpdateDAIToSGIMembersTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/UpdateDAIToSGIMembersTask.java
@@ -26,7 +26,6 @@ import org.apache.log4j.Logger;
 import org.osc.core.broker.model.entities.appliance.DistributedApplianceInstance;
 import org.osc.core.broker.model.entities.virtualization.SecurityGroupInterface;
 import org.osc.core.broker.model.entities.virtualization.SecurityGroupMember;
-import org.osc.core.broker.model.entities.virtualization.SecurityGroupMemberType;
 import org.osc.core.broker.model.entities.virtualization.openstack.VMPort;
 import org.osc.core.broker.service.persistence.OSCEntityManager;
 import org.osc.core.broker.service.tasks.TransactionalTask;
@@ -62,13 +61,7 @@ public abstract class UpdateDAIToSGIMembersTask extends TransactionalTask {
         for (SecurityGroupMember sgm : this.sgi.getSecurityGroup().getSecurityGroupMembers()) {
             // If SGM is marked for deletion, previous tasks should have removed the hooks and deleted the member from D.
             if (!sgm.getMarkedForDeletion()) {
-                if (sgm.getType() == SecurityGroupMemberType.VM) {
-                    ports.addAll(sgm.getVm().getPorts());
-                } else if (sgm.getType() == SecurityGroupMemberType.NETWORK) {
-                    ports.addAll(sgm.getNetwork().getPorts());
-                } else if (sgm.getType() == SecurityGroupMemberType.SUBNET) {
-                    ports.addAll(sgm.getSubnet().getPorts());
-                }
+                ports.addAll(sgm.getPorts());
             }
         }
 

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/UpdateDAIToSGIMembersTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/UpdateDAIToSGIMembersTask.java
@@ -61,7 +61,7 @@ public abstract class UpdateDAIToSGIMembersTask extends TransactionalTask {
         for (SecurityGroupMember sgm : this.sgi.getSecurityGroup().getSecurityGroupMembers()) {
             // If SGM is marked for deletion, previous tasks should have removed the hooks and deleted the member from D.
             if (!sgm.getMarkedForDeletion()) {
-                ports.addAll(sgm.getPorts());
+                ports.addAll(sgm.getVmPorts());
             }
         }
 

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/VmPortAllHooksRemoveTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/VmPortAllHooksRemoveTask.java
@@ -72,9 +72,12 @@ public class VmPortAllHooksRemoveTask extends TransactionalTask {
 
         this.port.removeAllDais();
 
-        // If port group is not supported also remove the inspection hooks from the controller.
-        if (!this.apiFactoryService.supportsPortGroup(this.sgm.getSecurityGroup())) {
-            try (SdnRedirectionApi controller = this.apiFactoryService.createNetworkRedirectionApi(this.sgm)) {
+        try (SdnRedirectionApi controller = this.apiFactoryService.createNetworkRedirectionApi(this.sgm)) {
+            if (this.apiFactoryService.supportsNeutronSFC(this.sgm.getSecurityGroup())) {
+                // In case of SFC, removing the flow classifier(Inspection hook) is effectively removing all
+                // inspection hooks for that port.
+                controller.removeInspectionHook(this.port.getInspectionHookId());
+            } else {
                 controller.removeAllInspectionHooks(new NetworkElementImpl(this.port));
             }
         }

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/VmPortHookCreateTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/VmPortHookCreateTask.java
@@ -16,7 +16,6 @@
  *******************************************************************************/
 package org.osc.core.broker.service.tasks.conformance.openstack.securitygroup;
 
-import java.util.Arrays;
 import java.util.Set;
 
 import javax.persistence.EntityManager;
@@ -30,7 +29,6 @@ import org.osc.core.broker.model.entities.virtualization.openstack.VMPort;
 import org.osc.core.broker.model.plugin.ApiFactoryService;
 import org.osc.core.broker.model.plugin.sdncontroller.NetworkElementImpl;
 import org.osc.core.broker.service.tasks.TransactionalTask;
-import org.osc.core.broker.service.tasks.conformance.openstack.securitygroup.element.PortGroup;
 import org.osc.sdk.controller.DefaultInspectionPort;
 import org.osc.sdk.controller.DefaultNetworkPort;
 import org.osc.sdk.controller.FailurePolicyType;
@@ -90,21 +88,10 @@ public class VmPortHookCreateTask extends TransactionalTask {
 
             TagEncapsulationType encapsulationType = vs.getEncapsulationType() != null
                     ? TagEncapsulationType.valueOf(vs.getEncapsulationType().name()) : null;
-            if (this.apiFactoryService.supportsPortGroup(this.dai.getVirtualSystem())){
-                String portGroupId = this.securityGroupInterface.getSecurityGroup().getNetworkElementId();
-                if (portGroupId != null){
-                    PortGroup portGroup = new PortGroup();
-                    portGroup.setPortGroupId(portGroupId);
-                    controller.installInspectionHook(Arrays.asList(portGroup), new DefaultInspectionPort(ingressPort, egressPort, null),
-                            this.securityGroupInterface.getTagValue(), encapsulationType,
-                            this.securityGroupInterface.getOrder(), FailurePolicyType.valueOf(this.securityGroupInterface.getFailurePolicyType().name()));
-                }
-            } else {
-                controller.installInspectionHook(Arrays.asList(new NetworkElementImpl(this.vmPort)),
-                        new DefaultInspectionPort(ingressPort, egressPort, null),
-                        this.securityGroupInterface.getTagValue(), encapsulationType,
-                        this.securityGroupInterface.getOrder(), FailurePolicyType.valueOf(this.securityGroupInterface.getFailurePolicyType().name()));
-            }
+            controller.installInspectionHook(new NetworkElementImpl(this.vmPort),
+                    new DefaultInspectionPort(ingressPort, egressPort, null), this.securityGroupInterface.getTagValue(),
+                    encapsulationType, this.securityGroupInterface.getOrder(),
+                    FailurePolicyType.valueOf(this.securityGroupInterface.getFailurePolicyType().name()));
         } finally {
             controller.close();
         }

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/VmPortHookCreateTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/VmPortHookCreateTask.java
@@ -37,6 +37,10 @@ import org.osc.sdk.controller.api.SdnRedirectionApi;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
+/**
+ * This gets called from VmPortHookCheckTask and is tied to a specifc sgi. This should only be called in case of an
+ * sdn controller which does NOT support portgroups and SFC.
+ */
 @Component(service = VmPortHookCreateTask.class)
 public class VmPortHookCreateTask extends TransactionalTask {
 

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/VmPortHookRemoveTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/VmPortHookRemoveTask.java
@@ -16,23 +16,17 @@
  *******************************************************************************/
 package org.osc.core.broker.service.tasks.conformance.openstack.securitygroup;
 
-import java.util.Arrays;
-
 import javax.persistence.EntityManager;
 
 import org.apache.log4j.Logger;
 import org.osc.core.broker.model.entities.appliance.DistributedApplianceInstance;
 import org.osc.core.broker.model.entities.virtualization.SecurityGroupMember;
 import org.osc.core.broker.model.entities.virtualization.SecurityGroupMemberType;
-import org.osc.core.broker.model.entities.virtualization.openstack.Network;
-import org.osc.core.broker.model.entities.virtualization.openstack.Subnet;
-import org.osc.core.broker.model.entities.virtualization.openstack.VM;
 import org.osc.core.broker.model.entities.virtualization.openstack.VMPort;
 import org.osc.core.broker.model.plugin.ApiFactoryService;
 import org.osc.core.broker.model.plugin.sdncontroller.NetworkElementImpl;
 import org.osc.core.broker.service.persistence.OSCEntityManager;
 import org.osc.core.broker.service.tasks.TransactionalTask;
-import org.osc.core.broker.service.tasks.conformance.openstack.securitygroup.element.PortGroup;
 import org.osc.sdk.controller.DefaultInspectionPort;
 import org.osc.sdk.controller.DefaultNetworkPort;
 import org.osc.sdk.controller.api.SdnRedirectionApi;
@@ -73,38 +67,15 @@ public class VmPortHookRemoveTask extends TransactionalTask {
         if (this.dai != null) {
             this.dai = OSCEntityManager.loadPessimistically(em, this.dai);
 
-            VM vm = this.sgm.getVm();
-            Network network = this.sgm.getNetwork();
-            Subnet subnet = this.sgm.getSubnet();
-
-            if (this.sgm.getType() == SecurityGroupMemberType.VM && vm != null) {
-                this.log.info(String.format(
-                        "Removing Inspection Hooks for Security Group VM Member '%s' for service '%s'",
-                        this.sgm.getMemberName(), this.serviceName));
-            } else if (this.sgm.getType() == SecurityGroupMemberType.NETWORK && network != null) {
-                this.log.info(String
-                        .format("Removing Inspection Hooks for Port with mac '%s' belonging to Security Group Network Member '%s' for service '%s'",
-                                this.vmPort.getMacAddresses(), this.sgm.getMemberName(), this.serviceName));
-            } else if (this.sgm.getType() == SecurityGroupMemberType.SUBNET && subnet != null) {
-                this.log.info(String
-                        .format("Removing Inspection Hooks for Port with mac '%s' belonging to Security Group Subnet Member '%s' for service '%s'",
-                                this.vmPort.getMacAddresses(), this.sgm.getMemberName(), this.serviceName));
-            }
+            this.log.info(getTaskMessage());
 
             try (SdnRedirectionApi controller = this.apiFactoryService.createNetworkRedirectionApi(this.dai);) {
                 DefaultNetworkPort ingressPort = new DefaultNetworkPort(this.dai.getInspectionOsIngressPortId(),
                         this.dai.getInspectionIngressMacAddress());
                 DefaultNetworkPort egressPort = new DefaultNetworkPort(this.dai.getInspectionOsEgressPortId(),
                         this.dai.getInspectionEgressMacAddress());
-                if (this.apiFactoryService.supportsPortGroup(this.dai.getVirtualSystem())){
-                    String portGroupId = this.sgm.getSecurityGroup().getNetworkElementId();
-                    PortGroup portGroup = new PortGroup();
-                    portGroup.setPortGroupId(portGroupId);
-                    //Element object in DefaultInpectionPort will only be used in case of SFC , hence pass null
-                    controller.removeInspectionHook(Arrays.asList(portGroup), new DefaultInspectionPort(ingressPort, egressPort, null));
-                } else {
-                    controller.removeInspectionHook(Arrays.asList(new NetworkElementImpl(this.vmPort)), new DefaultInspectionPort(ingressPort, egressPort, null));
-                }
+                controller.removeInspectionHook(new NetworkElementImpl(this.vmPort),
+                        new DefaultInspectionPort(ingressPort, egressPort, null));
             }
             this.vmPort.removeDai(this.dai);
             OSCEntityManager.update(em, this.vmPort, this.txBroadcastUtil);
@@ -113,17 +84,21 @@ public class VmPortHookRemoveTask extends TransactionalTask {
 
     @Override
     public String getName() {
+       return getTaskMessage();
+    }
+
+    private String getTaskMessage() {
         if (this.sgm.getType() == SecurityGroupMemberType.VM && this.sgm.getVm() != null) {
             return String.format("Removing Inspection Hooks for Security Group VM Member '%s' for service '%s'",
                     this.sgm.getMemberName(), this.serviceName);
         } else if (this.sgm.getType() == SecurityGroupMemberType.NETWORK && this.sgm.getNetwork() != null) {
-            return String
-                    .format("Removing Inspection Hooks for Port with MAC '%s' belonging to Security Group Network Member '%s' for service '%s'",
-                            this.vmPort.getMacAddresses(), this.sgm.getMemberName(), this.serviceName);
+            return String.format(
+                    "Removing Inspection Hooks for Port with MAC '%s' belonging to Security Group Network Member '%s' for service '%s'",
+                    this.vmPort.getMacAddresses(), this.sgm.getMemberName(), this.serviceName);
         } else if (this.sgm.getType() == SecurityGroupMemberType.SUBNET && this.sgm.getSubnet() != null) {
-            return String
-                    .format("Removing Inspection Hooks for Port with MAC '%s' belonging to Security Group Subnet Member '%s' for service '%s'",
-                            this.vmPort.getMacAddresses(), this.sgm.getMemberName(), this.serviceName);
+            return String.format(
+                    "Removing Inspection Hooks for Port with MAC '%s' belonging to Security Group Subnet Member '%s' for service '%s'",
+                    this.vmPort.getMacAddresses(), this.sgm.getMemberName(), this.serviceName);
         }
         // We should never get here
         throw new IllegalStateException(

--- a/osc-server/src/main/java/org/osc/core/broker/util/crypto/X509TrustManagerFactory.java
+++ b/osc-server/src/main/java/org/osc/core/broker/util/crypto/X509TrustManagerFactory.java
@@ -251,7 +251,9 @@ public final class X509TrustManagerFactory implements X509TrustManager, X509Trus
     public void addEntry(X509Certificate certificate, String newAlias) throws Exception {
         if (fingerprintNotExist(getSha1Fingerprint(certificate))) {
             this.keyStore.setCertificateEntry(newAlias, certificate);
-            this.keyStore.store(new FileOutputStream(TRUSTSTORE_FILE), getTruststorePassword());
+            try (FileOutputStream outputStream = new FileOutputStream(TRUSTSTORE_FILE)) {
+                this.keyStore.store(outputStream, getTruststorePassword());
+            }
             reloadTrustManager();
             notifyTruststoreChanged();
         } else {
@@ -285,7 +287,9 @@ public final class X509TrustManagerFactory implements X509TrustManager, X509Trus
     public void removeEntry(String alias) throws Exception {
         reloadTrustManager();
         this.keyStore.deleteEntry(alias);
-        this.keyStore.store(new FileOutputStream(TRUSTSTORE_FILE), getTruststorePassword());
+        try (FileOutputStream outputStream = new FileOutputStream(TRUSTSTORE_FILE)) {
+            this.keyStore.store(outputStream, getTruststorePassword());
+        }
         notifyTruststoreChanged();
 
     }

--- a/osc-server/src/main/java/org/osc/core/broker/util/db/upgrade/ReleaseUpgradeMgr.java
+++ b/osc-server/src/main/java/org/osc/core/broker/util/db/upgrade/ReleaseUpgradeMgr.java
@@ -245,6 +245,8 @@ public class ReleaseUpgradeMgr {
                 upgrade87to88(stmt);
             case 88:
                 upgrade88to89(stmt);
+            case 89:
+                upgrade89to90(stmt);
             case TARGET_DB_VERSION:
                 if (curDbVer < TARGET_DB_VERSION) {
                     execSql(stmt, "UPDATE RELEASE_INFO SET db_version = " + TARGET_DB_VERSION + " WHERE id = 1;");
@@ -256,11 +258,16 @@ public class ReleaseUpgradeMgr {
         }
     }
 
+    private static void upgrade89to90(Statement stmt) throws SQLException {
+        execSql(stmt, "alter table VM_PORT add column inspection_hook_id varchar(255) " +
+                "after mac_address;");
+    }
+
     private static void upgrade88to89(Statement stmt) throws SQLException {
         execSql(stmt, "alter table DISTRIBUTED_APPLIANCE_INSTANCE DROP COLUMN IF EXISTS external_id;");
         execSql(stmt, "alter table DISTRIBUTED_APPLIANCE_INSTANCE alter column os_server_id RENAME TO " + "external_id;");
     }
-    
+
     private static void upgrade87to88(Statement stmt) throws SQLException {
         execSql(stmt, "alter table DEPLOYMENT_SPEC add column port_group_id varchar(255) " +
                       "after inspection_network_id;");

--- a/osc-server/src/main/java/org/osc/core/broker/util/db/upgrade/Schema.java
+++ b/osc-server/src/main/java/org/osc/core/broker/util/db/upgrade/Schema.java
@@ -667,6 +667,7 @@ public class Schema {
                 "os_network_id varchar(255) not null," +
                 "os_port_id varchar(255) not null," +
                 "mac_address varchar(255) not null," +
+                "inspection_hook_id varchar(255)," +
                 "vm_fk bigint," +
                 "network_fk bigint," +
                 "subnet_fk bigint," +

--- a/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/CreatePortGroupHookTaskTest.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/CreatePortGroupHookTaskTest.java
@@ -16,14 +16,9 @@
  *******************************************************************************/
 package org.osc.core.broker.service.tasks.conformance.openstack.securitygroup;
 
-import static org.mockito.Matchers.argThat;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isNull;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
 
-import java.util.List;
 import java.util.UUID;
 
 import org.junit.Assert;
@@ -165,7 +160,7 @@ public class CreatePortGroupHookTaskTest extends BasePortGroupHookTaskTest {
         }
     }
 
-    private class NetworkElementMatcher extends ArgumentMatcher<List<NetworkElement>> {
+    private class NetworkElementMatcher extends ArgumentMatcher<NetworkElement> {
         private SecurityGroup sg;
 
         public NetworkElementMatcher(SecurityGroup sg) {
@@ -173,12 +168,12 @@ public class CreatePortGroupHookTaskTest extends BasePortGroupHookTaskTest {
         }
 
         @Override
-        public boolean matches(Object objects) {
-            if (objects == null || !(objects instanceof List<?>)) {
+        public boolean matches(Object object) {
+            if (object == null) {
                 return false;
             }
 
-            NetworkElement netElement = (NetworkElement) ((List<?>)objects).get(0);
+            NetworkElement netElement = (NetworkElement) object;
 
             return netElement.getElementId().equals(this.sg.getNetworkElementId());
         }

--- a/osc-service-api/src/main/java/org/osc/core/broker/service/api/DBConnectionManagerApi.java
+++ b/osc-service-api/src/main/java/org/osc/core/broker/service/api/DBConnectionManagerApi.java
@@ -23,7 +23,7 @@ public interface DBConnectionManagerApi {
     /*
      * TARGET_DB_VERSION will be manually changed to the real target db version to which we will upgrade
      */
-    int TARGET_DB_VERSION = 89;
+    int TARGET_DB_VERSION = 90;
 
     Connection getSQLConnection() throws SQLException;
 }

--- a/osc-service-api/src/main/java/org/osc/core/broker/service/dto/PortDto.java
+++ b/osc-service-api/src/main/java/org/osc/core/broker/service/dto/PortDto.java
@@ -40,16 +40,22 @@ public class PortDto extends BaseDto {
     @XmlElement(name = "ipAddress")
     private Set<String> ipAddresses = new HashSet<>();
 
+    @ApiModelProperty(value = "Applicable if Port is being protected by Neutron SFC, this value corresponds to a flow"
+            + " classifier")
+    private String inspectionHookId;
+
     // Without this constructor, the result is not being returned in the xml format
     // JSON still works.
     PortDto() {
     }
 
-    public PortDto(Long id, String openStackId, String macAddress, Collection<String> ipAddresses) {
+    public PortDto(Long id, String openStackId, String macAddress, Collection<String> ipAddresses,
+            String inspectionHookId) {
         super(id);
         this.openstackId = openStackId;
         this.macAddress = macAddress;
         this.ipAddresses = new HashSet<>(ipAddresses);
+        this.inspectionHookId = inspectionHookId;
     }
 
     public Set<String> getIpAddresses() {


### PR DESCRIPTION
Updated OSC code for SDN Controller Changes https://github.com/opensecuritycontroller/sdn-controller-api/pull/36

Added inspectionHookId to vm port. This will store the flow classifier in case of networking sfc

Updated the tasks to remove checks for port group support if they are not applicable
Updated tasks to add placeholders for sfc calls once we have the entities defined on osc

**The build fails because the SDN controller api changes are not checked in.** We need to checkin these and api and plugins changes at the same time. once this code is approved, i will start the series of checkins