### PR TITLE
Copy the logback config so startup exceptions go to the correct log.

### DIFF
--- a/osc-control/bnd.bnd
+++ b/osc-control/bnd.bnd
@@ -19,7 +19,10 @@
     org.osc.core.broker.service.common,\
     com.google.gson.*
 
+# *.dep variables are defined in depend.bnd
+# The @ prefix unwraps the jar files
 -includeresource: \
+    logback.xml=target/logback.xml,\
     @${slf4j-api.dep},\
     @${logback-core.dep},\
     @${logback-classic.dep},\

--- a/osc-control/pom.xml
+++ b/osc-control/pom.xml
@@ -87,6 +87,8 @@
                                         <mapper type="regexp" from="^([^:]*):([^:]*):jar$" to="\2.dep"/>
                                     </propertyset>
                                 </echoproperties>
+                                <copy file="${basedir}/../osc-server-bom/root/opt/vmidc/bin/logback.xml" 
+                                      tofile="${basedir}/target/logback.xml"/>
                             </tasks>
                         </configuration>
                         <goals>


### PR DESCRIPTION
* See issue [#539](https://github.com/opensecuritycontroller/osc-core/issues/539)

* ServerControl is reverted to almost exactly what it was before logging changes.