### PR TITLE
Enabling delete DS for k8s

### DIFF
--- a/osc-server/src/main/java/org/osc/core/broker/service/DeleteDeploymentSpecService.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/DeleteDeploymentSpecService.java
@@ -27,6 +27,7 @@ import org.osc.core.broker.model.entities.appliance.VirtualSystem;
 import org.osc.core.broker.model.entities.virtualization.openstack.DeploymentSpec;
 import org.osc.core.broker.service.api.DeleteDeploymentSpecServiceApi;
 import org.osc.core.broker.service.exceptions.VmidcBrokerValidationException;
+import org.osc.core.broker.service.persistence.DeploymentSpecEntityMgr;
 import org.osc.core.broker.service.persistence.OSCEntityManager;
 import org.osc.core.broker.service.persistence.VirtualSystemEntityMgr;
 import org.osc.core.broker.service.request.BaseDeleteRequest;
@@ -105,10 +106,16 @@ implements DeleteDeploymentSpecServiceApi {
 
         this.ds = em.find(DeploymentSpec.class, request.getId());
 
+        if (DeploymentSpecEntityMgr.isProtectingWorkload(this.ds)) {
+            throw new VmidcBrokerValidationException(
+                    String.format("The deployment spec with name '%s' and '%id' is currently protecting a workload",
+                            this.ds.getName(),
+                            this.ds.getId()));
+        }
+
         // entry must pre-exist in db
         if (this.ds == null) { // note: we cannot use name here in error msg since
             // del req does not have name, only ID
-
             throw new VmidcBrokerValidationException("Deployment Specification entry with ID " + request.getId()
             + " is not found.");
         }

--- a/osc-server/src/main/java/org/osc/core/broker/service/DeleteDeploymentSpecService.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/DeleteDeploymentSpecService.java
@@ -106,13 +106,6 @@ implements DeleteDeploymentSpecServiceApi {
 
         this.ds = em.find(DeploymentSpec.class, request.getId());
 
-        if (DeploymentSpecEntityMgr.isProtectingWorkload(this.ds)) {
-            throw new VmidcBrokerValidationException(
-                    String.format("The deployment spec with name '%s' and '%id' is currently protecting a workload",
-                            this.ds.getName(),
-                            this.ds.getId()));
-        }
-
         // entry must pre-exist in db
         if (this.ds == null) { // note: we cannot use name here in error msg since
             // del req does not have name, only ID
@@ -120,7 +113,12 @@ implements DeleteDeploymentSpecServiceApi {
             + " is not found.");
         }
 
-        // TODO: Future if DS/DDS is in use send Alert/Warning to the user...
+        if (DeploymentSpecEntityMgr.isProtectingWorkload(this.ds)) {
+            throw new VmidcBrokerValidationException(
+                    String.format("The deployment spec with name '%s' and '%s' is currently protecting a workload",
+                            this.ds.getName(),
+                            this.ds.getId()));
+        }
 
         if (!this.ds.getMarkedForDeletion() && request.isForceDelete()) {
             throw new VmidcBrokerValidationException(

--- a/osc-server/src/main/java/org/osc/core/broker/service/persistence/DeploymentSpecEntityMgr.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/persistence/DeploymentSpecEntityMgr.java
@@ -26,6 +26,7 @@ import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.osc.core.broker.model.entities.appliance.DistributedAppliance;
 import org.osc.core.broker.model.entities.appliance.VirtualSystem;
 import org.osc.core.broker.model.entities.virtualization.openstack.AvailabilityZone;
@@ -184,5 +185,9 @@ public class DeploymentSpecEntityMgr {
                 .where(root.get("virtualSystem").in(da.getVirtualSystems()));
 
         return em.createQuery(query).getResultList();
+    }
+
+    public static boolean isProtectingWorkload(DeploymentSpec ds) {
+        return CollectionUtils.emptyIfNull(ds.getDistributedApplianceInstances()).stream().anyMatch(dai -> !dai.getProtectedPorts().isEmpty());
     }
 }

--- a/osc-server/src/main/java/org/osc/core/broker/service/persistence/DistributedApplianceEntityMgr.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/persistence/DistributedApplianceEntityMgr.java
@@ -171,6 +171,6 @@ public class DistributedApplianceEntityMgr {
     }
 
     public static boolean isProtectingWorkload(DistributedAppliance da) {
-        return CollectionUtils.emptyIfNull(da.getVirtualSystems()).stream().anyMatch(vs -> !VirtualSystemEntityMgr.isProtectingWorkload(vs));
+        return CollectionUtils.emptyIfNull(da.getVirtualSystems()).stream().anyMatch(vs -> VirtualSystemEntityMgr.isProtectingWorkload(vs));
     }
 }

--- a/osc-server/src/main/java/org/osc/core/broker/service/persistence/DistributedApplianceEntityMgr.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/persistence/DistributedApplianceEntityMgr.java
@@ -170,7 +170,7 @@ public class DistributedApplianceEntityMgr {
         return false;
     }
 
-    public static boolean isProtectingWorkload(DistributedAppliance ds) {
-        return CollectionUtils.emptyIfNull(ds.getVirtualSystems()).stream().anyMatch(vs -> !VirtualSystemEntityMgr.isProtectingWorkload(vs));
+    public static boolean isProtectingWorkload(DistributedAppliance da) {
+        return CollectionUtils.emptyIfNull(da.getVirtualSystems()).stream().anyMatch(vs -> !VirtualSystemEntityMgr.isProtectingWorkload(vs));
     }
 }

--- a/osc-server/src/main/java/org/osc/core/broker/service/persistence/DistributedApplianceEntityMgr.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/persistence/DistributedApplianceEntityMgr.java
@@ -26,6 +26,7 @@ import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.osc.core.broker.model.entities.appliance.Appliance;
 import org.osc.core.broker.model.entities.appliance.ApplianceSoftwareVersion;
 import org.osc.core.broker.model.entities.appliance.DistributedAppliance;
@@ -112,7 +113,7 @@ public class DistributedApplianceEntityMgr {
 
         query = query.select(root).distinct(true)
                 .where(cb.equal(root.get("markedForDeletion"), false),
-                       cb.equal(root.get("applianceManagerConnector"), mc));
+                        cb.equal(root.get("applianceManagerConnector"), mc));
 
         return em.createQuery(query).getResultList();
     }
@@ -142,7 +143,6 @@ public class DistributedApplianceEntityMgr {
     }
 
     public static boolean isReferencedByDistributedAppliance(EntityManager em, ApplianceManagerConnector mc) {
-
         CriteriaBuilder cb = em.getCriteriaBuilder();
 
         CriteriaQuery<DistributedAppliance> query = cb.createQuery(DistributedAppliance.class);
@@ -168,7 +168,9 @@ public class DistributedApplianceEntityMgr {
         }
 
         return false;
-
     }
 
+    public static boolean isProtectingWorkload(DistributedAppliance ds) {
+        return CollectionUtils.emptyIfNull(ds.getVirtualSystems()).stream().anyMatch(vs -> !VirtualSystemEntityMgr.isProtectingWorkload(vs));
+    }
 }

--- a/osc-server/src/main/java/org/osc/core/broker/service/persistence/VirtualSystemEntityMgr.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/persistence/VirtualSystemEntityMgr.java
@@ -185,6 +185,6 @@ public class VirtualSystemEntityMgr {
     }
 
     public static boolean isProtectingWorkload(VirtualSystem vs) {
-        return CollectionUtils.emptyIfNull(vs.getDeploymentSpecs()).stream().anyMatch(ds -> !DeploymentSpecEntityMgr.isProtectingWorkload(ds));
+        return CollectionUtils.emptyIfNull(vs.getDeploymentSpecs()).stream().anyMatch(ds -> DeploymentSpecEntityMgr.isProtectingWorkload(ds));
     }
 }

--- a/osc-server/src/main/java/org/osc/core/broker/service/persistence/VirtualSystemEntityMgr.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/persistence/VirtualSystemEntityMgr.java
@@ -27,6 +27,7 @@ import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.osc.core.broker.model.entities.appliance.VirtualSystem;
 import org.osc.core.broker.service.dto.VirtualSystemDto;
 import org.osc.core.common.virtualization.VirtualizationType;
@@ -183,4 +184,7 @@ public class VirtualSystemEntityMgr {
         return prevVal;
     }
 
+    public static boolean isProtectingWorkload(VirtualSystem vs) {
+        return CollectionUtils.emptyIfNull(vs.getDeploymentSpecs()).stream().anyMatch(ds -> !DeploymentSpecEntityMgr.isProtectingWorkload(ds));
+    }
 }

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/DeleteK8sDeploymentTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/DeleteK8sDeploymentTask.java
@@ -22,29 +22,55 @@ import javax.persistence.EntityManager;
 
 import org.osc.core.broker.job.lock.LockObjectReference;
 import org.osc.core.broker.model.entities.virtualization.openstack.DeploymentSpec;
+import org.osc.core.broker.rest.client.k8s.KubernetesClient;
+import org.osc.core.broker.rest.client.k8s.KubernetesDeploymentApi;
+import org.osc.core.broker.service.persistence.OSCEntityManager;
 import org.osc.core.broker.service.tasks.TransactionalTask;
 import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Component(service = DeleteK8sDeploymentTask.class)
 public class DeleteK8sDeploymentTask extends TransactionalTask {
-    //private static final Logger LOG = LoggerFactory.getLogger(DeleteK8sDeploymentTask.class);
+    private static final Logger LOG = LoggerFactory.getLogger(DeleteK8sDeploymentTask.class);
 
     private DeploymentSpec ds;
 
-    public DeleteK8sDeploymentTask create(DeploymentSpec ds) {
-        DeleteK8sDeploymentTask task = new DeleteK8sDeploymentTask();
-        task.ds = ds;
+    private KubernetesDeploymentApi k8sDeploymentApi;
 
+    public DeleteK8sDeploymentTask create(DeploymentSpec ds) {
+        return create(ds, null);
+    }
+
+    DeleteK8sDeploymentTask create(DeploymentSpec ds, KubernetesDeploymentApi k8sDeploymentApi) {
+        DeleteK8sDeploymentTask task = new DeleteK8sDeploymentTask();
+        task.dbConnectionManager = this.dbConnectionManager;
+        task.txBroadcastUtil = this.txBroadcastUtil;
+        task.ds = ds;
+        task.k8sDeploymentApi = k8sDeploymentApi;
         return task;
     }
 
     @Override
     public void executeTransaction(EntityManager em) throws Exception {
+        OSCEntityManager<DeploymentSpec> dsEmgr = new OSCEntityManager<DeploymentSpec>(DeploymentSpec.class, em, this.txBroadcastUtil);
+        this.ds = dsEmgr.findByPrimaryKey(this.ds.getId());
+
+        try (KubernetesClient client = new KubernetesClient(this.ds.getVirtualSystem().getVirtualizationConnector())) {
+            if (this.k8sDeploymentApi == null) {
+                this.k8sDeploymentApi = new KubernetesDeploymentApi(client);
+            } else {
+                this.k8sDeploymentApi.setKubernetesClient(client);
+            }
+
+            this.k8sDeploymentApi.deleteDeployment(this.ds.getExternalId(), this.ds.getNamespace(), K8sUtil.getK8sName(this.ds));
+            LOG.info(String.format("Deleted the deployment in kubernetes with name '%s' and id '%s'.", K8sUtil.getK8sName(this.ds), this.ds.getExternalId()));
+        }
     }
 
     @Override
     public String getName() {
-        return String.format("Deleting the K8s Deployment Spec '%s'", this.ds.getName());
+        return String.format("Deleting the K8s Deployment Spec '%s'", K8sUtil.getK8sName(this.ds));
     }
 
     @Override

--- a/osc-server/src/main/java/org/osc/core/broker/service/validator/DeleteDistributedApplianceRequestValidator.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/validator/DeleteDistributedApplianceRequestValidator.java
@@ -49,7 +49,7 @@ public class DeleteDistributedApplianceRequestValidator implements RequestValida
 
         if (DistributedApplianceEntityMgr.isProtectingWorkload(da)) {
             throw new VmidcBrokerValidationException(
-                    String.format("The ddistributed appliance with name '%s' and '%id' is currently protecting a workload",
+                    String.format("The distributed appliance with name '%s' and '%s' is currently protecting a workload",
                             da.getName(),
                             da.getId()));
         }

--- a/osc-server/src/main/java/org/osc/core/broker/service/validator/DeleteDistributedApplianceRequestValidator.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/validator/DeleteDistributedApplianceRequestValidator.java
@@ -49,7 +49,7 @@ public class DeleteDistributedApplianceRequestValidator implements RequestValida
 
         if (DistributedApplianceEntityMgr.isProtectingWorkload(da)) {
             throw new VmidcBrokerValidationException(
-                    String.format("The distributed appliance with name '%s' and '%s' is currently protecting a workload",
+                    String.format("The distributed appliance with name '%s' and id '%s' is currently protecting a workload",
                             da.getName(),
                             da.getId()));
         }

--- a/osc-server/src/main/java/org/osc/core/broker/service/validator/DistributedApplianceDtoValidator.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/validator/DistributedApplianceDtoValidator.java
@@ -142,7 +142,7 @@ public class DistributedApplianceDtoValidator implements DtoValidator<Distribute
                     "The associated Appliance Manager Connector must be selected for this Distributed Appliance.");
         }
 
-        List<Long> existingVsIds = new ArrayList<>();
+        List<Long> providedVsIds = new ArrayList<>();
         for (VirtualSystemDto vsDto : dto.getVirtualizationSystems()) {
             VirtualSystemDtoValidator.checkForNullFields(vsDto);
 
@@ -204,13 +204,13 @@ public class DistributedApplianceDtoValidator implements DtoValidator<Distribute
                 }
             }
 
-            existingVsIds.add(vsDto.getId());
+            providedVsIds.add(vsDto.getId());
         }
 
         if (!forCreate) {
             for (VirtualSystem vs : da.getVirtualSystems()) {
                 // When updating a DA if the user is attempting to remove a VS that is being used to protect a workload fail the call.
-                if (!existingVsIds.contains(vs.getId()) && VirtualSystemEntityMgr.isProtectingWorkload(vs)) {
+                if (!providedVsIds.contains(vs.getId()) && VirtualSystemEntityMgr.isProtectingWorkload(vs)) {
                     throw new VmidcBrokerInvalidEntryException(String.format("The virtual system '%s' cannot be deleted. It is currently assigned to protect a workload.", vs.getName()));
                 }
             }

--- a/osc-server/src/main/java/org/osc/core/broker/service/validator/DistributedApplianceDtoValidator.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/validator/DistributedApplianceDtoValidator.java
@@ -16,7 +16,9 @@
  *******************************************************************************/
 package org.osc.core.broker.service.validator;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -25,6 +27,7 @@ import javax.persistence.EntityManager;
 import org.osc.core.broker.model.entities.appliance.Appliance;
 import org.osc.core.broker.model.entities.appliance.ApplianceSoftwareVersion;
 import org.osc.core.broker.model.entities.appliance.DistributedAppliance;
+import org.osc.core.broker.model.entities.appliance.VirtualSystem;
 import org.osc.core.broker.model.entities.management.ApplianceManagerConnector;
 import org.osc.core.broker.model.entities.management.Domain;
 import org.osc.core.broker.model.entities.virtualization.VirtualizationConnector;
@@ -93,17 +96,17 @@ public class DistributedApplianceDtoValidator implements DtoValidator<Distribute
             throw new VmidcBrokerValidationException("Appliance Manager Connector change is not allowed.");
         }
 
-        validate(dto, false);
+        validate(dto, false, da);
 
         return da;
     }
 
     // TODO: Emanoel - Add a unit test for image url update for DA
     void validate(DistributedApplianceDto dto) throws Exception {
-        validate(dto, true);
+        validate(dto, true, null);
     }
 
-    void validate(DistributedApplianceDto dto, boolean forCreate) throws Exception {
+    void validate(DistributedApplianceDto dto, boolean forCreate, DistributedAppliance da) throws Exception {
         DistributedApplianceDtoValidator.checkForNullFields(dto);
 
         // Ensure DA name complies with Manager naming requirements
@@ -139,6 +142,7 @@ public class DistributedApplianceDtoValidator implements DtoValidator<Distribute
                     "The associated Appliance Manager Connector must be selected for this Distributed Appliance.");
         }
 
+        List<Long> existingVsIds = new ArrayList<>();
         for (VirtualSystemDto vsDto : dto.getVirtualizationSystems()) {
             VirtualSystemDtoValidator.checkForNullFields(vsDto);
 
@@ -197,6 +201,17 @@ public class DistributedApplianceDtoValidator implements DtoValidator<Distribute
                 if (domain.getName().length() > ValidateUtil.DEFAULT_MAX_LEN) {
                     throw new VmidcBrokerInvalidEntryException("Invalid domain length found in Virtual System "
                             + vc.getName() + ".");
+                }
+            }
+
+            existingVsIds.add(vsDto.getId());
+        }
+
+        if (!forCreate) {
+            for (VirtualSystem vs : da.getVirtualSystems()) {
+                // When updating a DA if the user is attempting to remove a VS that is being used to protect a workload fail the call.
+                if (!existingVsIds.contains(vs.getId()) && VirtualSystemEntityMgr.isProtectingWorkload(vs)) {
+                    throw new VmidcBrokerInvalidEntryException(String.format("The virtual system '%s' cannot be deleted. It is currently assigned to protect a workload.", vs.getName()));
                 }
             }
         }

--- a/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/ConformK8sDeploymentSpecMetaTaskTest.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/ConformK8sDeploymentSpecMetaTaskTest.java
@@ -37,7 +37,6 @@ import org.mockito.MockitoAnnotations;
 import org.osc.core.broker.job.TaskGraph;
 import org.osc.core.broker.model.entities.appliance.DistributedApplianceInstance;
 import org.osc.core.broker.model.entities.virtualization.openstack.DeploymentSpec;
-import org.osc.core.broker.service.tasks.conformance.deleteda.DeleteDAIFromDbTask;
 import org.osc.core.broker.service.tasks.conformance.manager.MgrCheckDevicesMetaTask;
 import org.osc.core.broker.service.tasks.conformance.openstack.deploymentspec.DeleteDSFromDbTask;
 import org.osc.core.broker.service.test.InMemDB;
@@ -118,7 +117,7 @@ public class ConformK8sDeploymentSpecMetaTaskTest {
         // Arrange.
         this.factoryTask.deleteDSFromDbTask = new DeleteDSFromDbTask();
         this.factoryTask.mgrCheckDevicesMetaTask = new MgrCheckDevicesMetaTask();
-        this.factoryTask.deleteDAIFromDbTask = new DeleteDAIFromDbTask();
+        this.factoryTask.deleteK8sDAIInspectionPortTask = new DeleteK8sDAIInspectionPortTask();
         this.factoryTask.createOrUpdateK8sDeploymentSpecMetaTask = new CreateOrUpdateK8sDeploymentSpecMetaTask();
         this.factoryTask.deleteK8sDeploymentTask = new DeleteK8sDeploymentTask();
 

--- a/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/ConformK8sDeploymentSpecMetaTaskTestData.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/ConformK8sDeploymentSpecMetaTaskTestData.java
@@ -31,7 +31,6 @@ import org.osc.core.broker.model.entities.management.ApplianceManagerConnector;
 import org.osc.core.broker.model.entities.management.Domain;
 import org.osc.core.broker.model.entities.virtualization.VirtualizationConnector;
 import org.osc.core.broker.model.entities.virtualization.openstack.DeploymentSpec;
-import org.osc.core.broker.service.tasks.conformance.deleteda.DeleteDAIFromDbTask;
 import org.osc.core.broker.service.tasks.conformance.manager.MgrCheckDevicesMetaTask;
 import org.osc.core.broker.service.tasks.conformance.openstack.deploymentspec.DeleteDSFromDbTask;
 import org.osc.core.common.virtualization.VirtualizationType;
@@ -98,7 +97,7 @@ public class ConformK8sDeploymentSpecMetaTaskTestData {
         expectedGraph.appendTask(new DeleteK8sDeploymentTask().create(ds));
 
         for (DistributedApplianceInstance dai : ds.getDistributedApplianceInstances()) {
-            expectedGraph.addTask(new DeleteDAIFromDbTask().create(dai));
+            expectedGraph.addTask(new DeleteK8sDAIInspectionPortTask().create(dai));
         }
 
         expectedGraph.appendTask(new MgrCheckDevicesMetaTask().create(ds.getVirtualSystem()));

--- a/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/DeleteK8sDeploymentTaskTest.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/k8s/deploymentspec/DeleteK8sDeploymentTaskTest.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) Intel Corporation
+ * Copyright (c) 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.osc.core.broker.service.tasks.conformance.k8s.deploymentspec;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityTransaction;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Answers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.osc.core.broker.model.entities.appliance.ApplianceSoftwareVersion;
+import org.osc.core.broker.model.entities.appliance.VirtualSystem;
+import org.osc.core.broker.model.entities.virtualization.VirtualizationConnector;
+import org.osc.core.broker.model.entities.virtualization.openstack.DeploymentSpec;
+import org.osc.core.broker.rest.client.k8s.KubernetesDeploymentApi;
+import org.osc.core.broker.util.TransactionalBroadcastUtil;
+import org.osc.core.broker.util.db.DBConnectionManager;
+import org.osc.core.test.util.TestTransactionControl;
+
+public class DeleteK8sDeploymentTaskTest  {
+    @Mock
+    protected EntityManager em;
+
+    @Mock
+    protected EntityTransaction tx;
+
+    @Mock(answer = Answers.CALLS_REAL_METHODS)
+    TestTransactionControl txControl;
+
+    @Mock
+    DBConnectionManager dbMgr;
+
+    @Mock
+    TransactionalBroadcastUtil txBroadcastUtil;
+
+    @Mock
+    private KubernetesDeploymentApi k8sDeploymentApi;
+
+    @InjectMocks
+    DeleteK8sDeploymentTask factory;
+
+    @Before
+    public void testInitialize() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        when(this.em.getTransaction()).thenReturn(this.tx);
+
+        this.txControl.setEntityManager(this.em);
+
+        Mockito.when(this.dbMgr.getTransactionalEntityManager()).thenReturn(this.em);
+        Mockito.when(this.dbMgr.getTransactionControl()).thenReturn(this.txControl);
+    }
+
+    @Test
+    public void testExecute_WithExistingDS_K8sDSIsDeleted() throws Exception {
+        // Arrange.
+        VirtualizationConnector vc = new VirtualizationConnector();
+        vc.setProviderIpAddress("1.1.1.1");
+        VirtualSystem vs = new VirtualSystem(null);
+        vs.setVirtualizationConnector(vc);
+        vs.setId(102L);
+
+        ApplianceSoftwareVersion asv = new ApplianceSoftwareVersion();
+        asv.setImageUrl("ds-image-url");
+        asv.setImagePullSecretName("ds-pull-secret-name");
+
+        vs.setApplianceSoftwareVersion(asv);
+        DeploymentSpec ds = new DeploymentSpec(vs, null, null, null, null, null);
+        ds.setId(101L);
+        ds.setName("ds-name");
+        ds.setNamespace("ds-namespace");
+        ds.setInstanceCount(8);
+        ds.setExternalId(UUID.randomUUID().toString());
+
+        when(this.em.find(DeploymentSpec.class, ds.getId())).thenReturn(ds);
+
+        DeleteK8sDeploymentTask task = this.factory.create(ds, this.k8sDeploymentApi);
+
+        // Act.
+        task.execute();
+
+        // Assert.
+        verify(this.k8sDeploymentApi, Mockito.times(1)).deleteDeployment(
+                ds.getExternalId(),
+                ds.getNamespace(),
+                K8sUtil.getK8sName(ds));
+    }
+}


### PR DESCRIPTION
1. Updating tasks to include k8s DS deletion.
2. Enforcing that DS, DA and VS deletion cannot happen if the ports are assigned/allocated to a protected port.