### PR TITLE
Set poms to runtime. Add LogUtil.

### DIFF
--- a/osc-control/bnd.bnd
+++ b/osc-control/bnd.bnd
@@ -20,9 +20,6 @@
     com.google.gson.*
 
 -includeresource: \
-    @${slf4j-api.dep},\
-    @${logback-core.dep},\
-    @${logback-classic.dep},\
     @${osc-service-api.dep},\
     @${commons-cli.dep},\
     @${commons-io.dep},\

--- a/osc-control/pom.xml
+++ b/osc-control/pom.xml
@@ -123,7 +123,6 @@
             <artifactId>jersey-client</artifactId>
             <version>2.25</version>
         </dependency>
-
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
@@ -134,11 +133,8 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>1.2.3</version>
-            <scope>provided</scope>
+            <scope>runtime</scope>
         </dependency>
-        
-        
-
         <!-- slf4j and log impl is not imported because server does. -->
         <dependency>
             <groupId>org.osc.core</groupId>

--- a/osc-control/pom.xml
+++ b/osc-control/pom.xml
@@ -123,18 +123,6 @@
             <artifactId>jersey-client</artifactId>
             <version>2.25</version>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
-            <scope>provided</scope>
-        </dependency>
-         <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
-            <scope>runtime</scope>
-        </dependency>
         <!-- slf4j and log impl is not imported because server does. -->
         <dependency>
             <groupId>org.osc.core</groupId>

--- a/osc-control/src/main/java/org/osc/core/server/control/ServerControl.java
+++ b/osc-control/src/main/java/org/osc/core/server/control/ServerControl.java
@@ -110,8 +110,8 @@ public class ServerControl {
             } else if (cmd.hasOption("check")) {
                 // --check is used by vmidc.sh
                 if (isRunningServer()) {
-                    System.out.println(ServerControl.PRODUCT_NAME + " Server is already running.");
-                    System.out.println(getServerVersion());
+                    log.info(ServerControl.PRODUCT_NAME + " Server is already running.");
+                    log.info(getServerVersion());
                     exitStatus = 2; // already running
                 }
             } else if (cmd.hasOption("version")) {
@@ -131,7 +131,7 @@ public class ServerControl {
                 throw new ParseException("no option specified");
             }
         } catch (ParseException e) {
-            log.info("Error parsing command line arguments", e);
+            log.error("Error parsing command line arguments", e);
             HelpFormatter formatter = new HelpFormatter();
             formatter.printHelp("vmiDC", options);
             System.exit(1);
@@ -142,20 +142,20 @@ public class ServerControl {
     private static void enableRestLogging(String enable) throws Exception {
         VmidcServerRestClient restClient = new VmidcServerRestClient(apiPort);
         String restLogging = restClient.postResource("rest-logging", String.class, enable);
-        System.out.println("Logging of Rest API's: " + restLogging);
+        log.info("Logging of Rest API's: " + restLogging);
     }
 
     private static void getLockInfomation() throws Exception {
         VmidcServerRestClient restClient = new VmidcServerRestClient(apiPort);
         String lockInfo = restClient.getResource("lock", String.class);
-        System.out.println(lockInfo);
+        log.info(lockInfo);
     }
 
     private static void query(String sql) throws Exception {
         if (isRunningServer()) {
             VmidcServerRestClient restClient = new VmidcServerRestClient(apiPort);
             String queryOutput = restClient.postResource("query", String.class, sql);
-            System.out.println(queryOutput);
+            log.info(queryOutput);
         } else {
             offlineQuery(sql);
         }
@@ -165,7 +165,7 @@ public class ServerControl {
         if (isRunningServer()) {
             VmidcServerRestClient restClient = new VmidcServerRestClient(apiPort);
             String queryOutput = restClient.postResource("exec", String.class, sql);
-            System.out.println(queryOutput);
+            log.info(queryOutput);
         } else {
             offlineExec(sql);
         }
@@ -189,7 +189,7 @@ public class ServerControl {
             }
         }
 
-        System.out.println(output.toString());
+        log.info(output.toString());
     }
 
     private static void offlineExec(String sql) throws IOException {
@@ -210,7 +210,7 @@ public class ServerControl {
                 ex.printStackTrace(pw);
             }
         }
-        System.out.println(output.toString());
+        log.info(output.toString());
     }
 
     private static void processResultSetForQuery(StringBuilder output, ResultSet result) throws SQLException {
@@ -237,14 +237,14 @@ public class ServerControl {
     }
 
     private static void reportVersion() {
-        System.out.println(ServerControl.PRODUCT_NAME + " version: " + VersionUtil.getVersion().getVersionStr());
+        log.info(ServerControl.PRODUCT_NAME + " version: " + VersionUtil.getVersion().getVersionStr());
     }
 
     private static void reportStatus() {
         if (isRunningServer()) {
-            System.out.println(ServerControl.PRODUCT_NAME + " Server is running.");
+            log.info(ServerControl.PRODUCT_NAME + " Server is running.");
         } else {
-            System.out.println(ServerControl.PRODUCT_NAME + " Server is not running.");
+            log.info(ServerControl.PRODUCT_NAME + " Server is not running.");
         }
     }
 
@@ -256,7 +256,7 @@ public class ServerControl {
             //set ISC public IP in Server Util
             ServerUtil.setServerIP(prop.getProperty(ISC_PUBLIC_IP, ""));
         } catch (Exception ex) {
-            System.out.println("Warning: Failed to load server configuration file "
+            log.warn("Warning: Failed to load server configuration file "
                     + ServerControl.CONFIG_PROPERTIES_FILE + " (Error:" + ex.getMessage() + ")");
         }
     }

--- a/osc-control/src/main/java/org/osc/core/server/control/ServerControl.java
+++ b/osc-control/src/main/java/org/osc/core/server/control/ServerControl.java
@@ -48,11 +48,8 @@ import org.osc.core.broker.util.ServerUtil;
 import org.osc.core.broker.util.ServerUtil.ServerServiceChecker;
 import org.osc.core.broker.util.VersionUtil;
 import org.osc.core.broker.util.db.DBConnectionParameters;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ServerControl {
-    private static final Logger log = LoggerFactory.getLogger(ServerControl.class);
 
     private static final Integer DEFAULT_API_PORT = 8090;
     private static final String CONFIG_PROPERTIES_FILE = "vmidcServer.conf";
@@ -110,8 +107,8 @@ public class ServerControl {
             } else if (cmd.hasOption("check")) {
                 // --check is used by vmidc.sh
                 if (isRunningServer()) {
-                    log.info(ServerControl.PRODUCT_NAME + " Server is already running.");
-                    log.info(getServerVersion());
+                    System.out.println(ServerControl.PRODUCT_NAME + " Server is already running.");
+                    System.out.println(getServerVersion());
                     exitStatus = 2; // already running
                 }
             } else if (cmd.hasOption("version")) {
@@ -131,7 +128,7 @@ public class ServerControl {
                 throw new ParseException("no option specified");
             }
         } catch (ParseException e) {
-            log.error("Error parsing command line arguments", e);
+            System.err.println("Error parsing command line arguments" + e.getMessage());
             HelpFormatter formatter = new HelpFormatter();
             formatter.printHelp("vmiDC", options);
             System.exit(1);
@@ -142,20 +139,20 @@ public class ServerControl {
     private static void enableRestLogging(String enable) throws Exception {
         VmidcServerRestClient restClient = new VmidcServerRestClient(apiPort);
         String restLogging = restClient.postResource("rest-logging", String.class, enable);
-        log.info("Logging of Rest API's: " + restLogging);
+        System.out.println("Logging of Rest API's: " + restLogging);
     }
 
     private static void getLockInfomation() throws Exception {
         VmidcServerRestClient restClient = new VmidcServerRestClient(apiPort);
         String lockInfo = restClient.getResource("lock", String.class);
-        log.info(lockInfo);
+        System.out.println(lockInfo);
     }
 
     private static void query(String sql) throws Exception {
         if (isRunningServer()) {
             VmidcServerRestClient restClient = new VmidcServerRestClient(apiPort);
             String queryOutput = restClient.postResource("query", String.class, sql);
-            log.info(queryOutput);
+            System.out.println(queryOutput);
         } else {
             offlineQuery(sql);
         }
@@ -165,7 +162,7 @@ public class ServerControl {
         if (isRunningServer()) {
             VmidcServerRestClient restClient = new VmidcServerRestClient(apiPort);
             String queryOutput = restClient.postResource("exec", String.class, sql);
-            log.info(queryOutput);
+            System.out.println(queryOutput);
         } else {
             offlineExec(sql);
         }
@@ -189,7 +186,7 @@ public class ServerControl {
             }
         }
 
-        log.info(output.toString());
+        System.out.println(output.toString());
     }
 
     private static void offlineExec(String sql) throws IOException {
@@ -210,7 +207,7 @@ public class ServerControl {
                 ex.printStackTrace(pw);
             }
         }
-        log.info(output.toString());
+        System.out.println(output.toString());
     }
 
     private static void processResultSetForQuery(StringBuilder output, ResultSet result) throws SQLException {
@@ -237,14 +234,14 @@ public class ServerControl {
     }
 
     private static void reportVersion() {
-        log.info(ServerControl.PRODUCT_NAME + " version: " + VersionUtil.getVersion().getVersionStr());
+        System.out.println(ServerControl.PRODUCT_NAME + " version: " + VersionUtil.getVersion().getVersionStr());
     }
 
     private static void reportStatus() {
         if (isRunningServer()) {
-            log.info(ServerControl.PRODUCT_NAME + " Server is running.");
+            System.out.println(ServerControl.PRODUCT_NAME + " Server is running.");
         } else {
-            log.info(ServerControl.PRODUCT_NAME + " Server is not running.");
+            System.out.println(ServerControl.PRODUCT_NAME + " Server is not running.");
         }
     }
 
@@ -256,7 +253,7 @@ public class ServerControl {
             //set ISC public IP in Server Util
             ServerUtil.setServerIP(prop.getProperty(ISC_PUBLIC_IP, ""));
         } catch (Exception ex) {
-            log.warn("Warning: Failed to load server configuration file "
+            System.out.println("Warning: Failed to load server configuration file "
                     + ServerControl.CONFIG_PROPERTIES_FILE + " (Error:" + ex.getMessage() + ")");
         }
     }
@@ -276,26 +273,26 @@ public class ServerControl {
 
     private static boolean isRunningServer() {
         try {
-            log.info("Check if server is running ...");
+            System.out.println("Check if server is running ...");
             VmidcServerRestClient restClient = new VmidcServerRestClient("localhost", apiPort, VMIDC_DEFAULT_LOGIN, VMIDC_DEFAULT_PASS, true);
 
             ServerStatusResponse res = getServerStatusResponse(restClient);
 
             String oldPid = res.getPid();
 
-            log.warn("Current pid:" + ServerUtil.getCurrentPid() + ". Running server (pid:" + oldPid + ") version: "
+            System.out.println("Current pid:" + ServerUtil.getCurrentPid() + ". Running server (pid:" + oldPid + ") version: "
                     + res.getVersion() + " with db version: " + res.getDbVersion());
 
             // If we're here, server is running. Check for active pending
             // upgrade
-            log.warn("Checking pending server upgrade.");
+            System.out.println("Checking pending server upgrade.");
 
             try {
                 restClient.putResource("upgradecomplete", Entity.entity(null, MediaType.APPLICATION_JSON));
                 // If we made it to here, running server is in active upgrade mode
                 // It should be shutting down now. We'll wait till the old process
                 // goes away first by testing if we can get status.
-                log.warn("Pending active server upgrade. Waiting for old process (" + oldPid
+                System.out.println("Pending active server upgrade. Waiting for old process (" + oldPid
                         + ") to exit... (current pid:" + ServerUtil.getCurrentPid() + ")");
                 int oldServerStatusCheckCount = 5; // 5 x 500ms = 2.5 seconds.
                 while (oldServerStatusCheckCount > 0) {
@@ -327,14 +324,14 @@ public class ServerControl {
                         if (!pidFound) {
                             break;
                         }
-                        log.info("Old process (" + oldPid + ") is still running. Retry (" + retries
+                        System.out.println("Old process (" + oldPid + ") is still running. Retry (" + retries
                                 + ") wait for graceful termination.");
                         retries--;
                         Thread.sleep(500);
                     }
                     // If process is still there, we'll force termination.
                     if (pidFound) {
-                        log.warn("Old process (" + oldPid + ") is still running. Triggering forceful termination.");
+                        System.out.println("Old process (" + oldPid + ") is still running. Triggering forceful termination.");
                         ServerUtil.execWithLog("kill -9 " + oldPid);
                     }
                 }
@@ -342,14 +339,14 @@ public class ServerControl {
                 // We'll proceed normal startup as the newly upgraded server.
                 return false;
             } catch (Exception ex) {
-                log.warn("No active pending upgrade.");
+                System.out.println("No active pending upgrade.");
             }
 
             return true;
         } catch (ProcessingException | ConnectException e1) {
-            log.warn("Fail to connect to running server: "+ e1.getMessage());
+            System.err.println("Fail to connect to running server: "+ e1.getMessage());
         } catch (Exception ex) {
-            log.warn("Fail to connect to running server. Assuming not running: " + ex);
+            System.err.println("Fail to connect to running server. Assuming not running: " + ex);
         }
 
         return false;

--- a/osc-export/pom.xml
+++ b/osc-export/pom.xml
@@ -218,6 +218,7 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>1.2.3</version>
+            <scope>runtime</scope>
         </dependency>
 
 		<dependency>

--- a/osc-rest-server/pom.xml
+++ b/osc-rest-server/pom.xml
@@ -80,14 +80,6 @@
             <version>${slf4j.version}</version>
             <scope>provided</scope>
         </dependency>
-
-         <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
-            <scope>provided</scope>
-        </dependency>
-
 		<!-- Test dependencies -->
 		<dependency>
 			<groupId>junit</groupId>

--- a/osc-server/pom.xml
+++ b/osc-server/pom.xml
@@ -165,13 +165,6 @@
             <version>${slf4j.version}</version>
             <scope>provided</scope>
         </dependency>
-         <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
-            <scope>provided</scope>
-        </dependency>
-		
 		<dependency>
 			<groupId>org.apache.aries.tx-control</groupId>
 			<artifactId>tx-control-api</artifactId>

--- a/osc-server/src/main/java/org/osc/core/broker/util/log/LogUtil.java
+++ b/osc-server/src/main/java/org/osc/core/broker/util/log/LogUtil.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) Intel Corporation
+ * Copyright (c) 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.osc.core.broker.util.log;
+
+import java.io.PrintStream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class LogUtil {
+
+    public static void initLog() {
+        try {
+            StdOutErrLog.tieSystemOutAndErrToLog();
+        } catch (Exception ex) {
+            System.out.println("failed to initialize logging");
+            ex.printStackTrace();
+        }
+    }
+
+    public static class StdOutErrLog {
+
+        private static final Logger logger = LoggerFactory.getLogger(StdOutErrLog.class);
+
+        public static void tieSystemOutAndErrToLog() {
+            synchronized (System.class) {
+                System.setOut(createLoggingProxy(System.out, false));
+                System.setErr(createLoggingProxy(System.err, true));
+            }
+        }
+
+        public static PrintStream createLoggingProxy(final PrintStream realPrintStream, final boolean isError) {
+            return new PrintStream(realPrintStream) {
+                @Override
+                public void print(final String string) {
+                    realPrintStream.print(string);
+                    if (isError) {
+                        logger.error(string);
+                    } else {
+                        logger.info(string);
+                    }
+                }
+
+                @Override
+                public void print(Object obj) {
+                    realPrintStream.print(obj);
+                    if (isError) {
+                        logger.error(String.valueOf(obj));
+                    } else {
+                        logger.info(String.valueOf(obj));
+                    }
+                }
+            };
+        }
+    }
+}

--- a/osc-server/src/main/java/org/osc/core/broker/util/log/LogUtil.java
+++ b/osc-server/src/main/java/org/osc/core/broker/util/log/LogUtil.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
 
 public class LogUtil {
 
-    public static void initLog() {
+    public static void redirectConsoleMessagesToLog() {
         try {
             StdOutErrLog.tieSystemOutAndErrToLog();
         } catch (Exception ex) {

--- a/osc-server/src/main/java/org/osc/core/server/Server.java
+++ b/osc-server/src/main/java/org/osc/core/server/Server.java
@@ -194,7 +194,7 @@ public class Server implements ServerApi {
     }
 
     private void startServer() throws Exception {
-        LogUtil.initLog();
+        LogUtil.redirectConsoleMessagesToLog();
         loadServerProps();
 
         try {

--- a/osc-server/src/main/java/org/osc/core/server/Server.java
+++ b/osc-server/src/main/java/org/osc/core/server/Server.java
@@ -59,6 +59,7 @@ import org.osc.core.broker.util.VersionUtil;
 import org.osc.core.broker.util.db.DBConnectionManager;
 import org.osc.core.broker.util.db.DBConnectionParameters;
 import org.osc.core.broker.util.db.upgrade.ReleaseUpgradeMgr;
+import org.osc.core.broker.util.log.LogUtil;
 import org.osc.core.broker.util.network.NetworkSettingsApi;
 import org.osc.core.server.scheduler.SyncDistributedApplianceJob;
 import org.osc.core.server.scheduler.SyncSecurityGroupJob;
@@ -193,6 +194,7 @@ public class Server implements ServerApi {
     }
 
     private void startServer() throws Exception {
+        LogUtil.initLog();
         loadServerProps();
 
         try {

--- a/osc-ui/pom.xml
+++ b/osc-ui/pom.xml
@@ -118,13 +118,6 @@
             <version>${slf4j.version}</version>
             <scope>provided</scope>
         </dependency>
-         <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
-            <scope>provided</scope>
-        </dependency>
-
 		<dependency>
 			<groupId>commons-lang</groupId>
 			<artifactId>commons-lang</artifactId>


### PR DESCRIPTION
* Some pom dependencies on logback-classic were redundant. Others could be left as runtime scope.
* Add back logging System.out  PrintStream: some initial log entries were lost without it.
* ServerControl can now easily use logback mechanism instead System.out.