### PR TITLE
Fixing bugs for the synchronization of k8s security groups

### DIFF
--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/securitygroup/CheckK8sSecurityGroupLabelMetaTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/securitygroup/CheckK8sSecurityGroupLabelMetaTask.java
@@ -63,7 +63,9 @@ public class CheckK8sSecurityGroupLabelMetaTask extends TransactionalMetaTask {
         OSCEntityManager<SecurityGroupMember> sgmEmgr = new OSCEntityManager<SecurityGroupMember>(SecurityGroupMember.class, em, this.txBroadcastUtil);
         this.sgm = sgmEmgr.findByPrimaryKey(this.sgm.getId());
 
-        if (!this.isDelete) {
+        boolean markedForDeletion = this.sgm.getMarkedForDeletion() == null ? false : this.sgm.getMarkedForDeletion();
+
+        if (!this.isDelete && !markedForDeletion) {
             this.tg.addTask(this.updateK8sSecurityGroupMemberLabelMetaTask.create(this.sgm, null));
         } else {
             this.tg.addTask(this.markSecurityGroupMemberDeleteTask.create(this.sgm));

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/securitygroup/CreateK8sLabelPodTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/securitygroup/CreateK8sLabelPodTask.java
@@ -85,25 +85,28 @@ public class CreateK8sLabelPodTask extends TransactionalTask{
             }
         }
 
-        PodPort podPort = new PodPort(
-                portElement.getElementId(),
-                portElement.getMacAddresses().get(0),
-                portElement.getPortIPs().get(0),
-                portElement.getParentId());
+        if (existingPod == null) {
+            PodPort podPort = new PodPort(
+                    portElement.getElementId(),
+                    portElement.getMacAddresses().get(0),
+                    portElement.getPortIPs().get(0),
+                    portElement.getParentId());
 
-        Pod newPod = new Pod(
-                this.k8sPod.getName(),
-                this.k8sPod.getNamespace(),
-                this.k8sPod.getNode(),
-                this.k8sPod.getUid());
+            Pod newPod = new Pod(
+                    this.k8sPod.getName(),
+                    this.k8sPod.getNamespace(),
+                    this.k8sPod.getNode(),
+                    this.k8sPod.getUid());
 
-        newPod.getPorts().add(podPort);
-        podPort.setPod(newPod);
+            newPod.getPorts().add(podPort);
+            podPort.setPod(newPod);
 
-        OSCEntityManager.create(em, podPort, this.txBroadcastUtil);
-        OSCEntityManager.create(em, newPod, this.txBroadcastUtil);
+            OSCEntityManager.create(em, podPort, this.txBroadcastUtil);
+            OSCEntityManager.create(em, newPod, this.txBroadcastUtil);
+            existingPod = newPod;
+        }
 
-        this.label.getPods().add(newPod);
+        this.label.getPods().add(existingPod);
 
         OSCEntityManager.update(em, this.label, this.txBroadcastUtil);
 

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/securitygroup/UpdateOrDeleteK8sSecurityGroupMetaTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/securitygroup/UpdateOrDeleteK8sSecurityGroupMetaTask.java
@@ -20,26 +20,26 @@ import java.util.Set;
 
 import javax.persistence.EntityManager;
 
-import org.apache.log4j.Logger;
 import org.osc.core.broker.job.TaskGraph;
 import org.osc.core.broker.job.lock.LockObjectReference;
 import org.osc.core.broker.model.entities.virtualization.SecurityGroup;
-import org.osc.core.broker.model.entities.virtualization.SecurityGroupMember;
 import org.osc.core.broker.service.persistence.OSCEntityManager;
 import org.osc.core.broker.service.tasks.TransactionalMetaTask;
+import org.osc.core.broker.service.tasks.conformance.openstack.securitygroup.DeleteSecurityGroupFromDbTask;
 import org.osc.core.broker.service.tasks.conformance.openstack.securitygroup.PortGroupCheckMetaTask;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 @Component(service = UpdateOrDeleteK8sSecurityGroupMetaTask.class)
 public class UpdateOrDeleteK8sSecurityGroupMetaTask extends TransactionalMetaTask {
-    private static final Logger LOG = Logger.getLogger(UpdateOrDeleteK8sSecurityGroupMetaTask.class);
-
     @Reference
     CheckK8sSecurityGroupLabelMetaTask checkK8sSecurityGroupLabelMetaTask;
 
     @Reference
     PortGroupCheckMetaTask portGroupCheckMetaTask;
+
+    @Reference
+    DeleteSecurityGroupFromDbTask deleteSecurityGroupFromDbTask;
 
     private SecurityGroup sg;
 
@@ -50,6 +50,7 @@ public class UpdateOrDeleteK8sSecurityGroupMetaTask extends TransactionalMetaTas
         task.sg = sg;
         task.checkK8sSecurityGroupLabelMetaTask = this.checkK8sSecurityGroupLabelMetaTask;
         task.portGroupCheckMetaTask = this.portGroupCheckMetaTask;
+        task.deleteSecurityGroupFromDbTask = this.deleteSecurityGroupFromDbTask;
         task.dbConnectionManager = this.dbConnectionManager;
         task.txBroadcastUtil = this.txBroadcastUtil;
 
@@ -76,25 +77,17 @@ public class UpdateOrDeleteK8sSecurityGroupMetaTask extends TransactionalMetaTas
 
         final boolean isDelete = this.sg.getMarkedForDeletion() == null ? false : this.sg.getMarkedForDeletion();
 
-        String domainId = null;
-
-        if (!this.sg.getSecurityGroupMembers().isEmpty()) {
-            SecurityGroupMember sgm = this.sg.getSecurityGroupMembers().iterator().next();
-
-            if (!sgm.getPodPorts().isEmpty()) {
-                domainId = sgm.getPodPorts().iterator().next().getParentId();
-            }
-        }
 
         this.sg.getSecurityGroupMembers().forEach(sgm -> {
             this.tg.addTask(this.checkK8sSecurityGroupLabelMetaTask.create(sgm, isDelete));
         });
 
-        if (domainId != null) {
-            this.tg.appendTask(this.portGroupCheckMetaTask.create(this.sg,
-                    isDelete, domainId));
-        } else {
-            LOG.info(String.format("This SG does not have any associated pods. Skipping port group sync."));
+
+        this.tg.appendTask(this.portGroupCheckMetaTask.create(this.sg,
+                isDelete, null));
+
+        if (isDelete) {
+            this.tg.appendTask(this.deleteSecurityGroupFromDbTask.create(this.sg));
         }
     }
 

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/PortGroupCheckMetaTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/PortGroupCheckMetaTask.java
@@ -20,7 +20,6 @@ import java.util.Set;
 
 import javax.persistence.EntityManager;
 
-import org.apache.log4j.Logger;
 import org.osc.core.broker.job.TaskGraph;
 import org.osc.core.broker.job.lock.LockObjectReference;
 import org.osc.core.broker.model.entities.virtualization.SecurityGroup;
@@ -31,8 +30,6 @@ import org.osgi.service.component.annotations.Reference;
 
 @Component(service=PortGroupCheckMetaTask.class)
 public class PortGroupCheckMetaTask extends TransactionalMetaTask {
-    private static final Logger LOG = Logger.getLogger(PortGroupCheckMetaTask.class);
-
     @Reference
     CreatePortGroupTask createPortGroupTask;
 
@@ -63,7 +60,6 @@ public class PortGroupCheckMetaTask extends TransactionalMetaTask {
 
     @Override
     public void executeTransaction(EntityManager em) throws Exception {
-        LOG.info("Start executing PortGroupCheckMetaTask Task. Security Group '" + this.securityGroup + "'");
         this.tg = new TaskGraph();
         this.securityGroup = em.find(SecurityGroup.class, this.securityGroup.getId());
 

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/UpdatePortGroupTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/UpdatePortGroupTask.java
@@ -64,27 +64,39 @@ public class UpdatePortGroupTask  extends TransactionalTask{
 
         Set<SecurityGroupMember> members = this.securityGroup.getSecurityGroupMembers();
         List<NetworkElement> protectedPorts = new ArrayList<>();
+        String domainId = null;
         if (this.securityGroup.getVirtualizationConnector().getVirtualizationType().isOpenstack()) {
             for (SecurityGroupMember sgm : members) {
                 protectedPorts.addAll(OpenstackUtil.getPorts(sgm));
             }
 
             // ??? how do we know all protected ports are within same domain?
-            String domainId = OpenstackUtil.extractDomainId(this.securityGroup.getProjectId(), this.securityGroup.getProjectName(),
+            domainId = OpenstackUtil.extractDomainId(this.securityGroup.getProjectId(), this.securityGroup.getProjectName(),
                     this.securityGroup.getVirtualizationConnector(), protectedPorts);
             if (domainId == null){
                 throw new Exception(String.format("Failed to retrieve domainId for given project: '%s' and Security Group: '%s",
                         this.securityGroup.getProjectName(), this.securityGroup.getName()));
             }
             this.portGroup.setParentId(domainId);
+
             for (NetworkElement elem : protectedPorts) {
                 ((NetworkElementImpl) elem).setParentId(domainId);
             }
         } else {
             for (SecurityGroupMember sgm : members) {
-                protectedPorts.addAll(getPodPorts(sgm));
+                if (domainId == null && !sgm.getPodPorts().isEmpty()) {
+                    domainId = sgm.getPodPorts().iterator().next().getParentId();
+                }
+
+                List<PodNetworkElementImpl> podPorts = getPodPorts(sgm);
+                for (PodNetworkElementImpl podPort : podPorts) {
+                    podPort.setParentId(domainId);
+                }
+
+                protectedPorts.addAll(podPorts);
             }
         }
+
         try (SdnRedirectionApi controller = this.apiFactoryService
                 .createNetworkRedirectionApi(this.securityGroup.getVirtualizationConnector())) {
             NetworkElement portGrp = controller.updateNetworkElement(this.portGroup, protectedPorts);
@@ -104,7 +116,7 @@ public class UpdatePortGroupTask  extends TransactionalTask{
         return String.format("Update Port Group for security group: %s ", this.securityGroup.getName());
     }
 
-    private static List<NetworkElement> getPodPorts(SecurityGroupMember sgm) throws VmidcBrokerValidationException {
+    private static List<PodNetworkElementImpl> getPodPorts(SecurityGroupMember sgm) throws VmidcBrokerValidationException {
         Set<PodPort> ports = sgm.getPodPorts();
         return ports.stream()
                 .map(PodNetworkElementImpl::new)

--- a/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/k8s/securitygroup/UpdateOrDeleteK8sSecurityGroupMetaTaskTest.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/k8s/securitygroup/UpdateOrDeleteK8sSecurityGroupMetaTaskTest.java
@@ -36,6 +36,7 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.osc.core.broker.job.TaskGraph;
 import org.osc.core.broker.model.entities.virtualization.SecurityGroup;
+import org.osc.core.broker.service.tasks.conformance.openstack.securitygroup.DeleteSecurityGroupFromDbTask;
 import org.osc.core.broker.service.tasks.conformance.openstack.securitygroup.PortGroupCheckMetaTask;
 import org.osc.core.broker.service.test.InMemDB;
 import org.osc.core.broker.util.TransactionalBroadcastUtil;
@@ -95,7 +96,7 @@ public class UpdateOrDeleteK8sSecurityGroupMetaTaskTest {
         // Arrange.
         this.factoryTask.checkK8sSecurityGroupLabelMetaTask = new CheckK8sSecurityGroupLabelMetaTask();
         this.factoryTask.portGroupCheckMetaTask = new PortGroupCheckMetaTask();
-
+        this.factoryTask.deleteSecurityGroupFromDbTask = new DeleteSecurityGroupFromDbTask();
         UpdateOrDeleteK8sSecurityGroupMetaTask task = this.factoryTask.create(this.sg);
 
         // Act.
@@ -111,8 +112,7 @@ public class UpdateOrDeleteK8sSecurityGroupMetaTaskTest {
             { NO_LABEL_SG, createK8sGraph(NO_LABEL_SG, false) },
             { SINGLE_LABEL_SG, createK8sGraph(SINGLE_LABEL_SG, false) },
             { MULTI_LABEL_SG, createK8sGraph(MULTI_LABEL_SG, false) },
-            { SINGLE_LABEL_MARKED_FOR_DELETION_SG, createK8sGraph(SINGLE_LABEL_MARKED_FOR_DELETION_SG, true) },
-            { POPULATED_WITH_POD_SG, checkPortGroupK8sGraph(POPULATED_WITH_POD_SG, false) }
+            { SINGLE_LABEL_MARKED_FOR_DELETION_SG, deleteSGK8sGraph(SINGLE_LABEL_MARKED_FOR_DELETION_SG, true) }
         });
     }
 

--- a/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/k8s/securitygroup/UpdateOrDeleteK8sSecurityGroupMetaTaskTestData.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/k8s/securitygroup/UpdateOrDeleteK8sSecurityGroupMetaTaskTestData.java
@@ -17,7 +17,6 @@
 package org.osc.core.broker.service.tasks.conformance.k8s.securitygroup;
 
 import java.util.Set;
-import java.util.UUID;
 
 import javax.persistence.EntityManager;
 
@@ -34,6 +33,7 @@ import org.osc.core.broker.model.entities.virtualization.VirtualizationConnector
 import org.osc.core.broker.model.entities.virtualization.k8s.Label;
 import org.osc.core.broker.model.entities.virtualization.k8s.Pod;
 import org.osc.core.broker.model.entities.virtualization.k8s.PodPort;
+import org.osc.core.broker.service.tasks.conformance.openstack.securitygroup.DeleteSecurityGroupFromDbTask;
 import org.osc.core.broker.service.tasks.conformance.openstack.securitygroup.PortGroupCheckMetaTask;
 import org.osc.core.common.virtualization.VirtualizationType;
 
@@ -45,7 +45,6 @@ public class UpdateOrDeleteK8sSecurityGroupMetaTaskTestData {
     public static SecurityGroup NO_LABEL_SG = createSecurityGroup("NO_LABEL", 0, false);
     public static SecurityGroup SINGLE_LABEL_SG = createSecurityGroup("SINGLE_LABEL", 1, false);
     public static SecurityGroup MULTI_LABEL_SG = createSecurityGroup("MULTI_LABEL", MANY, false);
-    public static SecurityGroup POPULATED_WITH_POD_SG = createSecurityGroupWithPod("POPULATED_WITH_POD_SG");
     public static SecurityGroup SINGLE_LABEL_MARKED_FOR_DELETION_SG = createSecurityGroup("SINGLE_LABEL", 1, true);
 
     public static TaskGraph createK8sGraph(SecurityGroup sg, boolean isDelete) {
@@ -55,20 +54,21 @@ public class UpdateOrDeleteK8sSecurityGroupMetaTaskTestData {
             expectedGraph.addTask(new CheckK8sSecurityGroupLabelMetaTask().create(sgm, isDelete));
         }
 
+        expectedGraph.appendTask(new PortGroupCheckMetaTask().create(sg, isDelete, null));
+
         return expectedGraph;
     }
 
-    public static TaskGraph checkPortGroupK8sGraph(SecurityGroup sg, boolean isDelete) {
+    public static TaskGraph deleteSGK8sGraph(SecurityGroup sg, boolean isDelete) {
         TaskGraph expectedGraph = new TaskGraph();
 
         for (SecurityGroupMember sgm : sg.getSecurityGroupMembers()) {
             expectedGraph.addTask(new CheckK8sSecurityGroupLabelMetaTask().create(sgm, isDelete));
         }
 
-        SecurityGroupMember sgm = sg.getSecurityGroupMembers().iterator().next();
-        String domainId = sgm.getPodPorts().iterator().next().getParentId();
+        expectedGraph.appendTask(new PortGroupCheckMetaTask().create(sg, isDelete, null));
 
-        expectedGraph.appendTask(new PortGroupCheckMetaTask().create(sg, isDelete, domainId));
+        expectedGraph.appendTask(new DeleteSecurityGroupFromDbTask().create(sg));
 
         return expectedGraph;
     }
@@ -121,30 +121,6 @@ public class UpdateOrDeleteK8sSecurityGroupMetaTaskTestData {
             SecurityGroupMember sgm = new SecurityGroupMember(sg, label);
             sg.addSecurityGroupMember(sgm);
         }
-
-        return sg;
-    }
-
-    private static SecurityGroup createSecurityGroupWithPod(String baseName) {
-        SecurityGroup sg = createSecurityGroup(baseName, 1, false);
-        Label label = sg.getSecurityGroupMembers().iterator().next().getLabel();
-
-        PodPort podPort = new PodPort(
-                UUID.randomUUID().toString(),
-                UUID.randomUUID().toString(),
-                UUID.randomUUID().toString(),
-                UUID.randomUUID().toString());
-
-        Pod pod = new Pod(
-                UUID.randomUUID().toString(),
-                UUID.randomUUID().toString(),
-                UUID.randomUUID().toString(),
-                UUID.randomUUID().toString());
-
-        pod.getPorts().add(podPort);
-        podPort.setPod(pod);
-
-        label.getPods().add(pod);
 
         return sg;
     }


### PR DESCRIPTION
This PR addresses the following issues with the K8s SG sync:

- Avoiding failed redundant creation of an existing  pod in OSC associated with a label in the same SG.
- Creating the port group when the SG is created/updated.
- Adding security group deletion job.
- Ensure that an SGM marked for deletion is deleted.