### PR TITLE
 moved make file from xml to makefile cmd script and added proxy scri…

### DIFF
--- a/osc-server-bom/bin/create-centos
+++ b/osc-server-bom/bin/create-centos
@@ -5,6 +5,7 @@ apt-get install schroot yum rpm
 #
 # Build the centos env for install
 #
+mkdir -p /var/www/
 mkdir -p $BUILDDIR-bootstrap/proc
 mkdir -p $BUILDDIR-bootstrap/sys
 mkdir -p $BUILDDIR-bootstrap/mnt/sysimage
@@ -32,6 +33,7 @@ mount --bind /var/www $BUILDDIR-bootstrap/var/www/
 mount --bind $BUILDDIR $BUILDDIR-bootstrap/mnt/sysimage
 cp centos-6.yum.conf $BUILDDIR-bootstrap/
 cp /etc/resolv.conf $BUILDDIR-bootstrap/etc/
+cp /etc/profile.d/proxy.sh $BUILDDIR-bootstrap/etc/profile.d/
 
 chroot $BUILDDIR-bootstrap rpmdb --root /mnt/sysimage --initdb
 chroot $BUILDDIR-bootstrap rpm --root=/mnt/sysimage --import /RPM-GPG-KEY-CENTOS6.pub
@@ -60,6 +62,7 @@ find $BUILDDIR/var/lib/yum -type d -exec chmod 755 {} \;
 # 
 #
 install -o root -g root -m 644 /etc/resolv.conf $BUILDDIR/etc/
+install -o root -g root -m 777 /etc/profile.d/proxy.sh $BUILDDIR/etc/profile.d/
 install -o root -g root -m 600 /etc/sudoers $BUILDDIR/etc/
 getent passwd > $BUILDDIR/etc/passwd
 getent group > $BUILDDIR/etc/group
@@ -77,6 +80,9 @@ root-groups=sudo
 users=jenkins
 groups=vmidc
 EOF
+
+mkdir -p /var/lib/jenkins
+chmod 400 /etc/schroot/chroot.d/centos.conf
 
 cat >> /etc/schroot/default/fstab << EOF
 /var/lib/jenkins/ /var/lib/jenkins/ none rw,bind        0       0

--- a/osc-server-bom/build.xml
+++ b/osc-server-bom/build.xml
@@ -22,13 +22,7 @@
       <arg value="clean" />
     </exec>
     <exec executable="sudo" resultproperty="ovf.result">
-      <arg value="make" />
-      <arg value="image-format=${image-format}"/>
-      <arg value="buildNumber=${buildNumber}"/>
-      <arg value="-j" />
-      <arg value="--no-print-directory"/>
-      <arg value="-f" />
-      <arg value="makefiles/master.mk" />
+	    <arg value="./make-cmd-line.sh" />
     </exec>
   </target>
 

--- a/osc-server-bom/make-cmd-line.sh
+++ b/osc-server-bom/make-cmd-line.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+source /etc/profile.d/proxy.sh > /dev/null 2>&1
+make image-format=${image-format} buildNumber=${buildNumber} -j --no-print-directory -f makefiles/master.mk

--- a/osc-server-bom/makefiles/master.mk
+++ b/osc-server-bom/makefiles/master.mk
@@ -19,19 +19,6 @@ bindir=$(realpath $(makedir)/..)/bin
 
 export buildNumber blddir bindir
 
-#Proxy setting needed for jenkins. By default these env variables exist in the shell. But for jenkins shell we have to add these env variables
-#here,due to a bug in jenkins.
-export http_proxy=http://proxy-us.intel.com:911
-export https_proxy=http://proxy-us.intel.com:912
-export ftp_proxy=http://proxy-us.intel.com:911
-export socks_proxy=http://proxy-us.intel.com:1080
-export HTTP_PROXY=http://proxy-us.intel.com:911
-export HTTPS_PROXY=http://proxy-us.intel.com:912
-export FTP_PROXY=http://proxy-us.intel.com:911
-export SOCKS_PROXY=http://proxy-us.intel.com:1080
-export NO_PROXY=.corp.nai.org,corp.nai.org,intel.com,.intel.com,10.0.0.0/8,192.168.0.0/16,localhost,.local,127.0.0.0/8,134.134.0.0/16
-export no_proxy=.corp.nai.org,corp.nai.org,intel.com,.intel.com,10.0.0.0/8,192.168.0.0/16,localhost,.local,127.0.0.0/8,134.134.0.0/16
-
 dowithbindmount= \
      mount -o loop boot.img $(blddir)/boot && \
      trap "umount -d $(blddir)/boot" EXIT &&

--- a/osc-server-bom/repo/centos-epel.yum.conf
+++ b/osc-server-bom/repo/centos-epel.yum.conf
@@ -17,6 +17,5 @@ name=Centos EPEL base
 mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch
 gpgcheck=1
 enabled=1
-#gpgkey=http://ftp.riken.jp/Linux/fedora/epel/RPM-GPG-KEY-EPEL-6
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6
+gpgkey=http://ftp.riken.jp/Linux/fedora/epel/RPM-GPG-KEY-EPEL-6
 


### PR DESCRIPTION
## Description
Removing intel proxies that were part of make file in build environment.

## Motivation and Context:
This is related to bug https://github.com/opensecuritycontroller/community/issues/87 filed by user outside intel, that they are not able to get all the repos from centos. Removing the intel proxies fixed this issue.

## Has this been Tested:
This is been tested, by making sure build is successful after fixing proxy setup .

## Types of Changes : 
A script is added to configure proxies in chroot environment . According the documentation on build process is updated.
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Check-list:
No unit tests.
Coding style followed