### PR TITLE
API Doc needs to be updated for various API's

### DIFF
--- a/osc-rest-server/src/main/java/org/osc/core/broker/rest/server/api/VirtualizationConnectorApis.java
+++ b/osc-rest-server/src/main/java/org/osc/core/broker/rest/server/api/VirtualizationConnectorApis.java
@@ -57,14 +57,13 @@ import org.osc.core.broker.service.api.UpdateServiceFunctionChainServiceApi;
 import org.osc.core.broker.service.api.UpdateVirtualizationConnectorServiceApi;
 import org.osc.core.broker.service.api.server.UserContextApi;
 import org.osc.core.broker.service.api.vc.DeleteVirtualizationConnectorServiceApi;
+import org.osc.core.broker.service.dto.BaseDto;
 import org.osc.core.broker.service.dto.SecurityGroupDto;
 import org.osc.core.broker.service.dto.SecurityGroupMemberItemDto;
 import org.osc.core.broker.service.dto.ServiceFunctionChainDto;
 import org.osc.core.broker.service.dto.VirtualSystemPolicyBindingDto;
 import org.osc.core.broker.service.dto.VirtualizationConnectorDto;
 import org.osc.core.broker.service.exceptions.ErrorCodeDto;
-import org.osc.core.broker.service.exceptions.ExceptionConstants;
-import org.osc.core.broker.service.exceptions.OscBadRequestException;
 import org.osc.core.broker.service.request.AddOrUpdateSecurityGroupRequest;
 import org.osc.core.broker.service.request.AddOrUpdateServiceFunctionChainRequest;
 import org.osc.core.broker.service.request.BaseDeleteRequest;
@@ -527,8 +526,7 @@ public class VirtualizationConnectorApis {
         logger.info("Creating Service Function Chain ...");
         this.userContext.setUser(OscAuthFilter.getUsername(headers));
         if (sfcAddRequest.getDto() == null) {
-            throw new OscBadRequestException("Dto needs to be specified",
-                    ExceptionConstants.VMIDC_VALIDATION_EXCEPTION_ERROR_CODE);
+            sfcAddRequest.setDto(new BaseDto());
         }
         this.apiUtil.setIdAndParentIdOrThrow(sfcAddRequest.getDto(), null, vcId, "Service Function Chain");
         return this.apiUtil.getResponseForBaseRequest(this.addServiceFunctionChainService, sfcAddRequest);
@@ -602,8 +600,7 @@ public class VirtualizationConnectorApis {
         logger.info("Update Service Function Chain ...");
         this.userContext.setUser(OscAuthFilter.getUsername(headers));
         if (sfcUpdateRequest.getDto() == null) {
-            throw new OscBadRequestException("Dto needs to be specified",
-                    ExceptionConstants.VMIDC_VALIDATION_EXCEPTION_ERROR_CODE);
+            sfcUpdateRequest.setDto(new BaseDto());
         }
         this.apiUtil.setIdAndParentIdOrThrow(sfcUpdateRequest.getDto(), sfcId, vcId, "Service Function Chain");
         return this.apiUtil.getResponseForBaseRequest(this.updateServiceFunctionChainService, sfcUpdateRequest);

--- a/osc-service-api/src/main/java/org/osc/core/broker/service/request/AddOrUpdateServiceFunctionChainRequest.java
+++ b/osc-service-api/src/main/java/org/osc/core/broker/service/request/AddOrUpdateServiceFunctionChainRequest.java
@@ -60,6 +60,7 @@ public class AddOrUpdateServiceFunctionChainRequest extends BaseRequest<BaseDto>
 		this.virtualSystemIds = virtualSystemIds;
 	}
 
+    // Make sure swagger hides the dto field when generating documentation
     @ApiModelProperty(hidden = true)
     @Override
     public BaseDto getDto() {

--- a/osc-service-api/src/main/java/org/osc/core/broker/service/request/AddOrUpdateServiceFunctionChainRequest.java
+++ b/osc-service-api/src/main/java/org/osc/core/broker/service/request/AddOrUpdateServiceFunctionChainRequest.java
@@ -59,4 +59,12 @@ public class AddOrUpdateServiceFunctionChainRequest extends BaseRequest<BaseDto>
 	public void setVirtualSystemIds(List<Long> virtualSystemIds) {
 		this.virtualSystemIds = virtualSystemIds;
 	}
+
+    @ApiModelProperty(hidden = true)
+    @Override
+    public BaseDto getDto() {
+        return super.getDto();
+    }
+
+
 }

--- a/osc-service-api/src/main/java/org/osc/core/broker/service/request/BaseIdRequest.java
+++ b/osc-service-api/src/main/java/org/osc/core/broker/service/request/BaseIdRequest.java
@@ -22,6 +22,8 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 import org.osc.core.broker.service.dto.BaseDto;
 
+import io.swagger.annotations.ApiModelProperty;
+
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
 public class BaseIdRequest extends BaseRequest<BaseDto> {
@@ -57,6 +59,13 @@ public class BaseIdRequest extends BaseRequest<BaseDto> {
 
     public void setParentId(long parentId) {
         this.parentId = parentId;
+    }
+
+    // Make sure swagger hides the dto field when generating documentation
+    @ApiModelProperty(hidden = true)
+    @Override
+    public BaseDto getDto() {
+        throw new UnsupportedOperationException();
     }
 
 }

--- a/osc-service-api/src/main/java/org/osc/core/broker/service/request/BaseIdRequest.java
+++ b/osc-service-api/src/main/java/org/osc/core/broker/service/request/BaseIdRequest.java
@@ -68,4 +68,11 @@ public class BaseIdRequest extends BaseRequest<BaseDto> {
         throw new UnsupportedOperationException();
     }
 
+    // Make sure swagger hides the dto field when generating documentation
+    @ApiModelProperty(hidden = true)
+    @Override
+    public boolean isApi() {
+        return super.isApi();
+    }
+
 }

--- a/osc-service-api/src/main/java/org/osc/core/broker/service/request/BaseIdRequest.java
+++ b/osc-service-api/src/main/java/org/osc/core/broker/service/request/BaseIdRequest.java
@@ -68,7 +68,7 @@ public class BaseIdRequest extends BaseRequest<BaseDto> {
         throw new UnsupportedOperationException();
     }
 
-    // Make sure swagger hides the dto field when generating documentation
+    // Make sure swagger hides the api field when generating documentation
     @ApiModelProperty(hidden = true)
     @Override
     public boolean isApi() {

--- a/osc-service-api/src/main/java/org/osc/core/broker/service/request/BaseRequest.java
+++ b/osc-service-api/src/main/java/org/osc/core/broker/service/request/BaseRequest.java
@@ -32,8 +32,8 @@ import io.swagger.annotations.ApiModelProperty;
 public class BaseRequest<T extends BaseDto> implements Request {
 
     private T dto;
-   
-    @ApiModelProperty(readOnly = true)
+
+    @ApiModelProperty(readOnly = true, hidden = true)
     @XmlElement(name = "api")
     private boolean isApi;
 

--- a/osc-service-api/src/main/java/org/osc/core/broker/service/request/BaseRequest.java
+++ b/osc-service-api/src/main/java/org/osc/core/broker/service/request/BaseRequest.java
@@ -33,7 +33,6 @@ public class BaseRequest<T extends BaseDto> implements Request {
 
     private T dto;
 
-    @ApiModelProperty(readOnly = true, hidden = true)
     @XmlElement(name = "api")
     private boolean isApi;
 
@@ -56,6 +55,8 @@ public class BaseRequest<T extends BaseDto> implements Request {
         this.dto = dto;
     }
 
+    // Make sure swagger ignores this property
+    @ApiModelProperty(readOnly = true, hidden = true)
     public boolean isApi() {
         return this.isApi;
     }


### PR DESCRIPTION
fixes #477

BaseID request already has id and name as part of its fields. 

BaseIdRequest and its subclasses dont use the getDto functionality. But because it is part of the inheritence chain API doc is generated for it incorrectly. 

also hide the isApi Field which is intended for internal use only.

Updated SFC request to not require dto since the id's are provided as part of url