### PR TITLE
Unit test cases for bindSecurityGroupServices

### DIFF
--- a/osc-server/src/main/java/org/osc/core/broker/service/persistence/SecurityGroupEntityMgr.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/persistence/SecurityGroupEntityMgr.java
@@ -172,7 +172,7 @@ public class SecurityGroupEntityMgr {
 
         return em.createQuery(query).getResultList();
     }
-    
+
     public static List<SecurityGroup>  listSecurityGroupsBySfcIdAndProjectId(EntityManager em, Long sfcId, String projectId) {
         CriteriaBuilder cb = em.getCriteriaBuilder();
 
@@ -181,9 +181,8 @@ public class SecurityGroupEntityMgr {
         Root<SecurityGroup> root = query.from(SecurityGroup.class);
         query = query.select(root)
                 .where(cb.equal(root.join("serviceFunctionChain").get("id"), sfcId),
-                        cb.equal(root.get("projectId"), projectId))
-                .orderBy(cb.asc(root.get("name")));
-        
+                        cb.equal(root.get("projectId"), projectId));
+
         return em.createQuery(query).getResultList();
     }
 

--- a/osc-server/src/main/java/org/osc/core/broker/service/persistence/ServiceFunctionChainEntityMgr.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/persistence/ServiceFunctionChainEntityMgr.java
@@ -20,6 +20,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.persistence.EntityManager;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
 
 import org.osc.core.broker.model.entities.appliance.VirtualSystem;
 import org.osc.core.broker.model.entities.virtualization.ServiceFunctionChain;
@@ -44,6 +47,17 @@ public class ServiceFunctionChainEntityMgr {
 
 	public static ServiceFunctionChain findById(EntityManager em, Long id) {
         return em.find(ServiceFunctionChain.class, id);
+    }
+	
+    public static List<ServiceFunctionChain> listServiceFunctionChainsByVirtualSystem(EntityManager em, VirtualSystem vs) {
+        CriteriaBuilder cb = em.getCriteriaBuilder();
+
+        CriteriaQuery<ServiceFunctionChain> query = cb.createQuery(ServiceFunctionChain.class);
+
+        Root<ServiceFunctionChain> root = query.from(ServiceFunctionChain.class);
+        query = query.select(root).where(cb.equal(root.join("virtualSystems"), vs)).orderBy(cb.asc(root.get("name")));
+
+        return em.createQuery(query).getResultList();
     }
 
 }

--- a/osc-server/src/main/java/org/osc/core/broker/service/persistence/ServiceFunctionChainEntityMgr.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/persistence/ServiceFunctionChainEntityMgr.java
@@ -48,14 +48,14 @@ public class ServiceFunctionChainEntityMgr {
 	public static ServiceFunctionChain findById(EntityManager em, Long id) {
         return em.find(ServiceFunctionChain.class, id);
     }
-	
+
     public static List<ServiceFunctionChain> listServiceFunctionChainsByVirtualSystem(EntityManager em, VirtualSystem vs) {
         CriteriaBuilder cb = em.getCriteriaBuilder();
 
         CriteriaQuery<ServiceFunctionChain> query = cb.createQuery(ServiceFunctionChain.class);
 
         Root<ServiceFunctionChain> root = query.from(ServiceFunctionChain.class);
-        query = query.select(root).where(cb.equal(root.join("virtualSystems"), vs)).orderBy(cb.asc(root.get("name")));
+        query = query.select(root).where(cb.equal(root.join("virtualSystems"), vs));
 
         return em.createQuery(query).getResultList();
     }

--- a/osc-server/src/main/java/org/osc/core/broker/service/securitygroup/BindSecurityGroupService.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/securitygroup/BindSecurityGroupService.java
@@ -408,10 +408,10 @@ public class BindSecurityGroupService extends ServiceDispatcher<BindSecurityGrou
              
              //if this virtual system is pointing to more than one SFC and one of the SFC other than given SFC
              //is already binded to SG and active, throw exception;
-             //Get All the sfcs having this virutalsystem in the chain
+             //Get All the sfcs having this virtual system in the chain
              List<ServiceFunctionChain> serviceFunctionChainList = ServiceFunctionChainEntityMgr.
                                                                  listServiceFunctionChainsByVirtualSystem(em, vs);
-            if (serviceFunctionChainList != null && !serviceFunctionChainList.isEmpty()) {
+            if (serviceFunctionChainList != null) {
                 for (ServiceFunctionChain serviceFunctionChain : serviceFunctionChainList) {
                     if (!serviceFunctionChain.getId().equals(sfc.getId())) {
                         checkVirtualSystemRedundancyInServiceFunctionChains(em, serviceFunctionChain.getId(), vs);

--- a/osc-server/src/main/java/org/osc/core/broker/service/securitygroup/BindSecurityGroupService.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/securitygroup/BindSecurityGroupService.java
@@ -53,11 +53,11 @@ import org.osc.core.broker.service.response.BaseJobResponse;
 import org.osc.core.broker.service.tasks.conformance.UnlockObjectMetaTask;
 import org.osc.core.broker.service.validator.BindSecurityGroupRequestValidator;
 import org.osc.core.broker.util.ValidateUtil;
-import org.slf4j.LoggerFactory;
 import org.osc.sdk.controller.FailurePolicyType;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Sets;
 
@@ -403,19 +403,18 @@ public class BindSecurityGroupService extends ServiceDispatcher<BindSecurityGrou
              }
              //by removing virtual system id from the list , will help to throw any exception in case of duplication
              sfcVsIdList.remove(virtualSystemId);
-             
+
              VirtualSystem vs = validateAndLoadVirtualSystem(em, virtualSystemId);
-             
+
              //if this virtual system is pointing to more than one SFC and one of the SFC other than given SFC
              //is already binded to SG and active, throw exception;
              //Get All the sfcs having this virtual system in the chain
              List<ServiceFunctionChain> serviceFunctionChainList = ServiceFunctionChainEntityMgr.
                                                                  listServiceFunctionChainsByVirtualSystem(em, vs);
-            if (serviceFunctionChainList != null) {
-                for (ServiceFunctionChain serviceFunctionChain : serviceFunctionChainList) {
-                    if (!serviceFunctionChain.getId().equals(sfc.getId())) {
-                        checkVirtualSystemRedundancyInServiceFunctionChains(em, serviceFunctionChain.getId(), vs);
-                    }
+
+            for (ServiceFunctionChain serviceFunctionChain : serviceFunctionChainList) {
+                if (!serviceFunctionChain.getId().equals(sfc.getId())) {
+                    checkVirtualSystemRedundancyInServiceFunctionChains(em, serviceFunctionChain.getId(), vs);
                 }
             }
          }
@@ -428,7 +427,7 @@ public class BindSecurityGroupService extends ServiceDispatcher<BindSecurityGrou
          }
     	return sfc;
     }
-	
+
 	/**
      * This methods checks if there exist Security Groups binded with given sfcId and TentantId.
      * and If there are Security groups, checks if they are binded and not marked for deletion.
@@ -439,18 +438,19 @@ public class BindSecurityGroupService extends ServiceDispatcher<BindSecurityGrou
      * @param VirtualSystem
      * @return
      */
-    private void checkVirtualSystemRedundancyInServiceFunctionChains(EntityManager em, Long sfcId, VirtualSystem virtualSystem) throws Exception {
+    private void checkVirtualSystemRedundancyInServiceFunctionChains(EntityManager em, Long sfcId,
+            VirtualSystem virtualSystem) throws Exception {
 
         List<SecurityGroup> sgList = SecurityGroupEntityMgr.listSecurityGroupsBySfcIdAndProjectId(em, sfcId,
                 this.securityGroup.getProjectId());
-        for(SecurityGroup sg : sgList){
-            if(!sg.getMarkedForDeletion() && !sg.equals(this.securityGroup)) {
+        for (SecurityGroup sg : sgList) {
+            if (!sg.getMarkedForDeletion() && !sg.equals(this.securityGroup)) {
                 SecurityGroupInterface sgi = SecurityGroupInterfaceEntityMgr
                         .findSecurityGroupInterfacesByVsAndSecurityGroup(em, virtualSystem, sg);
-                if(sgi != null && !sgi.getMarkedForDeletion()) {
-                    throw new VmidcBrokerValidationException(
-                            "Service with VirtualSystem " + virtualSystem.getId() + " is already chained to ServiceFunctionChain Id " +
-                            sfcId + " and binded to SecurityGroup : " + sg.getName());  
+                if (sgi != null && !sgi.getMarkedForDeletion()) {
+                    throw new VmidcBrokerValidationException("Service with VirtualSystem " + virtualSystem.getId()
+                            + " is already chained to ServiceFunctionChain Id " + sfcId
+                            + " and binded to SecurityGroup : " + sg.getName());
                 }
             }
         }

--- a/osc-server/src/test/java/org/osc/core/broker/service/BindSecurityGroupServicePersistenDbTest.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/BindSecurityGroupServicePersistenDbTest.java
@@ -1,0 +1,521 @@
+/*******************************************************************************
+ * Copyright (c) Intel Corporation
+ * Copyright (c) 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.osc.core.broker.service;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.persistence.EntityManager;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.osc.core.broker.job.Job;
+import org.osc.core.broker.job.JobEngine;
+import org.osc.core.broker.job.TaskGraph;
+import org.osc.core.broker.model.entities.appliance.Appliance;
+import org.osc.core.broker.model.entities.appliance.ApplianceSoftwareVersion;
+import org.osc.core.broker.model.entities.appliance.DistributedAppliance;
+import org.osc.core.broker.model.entities.appliance.VirtualSystem;
+import org.osc.core.broker.model.entities.management.ApplianceManagerConnector;
+import org.osc.core.broker.model.entities.management.Domain;
+import org.osc.core.broker.model.entities.management.Policy;
+import org.osc.core.broker.model.entities.virtualization.FailurePolicyType;
+import org.osc.core.broker.model.entities.virtualization.SecurityGroup;
+import org.osc.core.broker.model.entities.virtualization.SecurityGroupInterface;
+import org.osc.core.broker.model.entities.virtualization.ServiceFunctionChain;
+import org.osc.core.broker.model.entities.virtualization.VirtualizationConnector;
+import org.osc.core.broker.model.plugin.ApiFactoryService;
+import org.osc.core.broker.service.api.server.UserContextApi;
+import org.osc.core.broker.service.dto.PolicyDto;
+import org.osc.core.broker.service.dto.VirtualSystemPolicyBindingDto;
+import org.osc.core.broker.service.exceptions.VmidcBrokerValidationException;
+import org.osc.core.broker.service.request.BindSecurityGroupRequest;
+import org.osc.core.broker.service.response.BaseJobResponse;
+import org.osc.core.broker.service.securitygroup.BindSecurityGroupService;
+import org.osc.core.broker.service.tasks.conformance.UnlockObjectMetaTask;
+import org.osc.core.broker.service.test.InMemDB;
+import org.osc.core.broker.util.TransactionalBroadcastUtil;
+import org.osc.core.broker.util.db.DBConnectionManager;
+import org.osc.core.common.virtualization.VirtualizationType;
+import org.osc.core.test.util.TestTransactionControl;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(LockUtil.class)
+public class BindSecurityGroupServicePersistenDbTest {
+
+    private static final String DEFAULT_NAME = "test-sg-name";
+    private static final Long VALID_ID = 1L;
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    public EntityManager em;
+
+    @Mock(answer = Answers.CALLS_REAL_METHODS)
+    protected TestTransactionControl txControl;
+
+    @Mock
+    protected TransactionalBroadcastUtil txBroadcastUtil;
+
+    @Mock
+    private ConformService conformService;
+
+    @Mock
+    protected UserContextApi userContext;
+
+    @Mock
+    protected DBConnectionManager dbMgr;
+
+    @InjectMocks
+    private BindSecurityGroupService bindSecurityGroupService;
+
+    protected VirtualizationConnector vc;
+    protected VirtualSystem vs;
+    protected VirtualSystem vs1;
+    protected ServiceFunctionChain sfc;
+    protected ServiceFunctionChain sfc_dup;
+    protected SecurityGroup sg;
+    protected SecurityGroup sg_dup;
+    protected SecurityGroupInterface sgi_1;
+    protected Long job_id;
+    private UnlockObjectMetaTask ult;
+
+    @Before
+    public void testInitialize() throws Exception {
+
+        MockitoAnnotations.initMocks(this);
+
+        this.em = InMemDB.getEntityManagerFactory().createEntityManager();
+
+        this.txControl.setEntityManager(this.em);
+
+        ApiFactoryService apiFactoryService = Mockito.mock(ApiFactoryService.class);
+        this.bindSecurityGroupService.apiFactoryService = apiFactoryService;
+
+        populateDatabase();
+
+        Mockito.when(this.dbMgr.getTransactionalEntityManager()).thenReturn(this.em);
+        Mockito.when(this.dbMgr.getTransactionControl()).thenReturn(this.txControl);
+
+        JobEngine jobEngine = JobEngine.getEngine();
+        Job job = jobEngine.submit("testJob", new TaskGraph(), false);
+        job_id = job.getId();
+
+        Mockito.when(this.conformService.startBindSecurityGroupConformanceJob(Mockito.any(EntityManager.class),
+                Mockito.any(), Mockito.any(UnlockObjectMetaTask.class))).thenReturn(job);
+
+        PowerMockito.mockStatic(LockUtil.class);
+        Mockito.when(LockUtil.tryLockSecurityGroup(this.sg, this.sg.getVirtualizationConnector())).thenReturn(this.ult);
+    }
+
+    @After
+    public void testTearDown() {
+        InMemDB.shutdown();
+    }
+
+    private void populateDatabase() {
+        this.em.getTransaction().begin();
+
+        Appliance app = new Appliance();
+        app.setManagerSoftwareVersion("fizz");
+        app.setManagerType("buzz");
+        app.setModel("fizzbuzz");
+        this.em.persist(app);
+
+        Appliance app1 = new Appliance();
+        app1.setManagerSoftwareVersion("fizz1");
+        app1.setManagerType("buzz1");
+        app1.setModel("fizzbuzz1");
+        this.em.persist(app1);
+
+        ApplianceManagerConnector amc = new ApplianceManagerConnector();
+        amc.setManagerType("buzz");
+        amc.setIpAddress("127.0.0.1");
+        amc.setName("Steve");
+        amc.setServiceType("foobar");
+        this.em.persist(amc);
+
+        Domain domain = new Domain(amc);
+        domain.setName("domainName");
+        this.em.persist(domain);
+
+        this.vc = new VirtualizationConnector();
+        this.vc.setVirtualizationType(VirtualizationType.OPENSTACK);
+        this.vc.setVirtualizationSoftwareVersion("vcSoftwareVersion");
+        this.vc.setName("vcName");
+        this.vc.setProviderIpAddress("127.0.0.1");
+        this.vc.setProviderUsername("Natasha");
+        this.vc.setProviderPassword("********");
+        this.vc.setControllerType("Neutron-sfc");
+        this.em.persist(this.vc);
+
+        ApplianceSoftwareVersion asv = new ApplianceSoftwareVersion(app);
+        asv.setApplianceSoftwareVersion("softwareVersion");
+        asv.setImageUrl("bar");
+        asv.setVirtualizarionSoftwareVersion(this.vc.getVirtualizationSoftwareVersion());
+        asv.setVirtualizationType(this.vc.getVirtualizationType());
+        this.em.persist(asv);
+
+        ApplianceSoftwareVersion asv1 = new ApplianceSoftwareVersion(app);
+        asv1.setApplianceSoftwareVersion("softwareVersion1");
+        asv1.setImageUrl("bar1");
+        asv1.setVirtualizarionSoftwareVersion(this.vc.getVirtualizationSoftwareVersion());
+        asv1.setVirtualizationType(this.vc.getVirtualizationType());
+        this.em.persist(asv1);
+
+        DistributedAppliance da = new DistributedAppliance(amc);
+        da.setName("daName");
+        da.setApplianceVersion(asv.getApplianceSoftwareVersion());
+        da.setAppliance(app);
+        this.em.persist(da);
+
+        this.vs = new VirtualSystem(da);
+        this.vs.setApplianceSoftwareVersion(asv);
+        this.vs.setDomain(domain);
+        this.vs.setVirtualizationConnector(this.vc);
+        this.vs.setMarkedForDeletion(false);
+        this.vs.setName("vsName");
+        this.em.persist(this.vs);
+        da.addVirtualSystem(this.vs);
+
+        DistributedAppliance da1 = new DistributedAppliance(amc);
+        da1.setName("daName1");
+        da1.setApplianceVersion(asv.getApplianceSoftwareVersion());
+        da1.setAppliance(app);
+        this.em.persist(da1);
+
+        this.vs1 = new VirtualSystem(da1);
+        this.vs1.setApplianceSoftwareVersion(asv1);
+        this.vs1.setDomain(domain);
+        this.vs1.setVirtualizationConnector(this.vc);
+        this.vs1.setMarkedForDeletion(false);
+        this.vs1.setName("vsName1");
+        this.em.persist(this.vs1);
+        da1.addVirtualSystem(this.vs1);
+
+        this.sfc = new ServiceFunctionChain("sfc-exist", this.vc);
+        this.em.persist(this.sfc);
+
+        this.sg = new SecurityGroup(this.vc, "111", "Demopp");
+        this.sg.setName(DEFAULT_NAME + "PPP");
+        this.sg.setMarkedForDeletion(false);
+        this.em.persist(this.sg);
+
+        Set<Policy> policies = new HashSet<Policy>();
+        Policy policy = new Policy(amc, domain);
+        policy.setId(VALID_ID);
+        policy.setName("pol-name");
+        policy.setMgrPolicyId("5");
+        this.em.persist(policy);
+        policies.add(policy);
+
+        sgi_1 = new SecurityGroupInterface(this.vs, policies, "111", FailurePolicyType.NA, 0L);
+        sgi_1.setName(DEFAULT_NAME);
+        sgi_1.setSecurityGroup(this.sg);
+        this.em.persist(this.sgi_1);
+
+        this.sfc_dup = new ServiceFunctionChain("sfc-dup", this.vc);
+        this.sfc_dup.addVirtualSystem(this.vs1);
+        this.em.persist(this.sfc_dup);
+
+        this.sg_dup = new SecurityGroup(this.vc, "111", "Demopp");
+        this.sg_dup.setName(DEFAULT_NAME + "PPP-dup");
+        this.sg_dup.setMarkedForDeletion(false);
+        this.sg_dup.setServiceFunctionChain(this.sfc_dup);
+        this.em.persist(this.sg_dup);
+
+        SecurityGroupInterface sgi_2 = new SecurityGroupInterface(this.vs1, policies, "111", FailurePolicyType.NA, 0L);
+        sgi_2.setName(DEFAULT_NAME + 1);
+        sgi_2.setSecurityGroup(this.sg_dup);
+        this.em.persist(sgi_2);
+
+        this.em.getTransaction().commit();
+    }
+
+    @Test
+    public void testValidate_WhenSupportsFailurePolicyAndFailurePolicyTypeIsNull_ThrowsValidationException()
+            throws Exception {
+        // Arrange
+        BindSecurityGroupRequest request = new BindSecurityGroupRequest();
+        request.setVcId(this.vc.getId());
+        request.setSecurityGroupId(this.sg.getId());
+
+        VirtualSystemPolicyBindingDto serviceToBindTo = createService(VALID_ID, this.vs);
+        serviceToBindTo.setOrder(0);
+        request.addServiceToBindTo(serviceToBindTo);
+
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.supportsServiceFunctionChaining(this.sg))
+                .thenReturn(true);
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.supportsMultiplePolicies(this.vs))
+                .thenReturn(true);
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.syncsPolicyMapping(this.vs)).thenReturn(true);
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.supportsFailurePolicy(this.sg)).thenReturn(true);
+
+        this.exception.expect(VmidcBrokerValidationException.class);
+        this.exception.expectMessage("Failure Policy should not have an empty value.");
+
+        // Act
+        this.bindSecurityGroupService.dispatch(request);
+    }
+
+    @Test
+    public void testValidate_WhenSupportsFailurePolicyAndFailurePolicyTypeIsNA_ThrowsValidationException()
+            throws Exception {
+        // Arrange
+        BindSecurityGroupRequest request = new BindSecurityGroupRequest();
+        request.setVcId(this.vc.getId());
+        request.setSecurityGroupId(this.sg.getId());
+
+        VirtualSystemPolicyBindingDto serviceToBindTo = createService(VALID_ID, this.vs);
+        serviceToBindTo.setFailurePolicyType(org.osc.sdk.controller.FailurePolicyType.NA);
+        serviceToBindTo.setOrder(0);
+        request.addServiceToBindTo(serviceToBindTo);
+
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.supportsServiceFunctionChaining(this.sg))
+                .thenReturn(true);
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.supportsMultiplePolicies(this.vs))
+                .thenReturn(true);
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.syncsPolicyMapping(this.vs)).thenReturn(true);
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.supportsFailurePolicy(this.sg)).thenReturn(true);
+
+        this.exception.expect(VmidcBrokerValidationException.class);
+        this.exception.expectMessage("Failure Policy should not have an empty value.");
+
+        // Act
+        this.bindSecurityGroupService.dispatch(request);
+    }
+
+    @Test
+    public void testValidate_WhenFailurePolicyNotSupportedAndFailurePolicyTypeIsFAIL_CLOSE_ThrowsValidationException()
+            throws Exception {
+        // Arrange
+        BindSecurityGroupRequest request = new BindSecurityGroupRequest();
+        request.setVcId(this.vc.getId());
+        request.setSecurityGroupId(this.sg.getId());
+
+        VirtualSystemPolicyBindingDto serviceToBindTo = createService(VALID_ID, this.vs);
+        serviceToBindTo.setFailurePolicyType(org.osc.sdk.controller.FailurePolicyType.FAIL_CLOSE);
+        serviceToBindTo.setOrder(0);
+        request.addServiceToBindTo(serviceToBindTo);
+
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.supportsServiceFunctionChaining(this.sg))
+                .thenReturn(true);
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.supportsMultiplePolicies(this.vs))
+                .thenReturn(true);
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.syncsPolicyMapping(this.vs)).thenReturn(true);
+
+        this.exception.expect(VmidcBrokerValidationException.class);
+        this.exception.expectMessage(
+                "SDN Controller Plugin of type '" + this.sg.getVirtualizationConnector().getControllerType()
+                        + "' does not support Failure Policy. Only valid values are null or NA");
+
+        // Act
+        this.bindSecurityGroupService.dispatch(request);
+    }
+
+    @Test
+    public void testValidate_WhenFailurePolicyNotSupportedAndFailurePolicyTypeIsFAIL_OPEN_ThrowsValidationException()
+            throws Exception {
+        // Arrange
+        BindSecurityGroupRequest request = new BindSecurityGroupRequest();
+        request.setVcId(this.vc.getId());
+        request.setSecurityGroupId(this.sg.getId());
+
+        VirtualSystemPolicyBindingDto serviceToBindTo = createService(VALID_ID, this.vs);
+        serviceToBindTo.setFailurePolicyType(org.osc.sdk.controller.FailurePolicyType.FAIL_OPEN);
+        serviceToBindTo.setOrder(0);
+        request.addServiceToBindTo(serviceToBindTo);
+
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.supportsServiceFunctionChaining(this.sg))
+                .thenReturn(true);
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.supportsMultiplePolicies(this.vs))
+                .thenReturn(true);
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.syncsPolicyMapping(this.vs)).thenReturn(true);
+
+        this.exception.expect(VmidcBrokerValidationException.class);
+        this.exception.expectMessage(
+                "SDN Controller Plugin of type '" + this.sg.getVirtualizationConnector().getControllerType()
+                        + "' does not support Failure Policy. Only valid values are null or NA");
+
+        // Act
+        this.bindSecurityGroupService.dispatch(request);
+    }
+
+    @Test
+    public void testValidate_WhenBindSecurityGroupService_UpdateSuccessful() throws Exception {
+        // Arrange
+        BindSecurityGroupRequest request = new BindSecurityGroupRequest();
+        request.setVcId(this.vc.getId());
+        request.setSecurityGroupId(this.sg.getId());
+
+        VirtualSystemPolicyBindingDto serviceToBindTo = createService(VALID_ID, this.vs);
+        serviceToBindTo.setOrder(0);
+        request.addServiceToBindTo(serviceToBindTo);
+
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.supportsServiceFunctionChaining(this.sg))
+                .thenReturn(true);
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.supportsMultiplePolicies(this.vs))
+                .thenReturn(true);
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.syncsPolicyMapping(this.vs)).thenReturn(true);
+
+        // Act
+        BaseJobResponse response = this.bindSecurityGroupService.dispatch(request);
+
+        // Assert
+        Assert.assertNotNull("The returned response should not be null.", response);
+        Assert.assertEquals("The job id was different than expected.", this.job_id, response.getJobId());
+    }
+
+    @Test
+    public void testValidate_WhenBindSecurityGroupServiceWithSfc_UpdateSuccessful() throws Exception {
+        // Arrange
+        BindSecurityGroupRequest request = new BindSecurityGroupRequest();
+        request.setVcId(this.vc.getId());
+        request.setSecurityGroupId(this.sg.getId());
+        request.setSfcId(this.sfc.getId());
+
+        this.sfc.addVirtualSystem(this.vs);
+
+        VirtualSystemPolicyBindingDto serviceToBindTo = createService(VALID_ID, this.vs);
+        serviceToBindTo.setOrder(0);
+        request.addServiceToBindTo(serviceToBindTo);
+
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.supportsServiceFunctionChaining(this.sg))
+                .thenReturn(true);
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.supportsMultiplePolicies(this.vs))
+                .thenReturn(true);
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.syncsPolicyMapping(this.vs)).thenReturn(true);
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.supportsNeutronSFC(this.sg)).thenReturn(true);
+
+        // Act
+        BaseJobResponse response = this.bindSecurityGroupService.dispatch(request);
+
+        // Assert
+        Assert.assertNotNull("The returned response should not be null.", response);
+        Assert.assertEquals("The job id was different than expected.", this.job_id, response.getJobId());
+    }
+
+    @Test
+    public void testValidate_WhenSfcsAreRedundantAndOneSfcIsBindedThenBindingSecondSfc_ThrowValidationException()
+            throws Exception {
+        // Arrange
+        BindSecurityGroupRequest request = new BindSecurityGroupRequest();
+        request.setVcId(this.vc.getId());
+        request.setSecurityGroupId(this.sg.getId());
+        request.setSfcId(this.sfc.getId());
+
+        this.sfc.addVirtualSystem(this.vs1);
+
+        VirtualSystemPolicyBindingDto serviceToBindTo = createService(VALID_ID, this.vs1);
+        serviceToBindTo.setOrder(0);
+        request.addServiceToBindTo(serviceToBindTo);
+
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.supportsNeutronSFC(this.sg)).thenReturn(true);
+
+        this.exception.expect(VmidcBrokerValidationException.class);
+        this.exception.expectMessage(
+                "Service with VirtualSystem " + this.vs1.getId() + " is already chained to ServiceFunctionChain Id "
+                        + this.sfc_dup.getId() + " and binded to SecurityGroup : " + this.sg.getName());
+
+        // Act
+        this.bindSecurityGroupService.dispatch(request);
+    }
+
+    @Test
+    public void testValidate_WhenSfcVsCountDoNotMatchWithBindSeviceVsCount_ThrowsValidationException()
+            throws Exception {
+        // Arrange
+        BindSecurityGroupRequest request = new BindSecurityGroupRequest();
+        request.setVcId(this.vc.getId());
+        request.setSecurityGroupId(this.sg_dup.getId());
+        request.setSfcId(this.sfc.getId());
+
+        this.sfc.addVirtualSystem(this.vs1);
+        this.sfc.addVirtualSystem(this.vs);
+
+        VirtualSystemPolicyBindingDto serviceToBindTo = createService(VALID_ID, this.vs1);
+        serviceToBindTo.setOrder(0);
+        request.addServiceToBindTo(serviceToBindTo);
+
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.supportsNeutronSFC(this.sg_dup)).thenReturn(true);
+
+        this.exception.expect(VmidcBrokerValidationException.class);
+        this.exception.expectMessage("Number of Virtual System Ids in ServiceFunctionChain  "
+                + this.sfc.getVirtualSystems().size() + " and Binding request Virtual System Ids "
+                + request.getServicesToBindTo().size() + " do not match");
+
+        // Act
+        this.bindSecurityGroupService.dispatch(request);
+    }
+    
+    @Test
+    public void testValidate_WhenBindSGServiceWithSfcWhichIsAlreadyBindToAnotheSG_UpdateSuccessful() throws Exception {
+        // Arrange
+        BindSecurityGroupRequest request = new BindSecurityGroupRequest();
+        request.setVcId(this.vc.getId());
+        request.setSecurityGroupId(this.sg.getId());
+        request.setSfcId(this.sfc_dup.getId());
+
+        VirtualSystemPolicyBindingDto serviceToBindTo = createService(VALID_ID, this.vs1);
+        serviceToBindTo.setOrder(0);
+        request.addServiceToBindTo(serviceToBindTo);
+
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.supportsServiceFunctionChaining(this.sg))
+                .thenReturn(true);
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.supportsMultiplePolicies(this.vs1))
+                .thenReturn(true);
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.syncsPolicyMapping(this.vs1)).thenReturn(true);
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.supportsNeutronSFC(this.sg)).thenReturn(true);
+
+        // Act
+        BaseJobResponse response = this.bindSecurityGroupService.dispatch(request);
+
+        // Assert
+        Assert.assertNotNull("The returned response should not be null.", response);
+        Assert.assertEquals("The job id was different than expected.", this.job_id, response.getJobId());
+    }
+
+    private static VirtualSystemPolicyBindingDto createService(Long id, VirtualSystem vs) {
+        Set<Long> policyIds = new HashSet<Long>();
+        policyIds.add(id);
+        PolicyDto policyDto = new PolicyDto();
+        policyDto.setId(id);
+        policyDto.setPolicyName("pol-name");
+        List<PolicyDto> policies = new ArrayList<PolicyDto>();
+        policies.add(policyDto);
+
+        VirtualSystemPolicyBindingDto serviceDto = new VirtualSystemPolicyBindingDto(vs.getId(), vs.getName(),
+                policyIds, policies);
+        return serviceDto;
+
+    }
+}

--- a/osc-server/src/test/java/org/osc/core/broker/service/BindSecurityGroupServiceTest.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/BindSecurityGroupServiceTest.java
@@ -1,0 +1,574 @@
+/*******************************************************************************
+ * Copyright (c) Intel Corporation
+ * Copyright (c) 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.osc.core.broker.service;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityTransaction;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.osc.core.broker.model.entities.appliance.DistributedAppliance;
+import org.osc.core.broker.model.entities.appliance.VirtualSystem;
+import org.osc.core.broker.model.entities.management.ApplianceManagerConnector;
+import org.osc.core.broker.model.entities.management.Domain;
+import org.osc.core.broker.model.entities.management.Policy;
+import org.osc.core.broker.model.entities.virtualization.FailurePolicyType;
+import org.osc.core.broker.model.entities.virtualization.SecurityGroup;
+import org.osc.core.broker.model.entities.virtualization.SecurityGroupInterface;
+import org.osc.core.broker.model.entities.virtualization.ServiceFunctionChain;
+import org.osc.core.broker.model.entities.virtualization.VirtualizationConnector;
+import org.osc.core.broker.model.plugin.ApiFactoryService;
+import org.osc.core.broker.service.api.server.UserContextApi;
+import org.osc.core.broker.service.dto.PolicyDto;
+import org.osc.core.broker.service.dto.VirtualSystemPolicyBindingDto;
+import org.osc.core.broker.service.exceptions.VmidcBrokerInvalidEntryException;
+import org.osc.core.broker.service.exceptions.VmidcBrokerInvalidRequestException;
+import org.osc.core.broker.service.exceptions.VmidcBrokerValidationException;
+import org.osc.core.broker.service.request.BindSecurityGroupRequest;
+import org.osc.core.broker.service.securitygroup.BindSecurityGroupService;
+import org.osc.core.broker.util.TransactionalBroadcastUtil;
+import org.osc.core.broker.util.db.DBConnectionManager;
+import org.osc.core.test.util.TestTransactionControl;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BindSecurityGroupServiceTest {
+    private static final String DEFAULT_SG_NAME = "sg-name";
+    private static final String DEFAULT_CONTROLLER_TYPE = "NSC";
+    private static final Long VALID_ID = 1L;
+    private static final Long INVALID_ID = 2L;
+    private static final Long VALID_ID_MARK_FOR_DELETION = 3L;
+
+    private static final SecurityGroup VALID_SG = createSecurityGroup(VALID_ID, false);
+    private static final SecurityGroup VALID_SG_MARK_FOR_DELETION = createSecurityGroup(VALID_ID_MARK_FOR_DELETION,
+            true);
+    private static final SecurityGroupInterface VALID_SGI = createSecurityGroupInterface(VALID_ID);
+    private static final SecurityGroupInterface VALID_SGI2 = createSecurityGroupInterface(VALID_ID + 1);
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Mock
+    EntityManager em;
+
+    @Mock
+    EntityTransaction tx;
+
+    @Mock(answer = Answers.CALLS_REAL_METHODS)
+    TestTransactionControl txControl;
+
+    @Mock
+    private UserContextApi userContext;
+
+    @Mock
+    private DBConnectionManager dbMgr;
+
+    @Mock
+    private ConformService conformService;
+
+    @Mock
+    private TransactionalBroadcastUtil txBroadcastUtil;
+
+    @InjectMocks
+    private BindSecurityGroupService bindSecurityGroupService;
+
+    @Before
+    public void testInitialize() throws Exception {
+
+        MockitoAnnotations.initMocks(this);
+        ApiFactoryService apiFactoryService = Mockito.mock(ApiFactoryService.class);
+        this.bindSecurityGroupService.apiFactoryService = apiFactoryService;
+
+        Mockito.when(this.em.getTransaction()).thenReturn(this.tx);
+        this.txControl.setEntityManager(this.em);
+
+        Mockito.when(this.dbMgr.getTransactionalEntityManager()).thenReturn(this.em);
+        Mockito.when(this.dbMgr.getTransactionControl()).thenReturn(this.txControl);
+
+        Mockito.when(this.em.find(Mockito.eq(SecurityGroup.class), Mockito.eq(VALID_ID))).thenReturn(VALID_SG);
+        Mockito.when(this.em.find(Mockito.eq(SecurityGroup.class), Mockito.eq(VALID_ID_MARK_FOR_DELETION)))
+                .thenReturn(VALID_SG_MARK_FOR_DELETION);
+        Mockito.when(this.em.find(Mockito.eq(SecurityGroupInterface.class), Mockito.eq(VALID_ID)))
+                .thenReturn(VALID_SGI);
+        Mockito.when(this.em.find(Mockito.eq(SecurityGroupInterface.class), Mockito.eq(VALID_ID + 1)))
+                .thenReturn(VALID_SGI2);
+
+    }
+
+    @Test
+    public void testValidate_WhenVcIdNull_ThrowsInvalidEntryException() throws Exception {
+        // Arrange
+        String field = "Virtualization Connector Id";
+        BindSecurityGroupRequest request = createRequest(null, VALID_ID, VALID_ID);
+        this.exception.expect(VmidcBrokerInvalidEntryException.class);
+        this.exception.expectMessage(field + " should not have an empty value.");
+
+        // Act
+        this.bindSecurityGroupService.dispatch(request);
+    }
+
+    @Test
+    public void testValidate_WhenSgIdNull_ThrowsInvalidEntryException() throws Exception {
+        // Arrange
+        String field = "Security Group Id";
+        BindSecurityGroupRequest request = createRequest(VALID_ID, null, VALID_ID);
+        this.exception.expect(VmidcBrokerInvalidEntryException.class);
+        this.exception.expectMessage(field + " should not have an empty value.");
+
+        // Act
+        this.bindSecurityGroupService.dispatch(request);
+    }
+
+    @Test
+    public void testValidate_WhenSfcIdAndOrderNull_ThrowsInvalidEntryException() throws Exception {
+        // Arrange
+        String field = "Service Order";
+        BindSecurityGroupRequest request = createRequest(VALID_ID, VALID_ID, null);
+        VirtualSystemPolicyBindingDto serviceToBindTo = createRequestWithService(VALID_ID);
+        request.addServiceToBindTo(serviceToBindTo);
+        this.exception.expect(VmidcBrokerInvalidEntryException.class);
+        this.exception.expectMessage(field + " should not have an empty value.");
+
+        // Act
+        this.bindSecurityGroupService.dispatch(request);
+    }
+
+    @Test
+    public void testValidate_WhenServiceVirtualSystemIdNull_ThrowsInvalidEntryException() throws Exception {
+        // Arrange
+        String field = "Virtual System Id";
+        BindSecurityGroupRequest request = createRequest(VALID_ID, VALID_ID, null);
+        VirtualSystemPolicyBindingDto serviceToBindTo = createRequestWithService(null);
+        request.addServiceToBindTo(serviceToBindTo);
+        this.exception.expect(VmidcBrokerInvalidEntryException.class);
+        this.exception.expectMessage(field + " should not have an empty value.");
+
+        // Act
+        this.bindSecurityGroupService.dispatch(request);
+    }
+
+    @Test
+    public void testValidate_WhenServiceNameNull_ThrowsInvalidEntryException() throws Exception {
+        // Arrange
+        String field = "Service Name";
+        BindSecurityGroupRequest request = createRequest(VALID_ID, VALID_ID, null);
+        VirtualSystemPolicyBindingDto serviceToBindTo = createRequestWithService(VALID_ID);
+        serviceToBindTo.setName(null);
+        request.addServiceToBindTo(serviceToBindTo);
+        this.exception.expect(VmidcBrokerInvalidEntryException.class);
+        this.exception.expectMessage(field + " should not have an empty value.");
+
+        // Act
+        this.bindSecurityGroupService.dispatch(request);
+    }
+
+    @Test
+    public void testValidate_WithInValidSgId_ThrowsValidationException() throws Exception {
+        // Arrange
+        BindSecurityGroupRequest request = createRequest(VALID_ID, INVALID_ID, VALID_ID);
+        this.exception.expect(VmidcBrokerValidationException.class);
+        this.exception.expectMessage("Security Group with Id: " + request.getSecurityGroupId() + "  is not found.");
+
+        // Act
+        this.bindSecurityGroupService.dispatch(request);
+
+    }
+
+    @Test
+    public void testValidate_WhenSgIdsVcIdAndActualVcIdMisMatch_ThrowsValidationException() throws Exception {
+        // Arrange
+        BindSecurityGroupRequest request = createRequest(INVALID_ID, VALID_ID, VALID_ID);
+        this.exception.expect(VmidcBrokerValidationException.class);
+        this.exception
+                .expectMessage(String.format("The Security Group '%s' does not belong to the Parent Object with ID %d",
+                        DEFAULT_SG_NAME, INVALID_ID));
+
+        // Act
+        this.bindSecurityGroupService.dispatch(request);
+
+    }
+
+    @Test
+    public void testValidate_WhenSgIsMarkedForDeletion_ThrowsInvalidRequestException() throws Exception {
+        // Arrange
+        BindSecurityGroupRequest request = createRequest(VALID_ID_MARK_FOR_DELETION, VALID_ID_MARK_FOR_DELETION,
+                VALID_ID_MARK_FOR_DELETION);
+        this.exception.expect(VmidcBrokerInvalidRequestException.class);
+        this.exception.expectMessage("Invalid Request '" + DEFAULT_SG_NAME + "' is marked for deletion");
+
+        // Act
+        this.bindSecurityGroupService.dispatch(request);
+
+    }
+
+    @Test
+    public void testValidate_WhenSgSupportsSFCAndServicesSizeGreaterThanOne_ThrowsValidationException()
+            throws Exception {
+        // Arrange
+        BindSecurityGroupRequest request = createRequest(VALID_ID, VALID_ID, null);
+
+        VirtualSystemPolicyBindingDto serviceToBindTo = createRequestWithService(VALID_ID);
+        serviceToBindTo.setOrder(0);
+        request.addServiceToBindTo(serviceToBindTo);
+
+        VirtualSystemPolicyBindingDto serviceToBindTo1 = createRequestWithService(VALID_ID + 1);
+        serviceToBindTo1.setOrder(1);
+        request.addServiceToBindTo(serviceToBindTo1);
+
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.supportsServiceFunctionChaining(VALID_SG))
+                .thenReturn(false);
+
+        this.exception.expect(VmidcBrokerValidationException.class);
+        this.exception.expectMessage("SDN Controller Plugin of type '" + DEFAULT_CONTROLLER_TYPE
+                + "' does not support more then one Service (Service Function Chaining)");
+
+        // Act
+        this.bindSecurityGroupService.dispatch(request);
+    }
+
+    @Test
+    public void testValidate_WhenServiceOrderIsNegative_ThrowsValidationException() throws Exception {
+        // Arrange
+        BindSecurityGroupRequest request = createRequest(VALID_ID, VALID_ID, null);
+
+        VirtualSystemPolicyBindingDto serviceToBindTo = createRequestWithService(VALID_ID);
+        serviceToBindTo.setOrder(-1);
+        request.addServiceToBindTo(serviceToBindTo);
+
+        VirtualSystemPolicyBindingDto serviceToBindTo1 = createRequestWithService(VALID_ID + 1);
+        serviceToBindTo1.setOrder(1);
+        request.addServiceToBindTo(serviceToBindTo1);
+
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.supportsServiceFunctionChaining(VALID_SG))
+                .thenReturn(true);
+
+        this.exception.expect(VmidcBrokerValidationException.class);
+        this.exception.expectMessage(
+                String.format("Service '%s' needs to have a valid order specified. '%s' value for order is not valid.",
+                        serviceToBindTo.getName(), serviceToBindTo.getOrder()));
+
+        // Act
+        this.bindSecurityGroupService.dispatch(request);
+    }
+
+    @Test
+    public void testValidate_WhenServicesAreDuplicated_ThrowsValidationException() throws Exception {
+        // Arrange
+        BindSecurityGroupRequest request = createRequest(VALID_ID, VALID_ID, null);
+
+        VirtualSystemPolicyBindingDto serviceToBindTo = createRequestWithService(VALID_ID);
+        serviceToBindTo.setOrder(0);
+        request.addServiceToBindTo(serviceToBindTo);
+
+        VirtualSystemPolicyBindingDto serviceToBindTo1 = createRequestWithService(VALID_ID);
+        serviceToBindTo1.setOrder(0);
+        request.addServiceToBindTo(serviceToBindTo1);
+
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.supportsServiceFunctionChaining(VALID_SG))
+                .thenReturn(true);
+        this.exception.expect(VmidcBrokerValidationException.class);
+        this.exception.expectMessage(
+                String.format("Duplicate Service found. Cannot Bind Security group to the same Service: '%s' twice.",
+                        serviceToBindTo.getName()));
+
+        // Act
+        this.bindSecurityGroupService.dispatch(request);
+    }
+
+    @Test
+    public void testValidate_WhenNotAbleToFindVirtualSystem_ThrowsValidationException() throws Exception {
+        // Arrange
+        BindSecurityGroupRequest request = createRequest(VALID_ID, VALID_ID, null);
+
+        VirtualSystemPolicyBindingDto serviceToBindTo = createRequestWithService(VALID_ID + 1);
+        serviceToBindTo.setOrder(0);
+        request.addServiceToBindTo(serviceToBindTo);
+
+        VirtualSystemPolicyBindingDto serviceToBindTo1 = createRequestWithService(VALID_ID + 2);
+        serviceToBindTo1.setOrder(0);
+        request.addServiceToBindTo(serviceToBindTo1);
+
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.supportsServiceFunctionChaining(VALID_SG))
+                .thenReturn(true);
+        this.exception.expect(VmidcBrokerValidationException.class);
+        this.exception.expectMessage("Virtual System with Id: " + (VALID_ID + 2) + "  is not found.");
+
+        // Act
+        this.bindSecurityGroupService.dispatch(request);
+    }
+
+    @Test
+    public void testValidate_WhenMultiPoliciesNotSupportedAndHaveMultipulePolcies_ThrowsValidationException()
+            throws Exception {
+        // Arrange
+        BindSecurityGroupRequest request = createRequest(VALID_ID, VALID_ID, null);
+
+        VirtualSystemPolicyBindingDto serviceToBindTo = createRequestWithService(VALID_ID);
+        serviceToBindTo.setOrder(0);
+        PolicyDto policyDto = createPolicyDto(VALID_ID + 1, "pol-name1");
+        serviceToBindTo.addPolicies(policyDto);
+        request.addServiceToBindTo(serviceToBindTo);
+
+        VirtualSystem vs = createVirtualSystem(VALID_ID);
+
+        Mockito.when(this.em.find(Mockito.eq(VirtualSystem.class), Mockito.eq(VALID_ID))).thenReturn(vs);
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.supportsServiceFunctionChaining(VALID_SG))
+                .thenReturn(true);
+        this.exception.expect(VmidcBrokerValidationException.class);
+        this.exception.expectMessage(
+                "Security group interface cannot have more than one policy for security manager not supporting multiple policy binding");
+
+        // Act
+        this.bindSecurityGroupService.dispatch(request);
+    }
+
+    @Test
+    public void testValidate_WhenVirtualSystemIsMarkedFroDeletion_ThrowsValidationException() throws Exception {
+        // Arrange
+        BindSecurityGroupRequest request = createRequest(VALID_ID, VALID_ID, null);
+
+        VirtualSystemPolicyBindingDto serviceToBindTo = createRequestWithService(VALID_ID);
+        serviceToBindTo.setOrder(0);
+        PolicyDto policyDto = createPolicyDto(VALID_ID + 1, "pol-name1");
+        serviceToBindTo.addPolicies(policyDto);
+        request.addServiceToBindTo(serviceToBindTo);
+
+        VirtualSystem vs = createVirtualSystem(VALID_ID);
+        vs.setMarkedForDeletion(true);
+
+        Mockito.when(this.em.find(Mockito.eq(VirtualSystem.class), Mockito.eq(VALID_ID))).thenReturn(vs);
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.supportsServiceFunctionChaining(VALID_SG))
+                .thenReturn(true);
+        this.exception.expect(VmidcBrokerValidationException.class);
+        this.exception.expectMessage(String.format(
+                "Cannot bind security group '%s' to service" + " '%s' as the service is marked for deletion",
+                DEFAULT_SG_NAME, vs.getDistributedAppliance().getName()));
+
+        // Act
+        this.bindSecurityGroupService.dispatch(request);
+    }
+
+    @Test
+    public void testValidate_WhenPolicyMappingNotSupportedAndOneOrMorePolcies_ThrowsValidationException()
+            throws Exception {
+        // Arrange
+        BindSecurityGroupRequest request = createRequest(VALID_ID, VALID_ID, null);
+
+        VirtualSystemPolicyBindingDto serviceToBindTo = createRequestWithService(VALID_ID);
+        serviceToBindTo.setOrder(0);
+        PolicyDto policyDto = createPolicyDto(VALID_ID + 1, "pol-name1");
+        serviceToBindTo.addPolicies(policyDto);
+        request.addServiceToBindTo(serviceToBindTo);
+
+        VirtualSystem vs = createVirtualSystem(VALID_ID);
+
+        Mockito.when(this.em.find(Mockito.eq(VirtualSystem.class), Mockito.eq(VALID_ID))).thenReturn(vs);
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.supportsServiceFunctionChaining(VALID_SG))
+                .thenReturn(true);
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.supportsMultiplePolicies(vs)).thenReturn(true);
+        this.exception.expect(VmidcBrokerValidationException.class);
+        this.exception.expectMessage("Security manager not supporting policy mapping cannot have one or more policies");
+
+        // Act
+        this.bindSecurityGroupService.dispatch(request);
+    }
+
+    @Test
+    public void testValidate_WhenPolicyMappingSupportedAndHaveEmptyPolicyIdList_ThrowsValidationException()
+            throws Exception {
+        // Arrange
+        BindSecurityGroupRequest request = createRequest(VALID_ID, VALID_ID, null);
+
+        VirtualSystemPolicyBindingDto serviceToBindTo = createRequestWithService(VALID_ID);
+        serviceToBindTo.setOrder(0);
+        Set<Long> policyIds = new HashSet<Long>();
+        serviceToBindTo.setPolicyIds(policyIds);
+        request.addServiceToBindTo(serviceToBindTo);
+
+        VirtualSystem vs = createVirtualSystem(VALID_ID);
+
+        Mockito.when(this.em.find(Mockito.eq(VirtualSystem.class), Mockito.eq(VALID_ID))).thenReturn(vs);
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.supportsServiceFunctionChaining(VALID_SG))
+                .thenReturn(true);
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.supportsMultiplePolicies(vs)).thenReturn(true);
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.syncsPolicyMapping(vs)).thenReturn(true);
+        this.exception.expect(VmidcBrokerValidationException.class);
+        this.exception.expectMessage("Service to bind: " + serviceToBindTo + " must have a policy id.");
+
+        // Act
+        this.bindSecurityGroupService.dispatch(request);
+    }
+
+    @Test
+    public void testValidate_WhenSfcIdIsNotFound_ThrowsValidationException() throws Exception {
+        // Arrange
+        BindSecurityGroupRequest request = createRequest(VALID_ID, VALID_ID, VALID_ID);
+
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.supportsNeutronSFC(VALID_SG)).thenReturn(true);
+        this.exception.expect(VmidcBrokerValidationException.class);
+        this.exception.expectMessage("Service Function Chain entry with Id: " + request.getSfcId() + " is not found.");
+
+        // Act
+        this.bindSecurityGroupService.dispatch(request);
+    }
+
+    @Test
+    public void testValidate_WhenSfcVcIdAndActualVcIdDoNotMatch_ThrowsValidationException() throws Exception {
+        // Arrange
+        BindSecurityGroupRequest request = createRequest(VALID_ID, VALID_ID, VALID_ID);
+        ServiceFunctionChain sfc = createSFC(VALID_ID, INVALID_ID);
+
+        Mockito.when(this.em.find(Mockito.eq(VirtualizationConnector.class), Mockito.eq(VALID_ID)))
+                .thenReturn(VALID_SG.getVirtualizationConnector());
+        Mockito.when(this.em.find(Mockito.eq(ServiceFunctionChain.class), Mockito.eq(VALID_ID))).thenReturn(sfc);
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.supportsNeutronSFC(VALID_SG)).thenReturn(true);
+        this.exception.expect(VmidcBrokerValidationException.class);
+        this.exception.expectMessage(
+                String.format("The Service Function Chain '%s' does not belong to the Parent Object with ID %d",
+                        sfc.getName(), VALID_ID));
+
+        // Act
+        this.bindSecurityGroupService.dispatch(request);
+    }
+
+    @Test
+    public void testValidate_WhenSfcVsDoNotMatchWithBindSeviceVs_ThrowsValidationException() throws Exception {
+        // Arrange
+        BindSecurityGroupRequest request = createRequest(VALID_ID, VALID_ID, VALID_ID);
+        ServiceFunctionChain sfc = createSFC(VALID_ID, VALID_ID);
+        VirtualSystemPolicyBindingDto serviceToBindTo = createRequestWithService(INVALID_ID);
+        request.addServiceToBindTo(serviceToBindTo);
+
+        Mockito.when(this.em.find(Mockito.eq(VirtualizationConnector.class), Mockito.eq(VALID_ID)))
+                .thenReturn(VALID_SG.getVirtualizationConnector());
+        Mockito.when(this.em.find(Mockito.eq(ServiceFunctionChain.class), Mockito.eq(VALID_ID))).thenReturn(sfc);
+        Mockito.when(this.bindSecurityGroupService.apiFactoryService.supportsNeutronSFC(VALID_SG)).thenReturn(true);
+        this.exception.expect(VmidcBrokerValidationException.class);
+        this.exception.expectMessage("Binding request Virutal System Id : " + INVALID_ID
+                + " do not match with any of the id in Service Function Chain's Virtual System Id list");
+
+        // Act
+        this.bindSecurityGroupService.dispatch(request);
+    }
+
+    private static SecurityGroup createSecurityGroup(Long id, boolean markedFOrDeletion) {
+        VirtualizationConnector vc = new VirtualizationConnector();
+        vc.setId(id);
+        vc.setControllerType(DEFAULT_CONTROLLER_TYPE);
+        SecurityGroup sg = new SecurityGroup(vc, "111", "Demo");
+        sg.setId(id);
+        sg.setName(DEFAULT_SG_NAME);
+        sg.setMarkedForDeletion(markedFOrDeletion);
+        return sg;
+    }
+
+    private static ApplianceManagerConnector createApplianceManagerConnector() {
+        ApplianceManagerConnector amc = new ApplianceManagerConnector();
+        amc.setManagerType("buzz");
+        amc.setIpAddress("127.0.0.1");
+        amc.setName("Steve");
+        amc.setServiceType("foobar");
+        return amc;
+    }
+
+    private static Policy createPolicy(Long id) {
+
+        ApplianceManagerConnector amc = createApplianceManagerConnector();
+
+        Domain domain = new Domain(amc);
+        domain.setName("domainName");
+
+        Policy policy = new Policy(amc, domain);
+        policy.setId(id);
+        return policy;
+    }
+
+    private static PolicyDto createPolicyDto(Long id, String name) {
+
+        PolicyDto policyDto = new PolicyDto();
+        policyDto.setId(id);
+        policyDto.setPolicyName(name);
+        return policyDto;
+    }
+
+    private static VirtualSystem createVirtualSystem(Long id) {
+        ApplianceManagerConnector amc = createApplianceManagerConnector();
+        DistributedAppliance da = new DistributedAppliance(amc);
+        da.setName("daName");
+        VirtualSystem vs = new VirtualSystem(da);
+        vs.setId(id);
+        return vs;
+    }
+
+    private static SecurityGroupInterface createSecurityGroupInterface(Long id) {
+
+        VirtualSystem vs = createVirtualSystem(id);
+
+        Policy policy = createPolicy(VALID_ID);
+        Set<Policy> policies = new HashSet<Policy>();
+        policies.add(policy);
+
+        SecurityGroupInterface sgi = new SecurityGroupInterface(vs, policies, "tag1" + id, FailurePolicyType.NA,
+                0L + 1);
+        return sgi;
+    }
+
+    private static BindSecurityGroupRequest createRequest(Long vcId, Long sgId, Long sfcId) {
+        BindSecurityGroupRequest request = new BindSecurityGroupRequest();
+        request.setVcId(vcId);
+        request.setSecurityGroupId(sgId);
+        request.setSfcId(sfcId);
+        return request;
+    }
+
+    private static VirtualSystemPolicyBindingDto createRequestWithService(Long id) {
+        Set<Long> policyIds = new HashSet<Long>();
+        policyIds.add(id);
+        PolicyDto policyDto = createPolicyDto(id, "pol-name" + id);
+        List<PolicyDto> policies = new ArrayList<PolicyDto>();
+        policies.add(policyDto);
+
+        VirtualSystemPolicyBindingDto serviceDto = new VirtualSystemPolicyBindingDto(id, "name-vs" + id, policyIds,
+                policies);
+        return serviceDto;
+
+    }
+
+    private static ServiceFunctionChain createSFC(Long sfcId, Long vcId) {
+        VirtualizationConnector vc = new VirtualizationConnector();
+        vc.setId(vcId);
+        vc.setControllerType(DEFAULT_CONTROLLER_TYPE);
+        ServiceFunctionChain sfc = new ServiceFunctionChain("sfc" + sfcId, vc);
+        VirtualSystem vs = createVirtualSystem(sfcId);
+        sfc.addVirtualSystem(vs);
+        return sfc;
+    }
+
+}

--- a/osc-server/src/test/java/org/osc/core/broker/service/BindSecurityGroupServiceWithPersistenceTest.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/BindSecurityGroupServiceWithPersistenceTest.java
@@ -70,7 +70,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(LockUtil.class)
-public class BindSecurityGroupServicePersistenDbTest {
+public class BindSecurityGroupServiceWithPersistenceTest {
 
     private static final String DEFAULT_NAME = "test-sg-name";
     private static final Long VALID_ID = 1L;


### PR DESCRIPTION
More unit test cases and bug fixes in binding services found during unit test runs

Following bugs are fixed that were found during unit test

1.During a check for , size of VirtualSystem List given compare to size of SFC VirtualSystem list we throw an exception and in that message the parameters were given wrong.


2. Retrieving sfc entities per virtual system is done through DB query now. Earlier we were getting them through virtual system get servicefunction chain attribute, where as SFC were never set in virtual system list.


3.When checking for redundant SFC chains in the system, we are querying for virtual system of a given SFC is part of any other SFC. And If they exist another SFC with same VS and if a security group exist with this other SFC and same tenant , we call it a redundant chain. In this check we should not include the current SG that is configured as part of getting all SGs. Fix it.

4. Addressed one of the comment which was a bug, like conditional check in the code during sfc redundancy check

