### PR TITLE
Three AlarmDto properties were enums. Cannot set them to strings

### DIFF
--- a/osc-ui/src/main/java/org/osc/core/broker/view/alarm/BaseAlarmWindow.java
+++ b/osc-ui/src/main/java/org/osc/core/broker/view/alarm/BaseAlarmWindow.java
@@ -29,8 +29,8 @@ import org.osc.core.broker.window.button.OkCancelButtonModel;
 import org.osc.core.common.alarm.AlarmAction;
 import org.osc.core.common.alarm.EventType;
 import org.osc.core.common.alarm.Severity;
-import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.vaadin.data.Property.ValueChangeEvent;
 import com.vaadin.data.Property.ValueChangeListener;
@@ -160,7 +160,7 @@ public abstract class BaseAlarmWindow extends CRUDBaseWindow<OkCancelButtonModel
 
             @Override
             public void valueChange(ValueChangeEvent event) {
-                if (BaseAlarmWindow.this.alarmAction.getValue().equals(AlarmAction.EMAIL.toString())) {
+                if (BaseAlarmWindow.this.alarmAction.getValue().equals(AlarmAction.EMAIL)) {
                     BaseAlarmWindow.this.email.setVisible(true);
                 } else {
                     BaseAlarmWindow.this.email.setVisible(false);

--- a/osc-ui/src/main/java/org/osc/core/broker/view/alarm/UpdateAlarmWindow.java
+++ b/osc-ui/src/main/java/org/osc/core/broker/view/alarm/UpdateAlarmWindow.java
@@ -24,8 +24,8 @@ import org.osc.core.broker.service.response.BaseResponse;
 import org.osc.core.broker.view.util.ViewUtil;
 import org.osc.core.common.alarm.AlarmAction;
 import org.osc.core.common.alarm.EventType;
-import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.vaadin.data.util.BeanItem;
 import com.vaadin.ui.Notification;
@@ -95,13 +95,13 @@ public class UpdateAlarmWindow extends BaseAlarmWindow {
                 this.alarmView.getParentContainer().getContainerProperty(request.getDto().getId(), "name")
                 .setValue(this.alarmName.getValue().trim());
                 this.alarmView.getParentContainer().getContainerProperty(request.getDto().getId(), "eventType")
-                .setValue(this.eventType.getValue().toString().trim());
+                .setValue(this.eventType.getValue());
                 this.alarmView.getParentContainer().getContainerProperty(request.getDto().getId(), "regexMatch")
                 .setValue(this.regexMatch.getValue().trim());
                 this.alarmView.getParentContainer().getContainerProperty(request.getDto().getId(), "severity")
-                .setValue(this.severity.getValue().toString().trim());
+                .setValue(this.severity.getValue());
                 this.alarmView.getParentContainer().getContainerProperty(request.getDto().getId(), "alarmAction")
-                .setValue(this.alarmAction.getValue().toString().trim());
+                .setValue(this.alarmAction.getValue());
                 this.alarmView.getParentContainer().getContainerProperty(request.getDto().getId(), "receipientEmail")
                 .setValue(this.email.getValue().trim());
                 this.alarmView.getParentContainer().getContainerProperty(request.getDto().getId(), "enabledAlarm")


### PR DESCRIPTION
Intended to fix the [issue #382](https://github.com/opensecuritycontroller/osc-core/issues/382)

The parentContainer had beanBeanContainer field, which is a map created
from an object in the standard fashion (named field <-> map key name)
The object in question was an AlarmDto.

Fixed the code which attempted to set the string value where enum
expected.