### PR TITLE
Neither porgGroup nor SFC calls for removeInspectionHook

### DIFF
--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/SecurityGroupUpdateOrDeleteMetaTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/securitygroup/SecurityGroupUpdateOrDeleteMetaTask.java
@@ -290,7 +290,7 @@ public class SecurityGroupUpdateOrDeleteMetaTask extends TransactionalMetaTask {
                 // are already deleted and this essentially a no op. The tasks SecurityGroupMemberVmCheckTask etc
                 // need to make sure hooks are removed in case of delete tg.
                 boolean shouldRemoveHooks = !this.apiFactoryService.supportsPortGroup(this.sg)
-                        || !this.apiFactoryService.supportsNeutronSFC(this.sg);
+                        && !this.apiFactoryService.supportsNeutronSFC(this.sg);
                 if (shouldRemoveHooks) {
                     tasksToSucceedToDeleteSGI.addAll(addSGMemberRemoveHooksTask(em, sgi));
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
Neither portGroup nor SFC situationcalls for removeInspectionHook. 
## Description
<!--- Describe your change in detail -->
Fixed the logic to reflect the above.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
The issue was discovered while testing with Nuage.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code style guidelines](https://github.com/opensecuritycontroller/community/blob/master/development/eclipse.md) of this project
- [x] My unit test follow the [Unit test guidelines](https://github.com/opensecuritycontroller/community/blob/master/development/unit_test_guidelines.md)
- [x] Unit test coverage percentage is maintained(increased/remains the same but not decreased)