### PR TITLE
Fix the wrong portGroupId: Issue 566

### DIFF
--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/DSUpdateOrDeleteMetaTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/DSUpdateOrDeleteMetaTask.java
@@ -286,7 +286,7 @@ public class DSUpdateOrDeleteMetaTask extends TransactionalMetaTask {
 
         for (DistributedApplianceInstance dai : daisToDelete) {
             // Remove any extra sva/DAI
-            log.info("Removing DAI/SVA: " + dai.getName() + " for host: " + dai.getHostName());
+            log.info("Removing DAI/SVA: %s for host: %s", dai.getName(), dai.getHostName());
             this.tg.addTask(this.deleteSvaServerAndDAIMetaTask.create(this.ds.getRegion(), dai),
                     this.firstCreatePGTask != null ? this.firstCreatePGTask : this.tg.getStartTaskNode().getTask());
         }

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/DSUpdateOrDeleteMetaTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/DSUpdateOrDeleteMetaTask.java
@@ -49,7 +49,6 @@ import org.osc.core.broker.service.tasks.IgnoreCompare;
 import org.osc.core.broker.service.tasks.TransactionalMetaTask;
 import org.osc.core.broker.service.tasks.conformance.manager.MgrCheckDevicesMetaTask;
 import org.osc.core.broker.service.tasks.conformance.openstack.DeleteOsSecurityGroupTask;
-import org.slf4j.LoggerFactory;
 import org.osgi.service.component.ComponentServiceObjects;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
@@ -57,6 +56,7 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Component(service = DSUpdateOrDeleteMetaTask.class)
 public class DSUpdateOrDeleteMetaTask extends TransactionalMetaTask {
@@ -252,7 +252,7 @@ public class DSUpdateOrDeleteMetaTask extends TransactionalMetaTask {
         }
 
         Set<DistributedApplianceInstance> existingDais = this.ds.getDistributedApplianceInstances();
-
+        Set<DistributedApplianceInstance> daisToDelete = new HashSet<>();
         for (DistributedApplianceInstance dai : existingDais) {
             String daiHostName = dai.getHostName();
             boolean isDAIHostSelectedInDs = isHostSelected(selectedHosts, daiHostName);
@@ -261,12 +261,9 @@ public class DSUpdateOrDeleteMetaTask extends TransactionalMetaTask {
             boolean doesHostNeedSva = removeHost(hostsMissingSvas, daiHostName);
             if (doesHostNeedSva && isDAIHostSelectedInDs) {
                 log.info("Conforming DAI/SVA: " + dai.getName());
-
                 addConformanceCheckTask(dai, osHostSet);
             } else {
-                // Remove any extra sva/DAI
-                log.info("Removing DAI/SVA: " + dai.getName() + " for host: " + daiHostName);
-                this.tg.addTask(this.deleteSvaServerAndDAIMetaTask.create(this.ds.getRegion(), dai));
+                daisToDelete.add(dai);
             }
         }
 
@@ -285,6 +282,13 @@ public class DSUpdateOrDeleteMetaTask extends TransactionalMetaTask {
                             LockObjectReference.getObjectReferences(this.ds)));
                 }
             }
+        }
+
+        for (DistributedApplianceInstance dai : daisToDelete) {
+            // Remove any extra sva/DAI
+            log.info("Removing DAI/SVA: " + dai.getName() + " for host: " + dai.getHostName());
+            this.tg.addTask(this.deleteSvaServerAndDAIMetaTask.create(this.ds.getRegion(), dai),
+                    this.firstCreatePGTask != null ? this.firstCreatePGTask : this.tg.getStartTaskNode().getTask());
         }
     }
 
@@ -373,7 +377,8 @@ public class DSUpdateOrDeleteMetaTask extends TransactionalMetaTask {
                     .listByDsIdAndAvailabilityZone(em, this.ds.getId(), unconformedAz);
             if (daisInZone != null) {
                 for (DistributedApplianceInstance dai : daisInZone) {
-                    this.tg.addTask(this.deleteSvaServerAndDAIMetaTask.create(this.ds.getRegion(), dai));
+                    this.tg.addTask(this.deleteSvaServerAndDAIMetaTask.create(this.ds.getRegion(), dai),
+                            this.firstCreatePGTask != null ? this.firstCreatePGTask : this.tg.getStartTaskNode().getTask());
                 }
             }
         }

--- a/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/DSUpdateOrDeleteMetaTaskTest.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/DSUpdateOrDeleteMetaTaskTest.java
@@ -16,6 +16,7 @@
  *******************************************************************************/
 package org.osc.core.broker.service.tasks.conformance.openstack.deploymentspec;
 
+import static java.util.stream.Collectors.toSet;
 import static org.osc.core.broker.service.tasks.conformance.openstack.deploymentspec.DSUpdateOrDeleteMetaTaskTestData.*;
 
 import java.util.Arrays;
@@ -78,6 +79,7 @@ public class DSUpdateOrDeleteMetaTaskTest {
 
     private TaskGraph expectedGraph;
 
+
     public DSUpdateOrDeleteMetaTaskTest(DeploymentSpec ds, TaskGraph tg) {
         this.ds = ds;
         this.expectedGraph = tg;
@@ -97,11 +99,18 @@ public class DSUpdateOrDeleteMetaTaskTest {
         populateDatabase();
 
         List<String> stringList = Arrays.asList(HS_1_1);
+
         List<AvailabilityZone> osAvailabilityZones1 = Arrays.asList(createAvailableZoneDetails(AZ_1, stringList));
         HostAggregate ha = Mockito.mock(HostAggregate.class);
         Mockito.doReturn(stringList).when(ha).getHosts();
         Mockito.doReturn("ha_name").when(ha).getName();
+
         Set<String> h1set = new HashSet<>(Arrays.asList(HS_1_1));
+        if (this.ds.getDistributedApplianceInstances().size() > 1) {
+            // For all our cases, if so, then the osHosts in here should all be defined in NovaApi
+            h1set.addAll(this.ds.getDistributedApplianceInstances().stream().map(d -> d.getName()).collect(toSet()));
+        }
+
         Mockito.doReturn(osAvailabilityZones1).when(this.novaApiMock).getAvailabilityZonesDetail(REGION_1);
         Mockito.doReturn(h1set).when(this.novaApiMock).getComputeHosts(REGION_1);
         Mockito.doReturn(ha).when(this.novaApiMock).getHostAggregateById(
@@ -184,6 +193,7 @@ public class DSUpdateOrDeleteMetaTaskTest {
             {UPDATE_NO_HOST_SELECTED_DS, createAllHostsInRegionGraph(UPDATE_NO_HOST_SELECTED_DS)},
             {UPDATE_DAI_HOST_SELECTED_DS, createDAIHostSelectedGraph(UPDATE_DAI_HOST_SELECTED_DS)},
             {UPDATE_DAI_HOST_NOT_SELECTED_DS, createDAIHostNotSelectedGraph(UPDATE_DAI_HOST_NOT_SELECTED_DS)},
+            {UPDATE_MULT_DAI_ONE_HOST_SELECTED_DS, createMultippleDAIOneHostSelectedGraph(UPDATE_MULT_DAI_ONE_HOST_SELECTED_DS)},
             {UPDATE_AZ_SELECTED_DS, createAZSelectedGraph(UPDATE_AZ_SELECTED_DS)},
             {UPDATE_DAI_HOST_NOT_IN_AZ_DS, createDaiHostNotInAZSelectedGraph(UPDATE_DAI_HOST_NOT_IN_AZ_DS)},
             {UPDATE_OPENSTACK_AZ_NOT_SELECTED_DS, createOpenStackAZNotSelectedGraph(UPDATE_OPENSTACK_AZ_NOT_SELECTED_DS)},

--- a/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/DSUpdateOrDeleteMetaTaskTestData.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/DSUpdateOrDeleteMetaTaskTestData.java
@@ -76,6 +76,15 @@ public class DSUpdateOrDeleteMetaTaskTestData {
                     HS_1_1,
                     "UPDATE_DAI_HOST_NOT_SELECTED_DAINAME");
 
+    public static DeploymentSpec UPDATE_MULT_DAI_ONE_HOST_SELECTED_DS =
+            createDsWithMultipleDaiAndHostSelectedData(
+                    "UPDATE_MULT_DAI_ONE_HOST_SELECTED_DS",
+                    REGION_1,
+                    HS_1_1,
+                    "UPDATE_DAI_HOST_NOT_SELECTED_DAI_HOSTNAME",
+                    HS_1_1,
+                    "UPDATE_MULT_DAI_ONE_HOST_SELECTED_DAINAME");
+
     public static DeploymentSpec UPDATE_AZ_SELECTED_DS =
             createDsWithAvailabilityZoneSelectedData(
                     "UPDATE_AZ_SELECTED_DS",
@@ -149,6 +158,19 @@ public class DSUpdateOrDeleteMetaTaskTestData {
         return ds;
     }
 
+    private static DeploymentSpec createDsWithMultipleDaiAndHostSelectedData(String dsName, String region, String daiHostName1, String daiHostName2, String selectedHostName, String daiName) {
+        DeploymentSpec ds = createDsWithDaiAndHostSelectedData(dsName, region, daiHostName1, selectedHostName, daiName + "_1");
+
+        DistributedApplianceInstance dai = new DistributedApplianceInstance(ds.getVirtualSystem());
+        dai.setDeploymentSpec(ds);
+        dai.setOsHostName(daiHostName2);
+        dai.setName(daiName + "_2");
+
+        ds.getDistributedApplianceInstances().add(dai);
+        ds.getVirtualSystem().addDistributedApplianceInstance(dai);
+        return ds;
+    }
+
     private static DeploymentSpec createDsForDeletionWithoutSgReferenceData(String dsName, String daiName) {
         DeploymentSpec ds = createDsWithDaiAndHostSelectedData(dsName, REGION_1, "foo", "bar", daiName);
         ds.setMarkedForDeletion(true);
@@ -218,7 +240,7 @@ public class DSUpdateOrDeleteMetaTaskTestData {
         TaskGraph expectedGraph = new TaskGraph();
         expectedGraph.addTask(
                 new OsDAIConformanceCheckMetaTask().create(
-                        (DistributedApplianceInstance) ds.getDistributedApplianceInstances().toArray()[0],
+                        ds.getDistributedApplianceInstances().iterator().next(),
                         true));
         return expectedGraph;
     }
@@ -228,8 +250,24 @@ public class DSUpdateOrDeleteMetaTaskTestData {
         Task firstCreateTask = new OsSvaCreateMetaTask().create(ds, HS_1_1, AZ_1);
         expectedGraph.addTask(firstCreateTask);
         expectedGraph.addTask(new DeleteSvaServerAndDAIMetaTask().create(ds.getRegion(),
-                (DistributedApplianceInstance) ds.getDistributedApplianceInstances().toArray()[0]),
+                ds.getDistributedApplianceInstances().iterator().next()),
                 firstCreateTask);
+
+        return expectedGraph;
+    }
+
+    public static TaskGraph createMultippleDAIOneHostSelectedGraph(DeploymentSpec ds) {
+        TaskGraph expectedGraph = new TaskGraph();
+
+        DistributedApplianceInstance daiToConform = ds.getDistributedApplianceInstances().stream()
+                .filter(d -> d.getOsHostName().equals(HS_1_1)).findFirst().get();
+
+        DistributedApplianceInstance daiToDelete = ds.getDistributedApplianceInstances().stream()
+                .filter(d -> !d.getOsHostName().equals(HS_1_1)).findFirst().get();
+
+        Task firstAddTask = new OsDAIConformanceCheckMetaTask().create(daiToConform, true);
+        expectedGraph.addTask(firstAddTask);
+        expectedGraph.addTask(new DeleteSvaServerAndDAIMetaTask().create(ds.getRegion(), daiToDelete), firstAddTask);
 
         return expectedGraph;
     }
@@ -237,38 +275,38 @@ public class DSUpdateOrDeleteMetaTaskTestData {
     public static TaskGraph createDAIHostAggregateNotSelectedGraph(DeploymentSpec ds) {
         TaskGraph expectedGraph = new TaskGraph();
         expectedGraph.addTask(new DeleteSvaServerAndDAIMetaTask().create(ds.getRegion(),
-                (DistributedApplianceInstance) ds.getDistributedApplianceInstances().toArray()[0]));
+                ds.getDistributedApplianceInstances().iterator().next()));
         return expectedGraph;
     }
 
     public static TaskGraph createAZSelectedGraph(DeploymentSpec ds) {
         TaskGraph expectedGraph = new TaskGraph();
-        expectedGraph.addTask(new OsDAIConformanceCheckMetaTask().create((DistributedApplianceInstance) UPDATE_AZ_SELECTED_DAIS.toArray()[0], true));
+        expectedGraph.addTask(new OsDAIConformanceCheckMetaTask().create(UPDATE_AZ_SELECTED_DAIS.iterator().next(), true));
         return expectedGraph;
     }
 
     public static TaskGraph createDaiHostNotInAZSelectedGraph(DeploymentSpec ds) {
         TaskGraph expectedGraph = new TaskGraph();
-        Task conformCheck = new OsDAIConformanceCheckMetaTask().create((DistributedApplianceInstance) UPDATE_DAI_HOST_NOT_IN_AZ_DAIS.toArray()[0], false);
+        Task conformCheck = new OsDAIConformanceCheckMetaTask().create(UPDATE_DAI_HOST_NOT_IN_AZ_DAIS.iterator().next(), false);
 
         expectedGraph.addTask(conformCheck);
-        expectedGraph.addTask(new OsSvaCreateMetaTask().create(ds, HS_1_1, ((AvailabilityZone)ds.getAvailabilityZones().toArray()[0]).getZone()), conformCheck);
+        expectedGraph.addTask(new OsSvaCreateMetaTask().create(ds, HS_1_1, (ds.getAvailabilityZones().iterator().next()).getZone()), conformCheck);
 
         return expectedGraph;
     }
 
     public static TaskGraph createOpenStackAZNotSelectedGraph(DeploymentSpec ds) {
         TaskGraph expectedGraph = new TaskGraph();
-        Task firstCreateTask = new OsDAIConformanceCheckMetaTask().create((DistributedApplianceInstance) UPDATE_OPENSTACK_AZ_NOT_SELECTED_DAIS.toArray()[0], false);
+        Task firstCreateTask = new OsDAIConformanceCheckMetaTask().create(UPDATE_OPENSTACK_AZ_NOT_SELECTED_DAIS.iterator().next(), false);
         expectedGraph.addTask(firstCreateTask);
-        expectedGraph.addTask(new DeleteSvaServerAndDAIMetaTask().create(ds.getRegion(), (DistributedApplianceInstance) UPDATE_OPENSTACK_AZ_NOT_SELECTED_DAIS.toArray()[0]),
+        expectedGraph.addTask(new DeleteSvaServerAndDAIMetaTask().create(ds.getRegion(), UPDATE_OPENSTACK_AZ_NOT_SELECTED_DAIS.iterator().next()),
                 firstCreateTask);
         return expectedGraph;
     }
 
     public static TaskGraph createDeleteDsGraph(DeploymentSpec ds) {
         TaskGraph expectedGraph = new TaskGraph();
-        expectedGraph.addTask(new DeleteSvaServerAndDAIMetaTask().create(ds.getRegion(), (DistributedApplianceInstance) ds.getDistributedApplianceInstances().toArray()[0]));
+        expectedGraph.addTask(new DeleteSvaServerAndDAIMetaTask().create(ds.getRegion(), ds.getDistributedApplianceInstances().iterator().next()));
         if (ds.getOsSecurityGroupReference() != null) {
             expectedGraph.appendTask(new DeleteOsSecurityGroupTask().create(ds, ds.getOsSecurityGroupReference()));
         }

--- a/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/DSUpdateOrDeleteMetaTaskTestData.java
+++ b/osc-server/src/test/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/DSUpdateOrDeleteMetaTaskTestData.java
@@ -225,10 +225,12 @@ public class DSUpdateOrDeleteMetaTaskTestData {
 
     public static TaskGraph createDAIHostNotSelectedGraph(DeploymentSpec ds) {
         TaskGraph expectedGraph = new TaskGraph();
+        Task firstCreateTask = new OsSvaCreateMetaTask().create(ds, HS_1_1, AZ_1);
+        expectedGraph.addTask(firstCreateTask);
         expectedGraph.addTask(new DeleteSvaServerAndDAIMetaTask().create(ds.getRegion(),
-                (DistributedApplianceInstance) ds.getDistributedApplianceInstances().toArray()[0]));
+                (DistributedApplianceInstance) ds.getDistributedApplianceInstances().toArray()[0]),
+                firstCreateTask);
 
-        expectedGraph.addTask(new OsSvaCreateMetaTask().create(ds, HS_1_1, AZ_1));
         return expectedGraph;
     }
 
@@ -257,8 +259,10 @@ public class DSUpdateOrDeleteMetaTaskTestData {
 
     public static TaskGraph createOpenStackAZNotSelectedGraph(DeploymentSpec ds) {
         TaskGraph expectedGraph = new TaskGraph();
-        expectedGraph.addTask(new OsDAIConformanceCheckMetaTask().create((DistributedApplianceInstance) UPDATE_OPENSTACK_AZ_NOT_SELECTED_DAIS.toArray()[0], false));
-        expectedGraph.addTask(new DeleteSvaServerAndDAIMetaTask().create(ds.getRegion(), (DistributedApplianceInstance) UPDATE_OPENSTACK_AZ_NOT_SELECTED_DAIS.toArray()[0]));
+        Task firstCreateTask = new OsDAIConformanceCheckMetaTask().create((DistributedApplianceInstance) UPDATE_OPENSTACK_AZ_NOT_SELECTED_DAIS.toArray()[0], false);
+        expectedGraph.addTask(firstCreateTask);
+        expectedGraph.addTask(new DeleteSvaServerAndDAIMetaTask().create(ds.getRegion(), (DistributedApplianceInstance) UPDATE_OPENSTACK_AZ_NOT_SELECTED_DAIS.toArray()[0]),
+                firstCreateTask);
         return expectedGraph;
     }
 


### PR DESCRIPTION
* Make sure the svaAndDAIDelete tasks run after at least one daiAdd task.
* Tested with a two-hypervisor system.
* [issue 566](https://github.com/opensecuritycontroller/osc-core/issues/566)