### PR TITLE
Build automation to generate OSC docker image

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -177,7 +177,7 @@
     <target name="createDockerImage" description="create docker image">
         <exec executable="docker" resultproperty="tar.result">
             <arg value="pull" />
-            <arg value="centos:7" />
+            <arg value="centos:latest" />
         </exec>
         <exec executable="docker" resultproperty="tar.result" dir="docker/">
             <arg value="build" />

--- a/build.xml
+++ b/build.xml
@@ -19,7 +19,7 @@
 
 	<property name="image-format" value="vmdk_only" />
 	<target name="ovf" depends="build,ovfOnly,ovfCopy" description="build all and generate vmidc ovf" />
-
+        <target name="dockerimage" depends="build,dockerImageBuild,clean" description="build all and generate docker image in tar" />
 	<target name="build" depends="deleteJavaJre">
 		<echo>Ant version: ${ant.version}</echo>
 		<echo>Ant Java/JVM version: ${ant.java.version}</echo>
@@ -132,17 +132,76 @@
 	</target>
 
     <target name="prodVersion">
-            <!-- Full version examples: 1.0.0-SNAPSHOT-0-HASH, 1.0.0-0-HASH, 1.0.0-1-HASH, etc -->
-            <exec outputproperty="fullVersion" dir="." executable="sh">
-			<arg value="-c" />
-                <arg value="git describe --long | tr -d v" />
-		</exec>
-            <!-- Version examples: 1.0.0-SNAPSHOT, 1.0.0, etc -->
-            <exec outputproperty="releaseVersion" dir="." executable="sh">
-                <arg value="-c" />
-                <arg value="git describe --abbrev=0 | tr -d v" />
-		</exec>
-            <echo>Full Version: ${fullVersion}</echo>
-            <echo>Version: ${releaseVersion}</echo>
-	</target>
+        <!-- Full version examples: 1.0.0-SNAPSHOT-0-HASH, 1.0.0-0-HASH, 1.0.0-1-HASH, etc -->
+        <exec outputproperty="fullVersion" dir="." executable="sh">
+            <arg value="-c" />
+            <arg value="git describe --long | tr -d v" />
+        </exec>
+        <!-- Version examples: 1.0.0-SNAPSHOT, 1.0.0, etc -->
+        <exec outputproperty="releaseVersion" dir="." executable="sh">
+            <arg value="-c" />
+            <arg value="git describe --abbrev=0 | tr -d v" />
+        </exec>
+        <echo>Full Version: ${fullVersion}</echo>
+        <echo>Version: ${releaseVersion}</echo>
+    </target>
+
+    <target name="dockerImageBuild" depends="prodVersion,createBuildDir,copyAndUnzipServerUpgradeBundle,copyServerUpgradeBundle,createDockerImage" description="Copy result files to build dir">
+        <zip destfile="Build${fullVersion}/OSC-${releaseVersion}_Build${fullVersion}.zip">
+            <fileset dir="Build${fullVersion}" includes="**/*.tar **/serverUpgradeBundle-*.zip" />
+        </zip>
+    </target>
+
+    <target name="checkServerUpgradeBundleExist">
+        <available file="docker/serverUpgradeBundle*.zip" property="isServerUpgradeBundleExist"/>
+    </target>
+
+    <target name="deleteOldServerUpgradeBundle" depends="checkServerUpgradeBundleExist" if="isServerUpgradeBundleExist">
+        <delete>
+            <fileset dir="docker/" includes="serverUpgradeBundle-*.zip" />
+        </delete>
+    </target>
+
+    <target name="copyAndUnzipServerUpgradeBundle" depends="deleteOldServerUpgradeBundle">
+        <copy file="target/serverUpgradeBundle.zip" tofile="docker/serverUpgradeBundle-${fullVersion}.zip" />
+            <exec executable="unzip" resultproperty="tar.result" dir="docker/">
+                <arg value="serverUpgradeBundle-${fullVersion}.zip" />
+            </exec>
+    </target>
+
+    <target name="clean" >
+        <delete file="docker/serverUpgradeBundle-${fullVersion}.zip"/>
+        <delete dir="docker/opt" />
+    </target>
+
+    <target name="createDockerImage" description="create docker image">
+        <exec executable="docker" resultproperty="tar.result">
+            <arg value="pull" />
+            <arg value="centos:7" />
+        </exec>
+        <exec executable="docker" resultproperty="tar.result" dir="docker/">
+            <arg value="build" />
+            <arg value="-f" />
+            <arg value="Dockerfile-osc-base" />
+            <arg value="." />
+            <arg value="-t" />
+            <arg value="osc-base-image:osc-base" />
+        </exec>
+        <exec executable="docker" resultproperty="tar.result" dir="docker/">
+            <arg value="build" />
+            <arg value="-f" />
+            <arg value="Dockerfile" />
+            <arg value="." />
+            <arg value="-t" />
+            <arg value="osc-docker-image:osc" />
+        </exec>
+        <exec executable="docker" resultproperty="tar.result" dir="Build${fullVersion}/">
+            <arg value="image" />
+            <arg value="save" />
+            <arg value="-o" />
+            <arg value="osc-docker.tar" />
+            <arg value="osc-docker-image:osc" />
+        </exec>
+    </target>
+        
 </project>

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM arvindn05:osc-base
+FROM osc-base-image:osc-base
 
 MAINTAINER Arvind Nadendla <arvindn05@gmail.com>
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM osc-base-image:osc-base
 MAINTAINER Arvind Nadendla <arvindn05@gmail.com>
 
 # Copy OSC opt folder to container
-COPY . /
+COPY opt /opt
 
 EXPOSE 8090 443
 

--- a/docker/Dockerfile-osc-base
+++ b/docker/Dockerfile-osc-base
@@ -1,0 +1,25 @@
+FROM centos:7
+
+MAINTAINER Arvind Nadendla <arvindn05@gmail.com>
+
+ENV http_proxy http://proxy-chain.intel.com:911
+ENV https_proxy https://proxy-chain.intel.com:912
+
+RUN yum update -y && \
+yum install -y wget && \
+wget --no-check-certificate --no-cookies --header "Cookie: oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jdk/8u161-b12/0da788060d494f5095bf8624735fa2f1/jre-8u161-linux-x64.rpm && \
+yum localinstall -y jre-8u161-linux-x64.rpm && \
+rm -rf jre-8u161-linux-x64.rpm && \
+yum install -y net-tools && \
+yum install -y graphviz && \
+rm -rf /var/cache/yum
+
+# Set environment variables.
+ENV JAVA_HOME /usr/java/jre1.8.0_161
+ENV HOME /root
+
+# Define working directory.
+WORKDIR /root
+
+# Define default command.
+CMD ["bash"]

--- a/docker/Dockerfile-osc-base
+++ b/docker/Dockerfile-osc-base
@@ -1,11 +1,11 @@
-FROM centos:7
+FROM centos:latest
 
 MAINTAINER Arvind Nadendla <arvindn05@gmail.com>
 
-ENV http_proxy http://proxy-chain.intel.com:911
-ENV https_proxy https://proxy-chain.intel.com:912
+COPY proxy.sh /etc/profile.d/
 
-RUN yum update -y && \
+RUN source /etc/profile.d/proxy.sh && \
+yum update -y && \
 yum install -y wget && \
 wget --no-check-certificate --no-cookies --header "Cookie: oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jdk/8u161-b12/0da788060d494f5095bf8624735fa2f1/jre-8u161-linux-x64.rpm && \
 yum localinstall -y jre-8u161-linux-x64.rpm && \

--- a/docker/proxy.sh
+++ b/docker/proxy.sh
@@ -1,0 +1,2 @@
+export http_proxy=http://proxy-chain.intel.com:911
+export https_proxy=http://proxy-chain.intel.com:912

--- a/osc-server/src/main/java/org/osc/core/broker/util/crypto/X509TrustManagerFactory.java
+++ b/osc-server/src/main/java/org/osc/core/broker/util/crypto/X509TrustManagerFactory.java
@@ -328,7 +328,7 @@ public final class X509TrustManagerFactory implements X509TrustManager, X509Trus
 
         if (doReboot) {
             LOG.info("Replaced internal private/public key! Rebooting system ! ! !");
-            ServerUtil.execWithLog("/sbin/reboot");
+            ServerUtil.execWithLog(new String[] { "/opt/vmidc/bin/vmidc.sh", "--stop"});
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
The build.xml is now updated to support OSC containerization, The user can get the OSC docker image in tar format.  
## Description
<!--- Describe your change in detail -->
The user need to run below command to get OSC as a docker image in tar format
go to osc-core
`ant dockerimage`
The docker image will  be generated in Build-xxx directory in a tar format
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
To support OSC Containerization
## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Tested Manually
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code style guidelines](https://github.com/opensecuritycontroller/community/blob/master/development/eclipse.md) of this project
- [ ] My unit test follow the [Unit test guidelines](https://github.com/opensecuritycontroller/community/blob/master/development/unit_test_guidelines.md)
- [ ] Unit test coverage percentage is maintained(increased/remains the same but not decreased)