### PR TITLE
OSC docker image build automation(replace net-tools with iproute)

### DIFF
--- a/docker/Dockerfile-osc-base
+++ b/docker/Dockerfile-osc-base
@@ -10,7 +10,7 @@ yum install -y wget && \
 wget --no-check-certificate --no-cookies --header "Cookie: oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jdk/8u161-b12/0da788060d494f5095bf8624735fa2f1/jre-8u161-linux-x64.rpm && \
 yum localinstall -y jre-8u161-linux-x64.rpm && \
 rm -rf jre-8u161-linux-x64.rpm && \
-yum install -y net-tools && \
+yum install -y iproute && \
 yum install -y graphviz && \
 rm -rf /var/cache/yum
 


### PR DESCRIPTION
OSC docker image build automation(replace net-tools with iproute)

<!--- Provide a general summary of your change in the Title above -->

## Description
OSC docker image build automation(replace net-tools with iproute)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Since net-tools package has many non relevant packages. net-tools has been replaced with iproute as iproute package is very light weight when compared to net-tools and provides sufficient dependency for fetching network configurations.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Tested Manually 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code style guidelines](https://github.com/opensecuritycontroller/community/blob/master/development/eclipse.md) of this project
- [ ] My unit test follow the [Unit test guidelines](https://github.com/opensecuritycontroller/community/blob/master/development/unit_test_guidelines.md)
- [ ] Unit test coverage percentage is maintained(increased/remains the same but not decreased)