### PR TITLE
Fixing null pointer exception on log message of the check port group hook MT

### DIFF
--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/CheckPortGroupHookMetaTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/CheckPortGroupHookMetaTask.java
@@ -97,7 +97,9 @@ public final class CheckPortGroupHookMetaTask extends TransactionalMetaTask {
         DistributedApplianceInstance assignedRedirectedDai = protectedPort == null ? null : DistributedApplianceInstanceEntityMgr
                 .findByVirtualSystemAndPort(em, this.sgi.getVirtualSystem(), protectedPort.getId(), protectedPort.getClass());
 
-        if (assignedRedirectedDai == null) {
+        if (protectedPort == null) {
+            LOG.info("No protected port found for SGI " + this.sgi.getName());
+        } else if (assignedRedirectedDai == null) {
             LOG.info("No assigned DAI found for port " + protectedPort.getId());
         }
 

--- a/osc-server/src/main/java/org/osc/core/broker/util/VersionUtil.java
+++ b/osc-server/src/main/java/org/osc/core/broker/util/VersionUtil.java
@@ -82,7 +82,8 @@ public class VersionUtil {
 
         @JsonIgnore
         public Long getBuildNumber() {
-            return Long.parseLong(this.build.split("-")[0]);
+            // The build string can be null for DEBUG builds.
+            return this.build != null ? Long.parseLong(this.build.split("-")[0]) : null;
         }
 
         public void setBuild(String build) {


### PR DESCRIPTION
This PR also fixes another unrelated NPE: When upgrading from/to DEBUG builds the builds.