### PR TITLE
Fixing bug #627: can delete bound SGs now.

### DIFF
--- a/osc-server/src/main/java/org/osc/core/broker/service/securitygroup/BindSecurityGroupService.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/securitygroup/BindSecurityGroupService.java
@@ -18,6 +18,7 @@ package org.osc.core.broker.service.securitygroup;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -122,19 +123,20 @@ public class BindSecurityGroupService extends ServiceDispatcher<BindSecurityGrou
 					throw new VmidcBrokerValidationException(
 							"Security group interface cannot have more than one policy for security manager not supporting multiple policy binding");
 				}
-				if (!isPolicyMappingSupported && !serviceToBindTo.getPolicyIds().isEmpty()) {
-					throw new VmidcBrokerValidationException(
-							"Security manager not supporting policy mapping cannot have one or more policies");
-				}
-				if (isPolicyMappingSupported && serviceToBindTo.getPolicyIds().isEmpty()) {
-					throw new VmidcBrokerValidationException(
-							"Service to bind: " + serviceToBindTo + " must have a policy id.");
-				}
 
-				Set<Policy> policies = null;
-				policies = PolicyEntityMgr.findPoliciesById(em, serviceToBindTo.getPolicyIds(),
-						vs.getDistributedAppliance().getApplianceManagerConnector());
+                Set<Long> policyIds = serviceToBindTo.getPolicyIds() != null ? serviceToBindTo.getPolicyIds() : new HashSet<>();
+                if (!isPolicyMappingSupported && !policyIds.isEmpty()) {
+                    throw new VmidcBrokerValidationException(
+                            "Security manager not supporting policy mapping cannot have one or more policies");
+                }
+                if (isPolicyMappingSupported && policyIds.isEmpty()) {
+                    throw new VmidcBrokerValidationException(
+                            "Service to bind: " + serviceToBindTo + " must have a policy id.");
+                }
 
+                Set<Policy> policies = null;
+                policies = PolicyEntityMgr.findPoliciesById(em, policyIds,
+                        vs.getDistributedAppliance().getApplianceManagerConnector());
 				if (this.apiFactoryService.supportsFailurePolicy(this.securityGroup)) {
 					// If failure policy is supported, failure policy is a required field
 					if (serviceToBindTo.getFailurePolicyType() == null

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/SecurityGroupMemberDeleteTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/SecurityGroupMemberDeleteTask.java
@@ -162,13 +162,13 @@ public class SecurityGroupMemberDeleteTask extends TransactionalTask {
         OSCEntityManager.delete(em, port, this.txBroadcastUtil);
     }
 
+    /**
+     * This method is only called when all the ports are gone.
+     * @param em
+     * @param vm
+     */
     private void deleteFromDB(EntityManager em, VM vm) {
         this.log.info("Removing vm " + vm);
-
-        for (VMPort port : vm.getPorts()) {
-            deleteFromDB(em, port);
-        }
-
         OSCEntityManager.delete(em, vm, this.txBroadcastUtil);
     }
 
@@ -179,7 +179,6 @@ public class SecurityGroupMemberDeleteTask extends TransactionalTask {
             VM vm = vmPort.getVm();
             deleteFromDB(em, vmPort);
             if (vm != null) {
-                vm.removePort(vmPort);
                 if (vm.getSecurityGroupMembers().size() == 0 && vm.getPorts().size() <= 0) {
                     deleteFromDB(em, vm);
                 }
@@ -195,7 +194,6 @@ public class SecurityGroupMemberDeleteTask extends TransactionalTask {
             VM vm = vmPort.getVm();
             deleteFromDB(em, vmPort);
             if (vm != null) {
-                vm.removePort(vmPort);
                 if (vm.getSecurityGroupMembers().size() == 0 && vm.getPorts().size() <= 0) {
                     deleteFromDB(em, vm);
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

Deleting bound ("binded") security groups or removing members from them -- whithout unbinding first -- used to result in referential integrity exceptions. This was reported as [issue #627](https://github.com/opensecuritycontroller/osc-core/issues/627)

## Description
<!--- Describe your change in detail -->

Changed SecurityGroupMemberDeleteTask to dissociate security group members from ports, networks, etc. Carefully severe the foreign key ties to prevent ReferrentialIntegrityException.



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Fixes [issue #627](https://github.com/opensecuritycontroller/osc-core/issues/627).
## How Has This Been Tested?

Tested with OSC PAN plugin, NSC plugin (custom version which supports port groups), Panorama 8.0 and Mitaka Openstack.

- Checked that SG with several Virtual Machine (VM) members can be bound and withstand VM being removed. .
- Checked that SG with several VM members can be bound and deleted.
- Checked that SG with a single Network or Subnet member can be bound and deleted.
Jobs for all these changes used to fail before this fix.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code style guidelines](https://github.com/opensecuritycontroller/community/blob/master/development/eclipse.md) of this project
- [x] My unit test follow the [Unit test guidelines](https://github.com/opensecuritycontroller/community/blob/master/development/unit_test_guidelines.md)
- [x] Unit test coverage percentage is maintained(increased/remains the same but not decreased)
  