### PR TITLE
Fixed Issue:462 - Automatic sync of SG when port are added not working

### DIFF
--- a/osc-server/src/main/java/org/osc/core/broker/rest/client/openstack/vmidc/notification/OsNotificationKeyType.java
+++ b/osc-server/src/main/java/org/osc/core/broker/rest/client/openstack/vmidc/notification/OsNotificationKeyType.java
@@ -17,10 +17,10 @@
 package org.osc.core.broker.rest.client.openstack.vmidc.notification;
 
 /**
- * 
+ *
  * This enum provides list of Keys we can parser Incoming Notification message on (i.e. "instance_id", "device_id"
  * etc..) those objects
- * 
+ *
  */
 
 public enum OsNotificationKeyType {
@@ -34,8 +34,7 @@ public enum OsNotificationKeyType {
     PROJECT_ID("tenant_id"),
     PORT_ID("port_id"),
     SUBNET_ID("subnet_id"),
-    FIXED_IPS("fixed_ips"),
-    DEVICE_OWNER("device_owner");
+    FIXED_IPS("fixed_ips");
 
     private final String text;
 

--- a/osc-server/src/main/java/org/osc/core/broker/rest/client/openstack/vmidc/notification/listener/OsPortNotificationListener.java
+++ b/osc-server/src/main/java/org/osc/core/broker/rest/client/openstack/vmidc/notification/listener/OsPortNotificationListener.java
@@ -125,6 +125,8 @@ public class OsPortNotificationListener extends OsNotificationListener {
             if (keyValue == null) {
                 keyValue = OsNotificationUtil.isMessageRelevant(message, this.objectIdList,
                         OsNotificationKeyType.SUBNET_ID.toString());
+                // Add subnet notification snippet back when the OpenStack device_owner issue is fixed.
+                // Related OSC issue: https://github.com/opensecuritycontroller/osc-core/issues/462
             }
         }
 

--- a/osc-server/src/main/java/org/osc/core/broker/rest/client/openstack/vmidc/notification/listener/OsPortNotificationListener.java
+++ b/osc-server/src/main/java/org/osc/core/broker/rest/client/openstack/vmidc/notification/listener/OsPortNotificationListener.java
@@ -26,7 +26,6 @@ import org.osc.core.broker.model.entities.BaseEntity;
 import org.osc.core.broker.model.entities.events.SystemFailureType;
 import org.osc.core.broker.model.entities.virtualization.SecurityGroup;
 import org.osc.core.broker.model.entities.virtualization.VirtualizationConnector;
-import org.osc.core.broker.model.entities.virtualization.openstack.Subnet;
 import org.osc.core.broker.model.entities.virtualization.openstack.VMPort;
 import org.osc.core.broker.rest.client.openstack.vmidc.notification.OsNotificationKeyType;
 import org.osc.core.broker.rest.client.openstack.vmidc.notification.OsNotificationObjectType;
@@ -35,7 +34,6 @@ import org.osc.core.broker.rest.client.openstack.vmidc.notification.runner.Rabbi
 import org.osc.core.broker.service.ConformService;
 import org.osc.core.broker.service.alert.AlertGenerator;
 import org.osc.core.broker.service.persistence.SecurityGroupEntityMgr;
-import org.osc.core.broker.service.persistence.SubnetEntityManager;
 import org.osc.core.broker.service.persistence.VMPortEntityManager;
 import org.osc.core.broker.util.db.DBConnectionManager;
 import org.osgi.service.transaction.control.ScopedWorkException;
@@ -127,18 +125,6 @@ public class OsPortNotificationListener extends OsNotificationListener {
             if (keyValue == null) {
                 keyValue = OsNotificationUtil.isMessageRelevant(message, this.objectIdList,
                         OsNotificationKeyType.SUBNET_ID.toString());
-
-                // if key value is null by now we assume it is a subnet related notification
-                if (keyValue != null) {
-                    Subnet subnet = SubnetEntityManager.findByOpenstackId(em, keyValue);
-                    String deviceOwner = OsNotificationUtil.getPropertyFromNotificationMessage(message,
-                            OsNotificationKeyType.DEVICE_OWNER.toString());
-                    if ((subnet.isProtectExternal() && deviceOwner.startsWith("compute:"))
-                            || (!subnet.isProtectExternal() && deviceOwner.equals(""))) {
-                        // we ignore message and do not trigger sync...
-                        keyValue = null;
-                    }
-                }
             }
         }
 


### PR DESCRIPTION
OpenStack notification for port or router create event, device_owner info is empty. We cannot process the notification without the device_owner information. Hence, removing the condition. We will trigger sync for the SG of type subnet everytime we receive the notification related to subnet.