### PR TITLE
File inject fix

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -18,7 +18,7 @@ coverage:
     project:
       default:
         enabled: yes
-        target: 24%
+        target: 25%
         threshold: 1%
         base: parent
     patch: false

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ osc-export/webapp/**
 osc-export/data/*.db*
 osc-export/data/log/**
 osc-export/data/plugins/**
+osc-export/data/ovf/**
 osc-export/data/mainKeyStore.p12
 osc-export/data/osctrustore.jks
 osc-export/*.db*

--- a/osc-server/src/main/java/org/osc/core/broker/rest/client/openstack/openstack4j/Openstack4JNova.java
+++ b/osc-server/src/main/java/org/osc/core/broker/rest/client/openstack/openstack4j/Openstack4JNova.java
@@ -17,7 +17,7 @@
 package org.osc.core.broker.rest.client.openstack.openstack4j;
 
 import java.io.IOException;
-import java.util.Arrays;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -38,10 +38,10 @@ import org.openstack4j.model.compute.ext.AvailabilityZone;
 import org.openstack4j.model.compute.ext.Hypervisor;
 import org.openstack4j.model.identity.v3.Region;
 import org.openstack4j.model.network.Port;
-import org.slf4j.LoggerFactory;
 import org.osc.sdk.manager.element.ApplianceBootstrapInformationElement;
 import org.osc.sdk.manager.element.ApplianceBootstrapInformationElement.BootstrapFileElement;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Maps;
 
@@ -131,7 +131,7 @@ public class Openstack4JNova extends BaseOpenstack4jApi {
             }
 
             for (BootstrapFileElement file : bootstrapInfo.getBootstrapFiles()) {
-                sc.addPersonality(file.getName(), Arrays.toString(file.getContent()));
+                sc.addPersonality(file.getName(), new String(file.getContent(), StandardCharsets.UTF_8));
             }
             sc.configDrive(true);
 


### PR DESCRIPTION
Bootstrap information is not being provided as a string to the openstack deployments. This change fixes the issue.

## Description
As part of the openstack library changes a regression seems to have been introduced where the bootstrap information is being provided as a array of integers instead of a string content. Changed the code to send the string content.

## Motivation and Context
See above

## How Has This Been Tested?
Has been tested by deploying a sample cirros appliance and integration tests were done with PAN appliance.

## Screenshots (if appropriate):
None.
## Types of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code style guidelines](https://github.com/opensecuritycontroller/community/blob/master/development/eclipse.md) of this project
- [x] My unit test follow the [Unit test guidelines](https://github.com/opensecuritycontroller/community/blob/master/development/unit_test_guidelines.md)
- [x] Unit test coverage percentage is maintained(increased/remains the same but not decreased)