### PR TITLE
Are-you-sure dialogue to let the user back out of replacing the internal keys.

### DIFF
--- a/osc-server/src/main/java/org/osc/core/broker/service/ReplaceInternalKeypairService.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/ReplaceInternalKeypairService.java
@@ -34,6 +34,7 @@ implements ReplaceInternalKeypairServiceApi {
 
     private static final String FILENAME_EXTENSION = ".zip";
     private static final String FILENAME_PREFIX = "repl_keystore";
+
     @Reference
     private X509TrustManagerApi x509TrustManagerApi;
 

--- a/osc-ui/src/main/java/org/osc/core/broker/view/maintenance/InternalCertReplacementUploader.java
+++ b/osc-ui/src/main/java/org/osc/core/broker/view/maintenance/InternalCertReplacementUploader.java
@@ -22,10 +22,17 @@ import static org.osc.core.broker.view.common.VmidcMessages_.*;
 import java.io.File;
 
 import org.osc.core.broker.service.ssl.X509TrustManagerApi;
+import org.osc.core.broker.view.util.ViewUtil;
+import org.osc.core.broker.window.VmidcWindow;
+import org.osc.core.broker.window.WindowUtil;
+import org.osc.core.broker.window.button.OkCancelButtonModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.ui.Button;
+import com.vaadin.ui.Button.ClickEvent;
 import com.vaadin.ui.Label;
+import com.vaadin.ui.Notification;
 import com.vaadin.ui.Panel;
 
 public class InternalCertReplacementUploader extends SslCertificateUploader {
@@ -52,11 +59,33 @@ public class InternalCertReplacementUploader extends SslCertificateUploader {
         this.upload.setDescription(getString(KEYPAIR_UPLOAD_DESCR));
     }
 
+    @SuppressWarnings("serial")
     @Override
     protected void processCertificateFile(File file) throws Exception {
         log.info("================ SSL certificate upload completed");
         log.info("================ Replacing internal certificate in truststore...");
-        this.x509TrustManager.replaceInternalCertificate(file, true);
-        removeUploadedFile();
+
+        final VmidcWindow<OkCancelButtonModel> alertWindow =
+                WindowUtil.createAlertWindow("Warning", getString(KEYPAIR_UPLOAD_WARN_CONFIRM));
+
+        alertWindow.getComponentModel().setOkClickedListener(new Button.ClickListener(){
+            @Override
+            public void buttonClick(ClickEvent event) {
+                try {
+                    InternalCertReplacementUploader.this.x509TrustManager.replaceInternalCertificate(file, true);
+                } catch (Exception e) {
+                    ViewUtil.iscNotification(e.getMessage(), Notification.Type.ERROR_MESSAGE);
+                } finally {
+                    alertWindow.close();
+                }
+            }});
+        alertWindow.getComponentModel().setCancelClickedListener(new Button.ClickListener(){
+            @Override
+            public void buttonClick(ClickEvent event) {
+                removeUploadedFile();
+                alertWindow.close();
+            }});
+
+        ViewUtil.addWindow(alertWindow);
     }
 }

--- a/osc-ui/src/main/java/org/osc/core/broker/view/maintenance/InternalCertReplacementUploader.java
+++ b/osc-ui/src/main/java/org/osc/core/broker/view/maintenance/InternalCertReplacementUploader.java
@@ -19,8 +19,6 @@ package org.osc.core.broker.view.maintenance;
 import static org.osc.core.broker.view.common.VmidcMessages.getString;
 import static org.osc.core.broker.view.common.VmidcMessages_.*;
 
-import java.io.File;
-
 import org.osc.core.broker.service.ssl.X509TrustManagerApi;
 import org.osc.core.broker.view.util.ViewUtil;
 import org.osc.core.broker.window.VmidcWindow;
@@ -59,20 +57,27 @@ public class InternalCertReplacementUploader extends SslCertificateUploader {
         this.upload.setDescription(getString(KEYPAIR_UPLOAD_DESCR));
     }
 
-    @SuppressWarnings("serial")
     @Override
-    protected void processCertificateFile(File file) throws Exception {
+    protected void processCertificateFile() throws Exception {
         log.info("================ SSL certificate upload completed");
         log.info("================ Replacing internal certificate in truststore...");
 
         final VmidcWindow<OkCancelButtonModel> alertWindow =
                 WindowUtil.createAlertWindow("Warning", getString(KEYPAIR_UPLOAD_WARN_CONFIRM));
 
+        setupOkClickedListener(alertWindow);
+        setupCancelClickedListener(alertWindow);
+        ViewUtil.addWindow(alertWindow);
+    }
+
+    @SuppressWarnings("serial")
+    private void setupOkClickedListener(final VmidcWindow<OkCancelButtonModel> alertWindow) {
         alertWindow.getComponentModel().setOkClickedListener(new Button.ClickListener(){
             @Override
             public void buttonClick(ClickEvent event) {
                 try {
-                    InternalCertReplacementUploader.this.x509TrustManager.replaceInternalCertificate(file, true);
+                    InternalCertReplacementUploader.this.x509TrustManager
+                        .replaceInternalCertificate(InternalCertReplacementUploader.this.file, true);
                 } catch (Exception e) {
                     ViewUtil.iscNotification(e.getMessage(), Notification.Type.ERROR_MESSAGE);
                 } finally {
@@ -80,6 +85,10 @@ public class InternalCertReplacementUploader extends SslCertificateUploader {
                     removeUploadedFile();
                 }
             }});
+    }
+
+    @SuppressWarnings("serial")
+    private void setupCancelClickedListener(final VmidcWindow<OkCancelButtonModel> alertWindow) {
         alertWindow.getComponentModel().setCancelClickedListener(new Button.ClickListener(){
             @Override
             public void buttonClick(ClickEvent event) {
@@ -87,7 +96,5 @@ public class InternalCertReplacementUploader extends SslCertificateUploader {
                 alertWindow.close();
                 ViewUtil.iscNotification(getString(KEYPAIR_NOT_REPLACED), Notification.Type.WARNING_MESSAGE);
             }});
-
-        ViewUtil.addWindow(alertWindow);
     }
 }

--- a/osc-ui/src/main/java/org/osc/core/broker/view/maintenance/InternalCertReplacementUploader.java
+++ b/osc-ui/src/main/java/org/osc/core/broker/view/maintenance/InternalCertReplacementUploader.java
@@ -77,6 +77,7 @@ public class InternalCertReplacementUploader extends SslCertificateUploader {
                     ViewUtil.iscNotification(e.getMessage(), Notification.Type.ERROR_MESSAGE);
                 } finally {
                     alertWindow.close();
+                    removeUploadedFile();
                 }
             }});
         alertWindow.getComponentModel().setCancelClickedListener(new Button.ClickListener(){

--- a/osc-ui/src/main/java/org/osc/core/broker/view/maintenance/InternalCertReplacementUploader.java
+++ b/osc-ui/src/main/java/org/osc/core/broker/view/maintenance/InternalCertReplacementUploader.java
@@ -84,6 +84,7 @@ public class InternalCertReplacementUploader extends SslCertificateUploader {
             public void buttonClick(ClickEvent event) {
                 removeUploadedFile();
                 alertWindow.close();
+                ViewUtil.iscNotification(getString(KEYPAIR_NOT_REPLACED), Notification.Type.WARNING_MESSAGE);
             }});
 
         ViewUtil.addWindow(alertWindow);

--- a/osc-ui/src/main/java/org/osc/core/broker/view/maintenance/SslCertificateUploader.java
+++ b/osc-ui/src/main/java/org/osc/core/broker/view/maintenance/SslCertificateUploader.java
@@ -51,9 +51,10 @@ public class SslCertificateUploader extends CustomComponent implements Receiver,
     private static final Logger log = LoggerFactory.getLogger(SslCertificateUploader.class);
 
     private static final long serialVersionUID = 1L;
-    private File file;
+
     private UploadNotifier uploadNotifier;
 
+    protected File file;
     protected Upload upload;
     protected final VerticalLayout verLayout = new VerticalLayout();
 
@@ -128,7 +129,7 @@ public class SslCertificateUploader extends CustomComponent implements Receiver,
     public void uploadSucceeded(SucceededEvent event) {
         boolean succeeded = true;
         try {
-            processCertificateFile(this.file);
+            processCertificateFile();
             log.info("=============== Upload certificate succeeded");
             repaintUpload();
         } catch (Exception ex) {
@@ -143,13 +144,13 @@ public class SslCertificateUploader extends CustomComponent implements Receiver,
         }
     }
 
-    protected void processCertificateFile(File file) throws Exception {
+    protected void processCertificateFile() throws Exception {
         log.info("================ SSL certificate upload completed");
         log.info("================ Adding new entry to truststore...");
         ViewUtil.iscNotification(getString(MAINTENANCE_SSLCONFIGURATION_SUCCESSFUL, new Date()),
                 null, Notification.Type.TRAY_NOTIFICATION);
 
-        this.x509TrustManager.addEntry(file);
+        this.x509TrustManager.addEntry(this.file);
         removeUploadedFile();
     }
 

--- a/osc-ui/src/main/java/org/osc/core/broker/view/maintenance/SslCertificateUploader.java
+++ b/osc-ui/src/main/java/org/osc/core/broker/view/maintenance/SslCertificateUploader.java
@@ -129,8 +129,6 @@ public class SslCertificateUploader extends CustomComponent implements Receiver,
         boolean succeeded = true;
         try {
             processCertificateFile(this.file);
-            ViewUtil.iscNotification(getString(MAINTENANCE_SSLCONFIGURATION_SUCCESSFUL, new Date()),
-                    null, Notification.Type.TRAY_NOTIFICATION);
             log.info("=============== Upload certificate succeeded");
             repaintUpload();
         } catch (Exception ex) {
@@ -148,6 +146,8 @@ public class SslCertificateUploader extends CustomComponent implements Receiver,
     protected void processCertificateFile(File file) throws Exception {
         log.info("================ SSL certificate upload completed");
         log.info("================ Adding new entry to truststore...");
+        ViewUtil.iscNotification(getString(MAINTENANCE_SSLCONFIGURATION_SUCCESSFUL, new Date()),
+                null, Notification.Type.TRAY_NOTIFICATION);
 
         this.x509TrustManager.addEntry(file);
         removeUploadedFile();

--- a/osc-ui/src/main/resources/org/osc/core/broker/view/common/VmidcMessages.properties
+++ b/osc-ui/src/main/resources/org/osc/core/broker/view/common/VmidcMessages.properties
@@ -232,5 +232,5 @@ keypair.upload.title = Replace internal key pair from key store.
 keypair.internal.display.alias = internal
 keypair.upload.button.txt = Upload ZIP
 certificate.upload.title = Upload certificate
-
+keypair.not.replaced= Key pair not replaced.
 

--- a/osc-ui/src/main/resources/org/osc/core/broker/view/common/VmidcMessages.properties
+++ b/osc-ui/src/main/resources/org/osc/core/broker/view/common/VmidcMessages.properties
@@ -227,6 +227,7 @@ with .pem or .pkipath extension.<br/>\
 <b>This operation will result in server restart ! ! !</b><br/>
 
 keypair.upload.warn.restart = WARNING: Replacing the internal key pair results in server restart!
+keypair.upload.warn.confirm = Replacing the internal key pair and restarting! Are you sure?
 keypair.upload.title = Replace internal key pair from key store.
 keypair.internal.display.alias = internal
 keypair.upload.button.txt = Upload ZIP

--- a/osc-ui/src/main/resources/org/osc/core/broker/view/common/VmidcMessages.properties
+++ b/osc-ui/src/main/resources/org/osc/core/broker/view/common/VmidcMessages.properties
@@ -232,5 +232,5 @@ keypair.upload.title = Replace internal key pair from key store.
 keypair.internal.display.alias = internal
 keypair.upload.button.txt = Upload ZIP
 certificate.upload.title = Upload certificate
-keypair.not.replaced= Key pair not replaced.
+keypair.not.replaced= Key pair will not be replaced. Deleting the uploaded file.
 


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description

With the previous change, when replacing the internal keys, the user was not given the "are-you-sure" last chance dialogue. Upload button resulted in uploading the keys and restarting.

<!--- Describe your change in detail -->

## Motivation and Context
Usability issue.

## How Has This Been Tested?
In my IDE.

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code style guidelines](https://github.com/opensecuritycontroller/community/blob/master/development/eclipse.md) of this project
- [x] My unit test follow the [Unit test guidelines](https://github.com/opensecuritycontroller/community/blob/master/development/unit_test_guidelines.md)
- [x] Unit test coverage percentage is maintained(increased/remains the same but not decreased)