### PR TITLE
Fix #454: Adding VC with invalid credentials/ip does not provide warning

### DIFF
--- a/osc-server/src/main/java/org/osc/core/broker/util/VirtualizationConnectorUtil.java
+++ b/osc-server/src/main/java/org/osc/core/broker/util/VirtualizationConnectorUtil.java
@@ -19,10 +19,13 @@ package org.osc.core.broker.util;
 import static org.osc.core.common.virtualization.VirtualizationConnectorProperties.ATTRIBUTE_KEY_HTTPS;
 
 import java.io.IOException;
+import java.net.ConnectException;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.openstack4j.api.exceptions.AuthenticationException;
+import org.openstack4j.api.exceptions.ConnectionException;
 import org.osc.core.broker.model.entities.virtualization.VirtualizationConnector;
 import org.osc.core.broker.model.plugin.ApiFactoryService;
 import org.osc.core.broker.rest.client.k8s.KubernetesClient;
@@ -177,7 +180,7 @@ public class VirtualizationConnectorUtil {
         errorTypeException = this.checkSDNControllerConnection(request, certificateResolverModels, vc);
 
         // Check Connectivity with Key stone if https response exception is not to be ignored
-        if (!request.isIgnoreErrorsAndCommit(ErrorType.PROVIDER_EXCEPTION)) {
+		if (errorTypeException == null && !request.isIgnoreErrorsAndCommit(ErrorType.PROVIDER_EXCEPTION)) {
             initSSLCertificatesListener(this.managerFactory, certificateResolverModels, "openstackkeystone");
             try {
                 VirtualizationConnectorDto vcDto = request.getDto();
@@ -194,7 +197,11 @@ public class VirtualizationConnectorUtil {
                 this.keystoneApi.listProjects();
 
             } catch (Exception exception) {
-                errorTypeException = new ErrorTypeException(exception, ErrorType.PROVIDER_EXCEPTION);
+				if (exception instanceof ConnectionException || exception instanceof AuthenticationException) {
+					errorTypeException = new ErrorTypeException(new ConnectException(), ErrorType.PROVIDER_EXCEPTION);
+				} else {
+					errorTypeException = new ErrorTypeException(exception, ErrorType.PROVIDER_EXCEPTION);
+				}
                 LOG.warn(
                         "Exception encountered when trying to add Keystone info to Virtualization Connector, allowing user to either ignore or correct issue");
             } finally {
@@ -205,7 +212,7 @@ public class VirtualizationConnectorUtil {
             }
         }
 
-        if (!request.isIgnoreErrorsAndCommit(ErrorType.RABBITMQ_EXCEPTION)) {
+        if (errorTypeException == null && !request.isIgnoreErrorsAndCommit(ErrorType.RABBITMQ_EXCEPTION)) {
             initSSLCertificatesListener(this.managerFactory, certificateResolverModels, "rabbitmq");
             try {
                 OsRabbitMQClient rabbitClient = new OsRabbitMQClient(vc);

--- a/osc-server/src/main/java/org/osc/core/broker/util/VirtualizationConnectorUtil.java
+++ b/osc-server/src/main/java/org/osc/core/broker/util/VirtualizationConnectorUtil.java
@@ -19,7 +19,6 @@ package org.osc.core.broker.util;
 import static org.osc.core.common.virtualization.VirtualizationConnectorProperties.ATTRIBUTE_KEY_HTTPS;
 
 import java.io.IOException;
-import java.net.ConnectException;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -197,8 +196,10 @@ public class VirtualizationConnectorUtil {
                 this.keystoneApi.listProjects();
 
             } catch (Exception exception) {
-				if (exception instanceof ConnectionException || exception instanceof AuthenticationException) {
-					errorTypeException = new ErrorTypeException(new ConnectException(), ErrorType.PROVIDER_EXCEPTION);
+				if (exception instanceof ConnectionException) {
+					errorTypeException = new ErrorTypeException(exception, ErrorType.PROVIDER_CONNECT_EXCEPTION);
+				} else if (exception instanceof AuthenticationException) {
+					errorTypeException = new ErrorTypeException(exception, ErrorType.PROVIDER_AUTH_EXCEPTION);
 				} else {
 					errorTypeException = new ErrorTypeException(exception, ErrorType.PROVIDER_EXCEPTION);
 				}

--- a/osc-service-api/src/main/java/org/osc/core/broker/service/request/ErrorTypeException.java
+++ b/osc-service-api/src/main/java/org/osc/core/broker/service/request/ErrorTypeException.java
@@ -24,9 +24,15 @@ import org.osc.core.broker.service.exceptions.VmidcBrokerValidationException;
 @SuppressWarnings("serial")
 public class ErrorTypeException extends VmidcBrokerValidationException {
 
-    public enum ErrorType {
-        CONTROLLER_EXCEPTION, PROVIDER_EXCEPTION, IP_CHANGED_EXCEPTION, MANAGER_CONNECTOR_EXCEPTION, RABBITMQ_EXCEPTION;
-    }
+	public enum ErrorType {
+		CONTROLLER_EXCEPTION,
+		PROVIDER_EXCEPTION,
+		PROVIDER_CONNECT_EXCEPTION,
+		PROVIDER_AUTH_EXCEPTION,
+		IP_CHANGED_EXCEPTION,
+		MANAGER_CONNECTOR_EXCEPTION,
+		RABBITMQ_EXCEPTION;
+	}
 
     private ErrorType type;
 

--- a/osc-ui/src/main/java/org/osc/core/broker/view/vc/BaseVCWindow.java
+++ b/osc-ui/src/main/java/org/osc/core/broker/view/vc/BaseVCWindow.java
@@ -303,13 +303,20 @@ public abstract class BaseVCWindow extends CRUDBaseWindow<OkCancelButtonModel> {
             exception = originalException.getCause();
 
             // TODO this exception leaks large amounts of implementation detail out of the API
-            if (errorType == ErrorType.PROVIDER_EXCEPTION) {
-                if (RestClientException.isConnectException(exception) && isOpenstack()) {
-                    // Keystone Connect Exception
-                    contentText = VmidcMessages.getString(VmidcMessages_.VC_CONFIRM_IP, KEYSTONE_CAPTION);
-                }
-            } else if (errorType == ErrorType.CONTROLLER_EXCEPTION) {
-                if (RestClientException.isCredentialError(exception)) {
+			if (errorType == ErrorType.PROVIDER_EXCEPTION) {
+				if (RestClientException.isConnectException(exception) && isOpenstack()) {
+					// Keystone Connect Exception
+					contentText = VmidcMessages.getString(VmidcMessages_.VC_CONFIRM_IP, KEYSTONE_CAPTION);
+				}
+			} else if (errorType == ErrorType.PROVIDER_CONNECT_EXCEPTION && isOpenstack()) {
+				// Keystone Connect Exception
+				// Handle ConnectionException(Not a standard exception) thrown by OpenStack4j
+				contentText = VmidcMessages.getString(VmidcMessages_.VC_CONFIRM_IP, KEYSTONE_CAPTION);
+			} else if (errorType == ErrorType.PROVIDER_AUTH_EXCEPTION && isOpenstack()) {
+				// Keystone Authentication Exception
+				contentText = VmidcMessages.getString(VmidcMessages_.VC_CONFIRM_CREDS, KEYSTONE_CAPTION);
+			} else if (errorType == ErrorType.CONTROLLER_EXCEPTION) {
+				if (RestClientException.isCredentialError(exception)) {
                     if (isOpenstack()) {
                         // SDN Invalid Credential Exception
                         contentText = VmidcMessages.getString(VmidcMessages_.VC_CONFIRM_CREDS,

--- a/osc-ui/src/main/resources/org/osc/core/broker/view/common/VmidcMessages.properties
+++ b/osc-ui/src/main/resources/org/osc/core/broker/view/common/VmidcMessages.properties
@@ -104,7 +104,6 @@ vc.confirm.creds = The supplied credentials for {0} are not valid. <br/><br/>Are
 vc.confirm.ip = Failed to connect to ''{0}''. <br/><br/> Possible reasons: \
 <ul>\
 <li>Incorrect IP address information</li>\
-<li>Credentials are wrong</li>\
 <li>Invalid domain id</li>\
 <li>Network connectivity</li>\
 <li>Server end point is down</li>\

--- a/osc-ui/src/main/resources/org/osc/core/broker/view/common/VmidcMessages.properties
+++ b/osc-ui/src/main/resources/org/osc/core/broker/view/common/VmidcMessages.properties
@@ -104,6 +104,8 @@ vc.confirm.creds = The supplied credentials for {0} are not valid. <br/><br/>Are
 vc.confirm.ip = Failed to connect to ''{0}''. <br/><br/> Possible reasons: \
 <ul>\
 <li>Incorrect IP address information</li>\
+<li>Credentials are wrong</li>\
+<li>Invalid domain id</li>\
 <li>Network connectivity</li>\
 <li>Server end point is down</li>\
 <li>SSL certificates are not set</li>\


### PR DESCRIPTION
Adding VC with invalid credentials/ip does not provide warning

## Description
Adding VC with invalid credentials/ip does not provide a warning allow you to ignore and continue.

## Motivation and Context
https://github.com/opensecuritycontroller/osc-core/issues/454

## How Has This Been Tested?
Manually verified. Unit tests are passing.