### PR TITLE
Add job buffering for sgsync jobs on RabbitMq Port messages

### DIFF
--- a/osc-server/src/main/java/org/osc/core/broker/rest/client/openstack/vmidc/notification/listener/OsPortNotificationListener.java
+++ b/osc-server/src/main/java/org/osc/core/broker/rest/client/openstack/vmidc/notification/listener/OsPortNotificationListener.java
@@ -16,6 +16,8 @@
  *******************************************************************************/
 package org.osc.core.broker.rest.client.openstack.vmidc.notification.listener;
 
+import static org.osc.core.broker.rest.client.openstack.vmidc.notification.listener.OsSyncJobSubmitter.triggerSGSync;
+
 import java.util.List;
 
 import javax.persistence.EntityManager;
@@ -133,7 +135,7 @@ public class OsPortNotificationListener extends OsNotificationListener {
 
         if (keyValue != null) {
             // start SG sync as the port is relevant to this SG object...
-            triggerSGSync(sg, em);
+            triggerSGSync(sg, em, this.sgConformJobFactory);
         }
 
     }
@@ -149,23 +151,17 @@ public class OsPortNotificationListener extends OsNotificationListener {
                         ((port.getNetwork() != null && this.objectIdList.contains(port.getNetwork().getOpenstackId()))
                                 || (port.getVm() != null && this.objectIdList.contains(port.getVm().getOpenstackId()))
                                 || (port.getSubnet() != null && this.objectIdList.contains(port.getSubnet().getOpenstackId())))) {
-                    triggerSGSync(sg, em);
+                    triggerSGSync(sg, em, this.sgConformJobFactory);
                 }
 
             } else {
                 String projectId = OsNotificationUtil.getPropertyFromNotificationMessage(message,
                         OsNotificationKeyType.CONTEXT_PROJECT_ID.toString());
                 if (this.objectIdList.contains(projectId)) {
-                    triggerSGSync(sg, em);
+                    triggerSGSync(sg, em, this.sgConformJobFactory);
                 }
             }
         }
-
     }
 
-    private void triggerSGSync(SecurityGroup sg, EntityManager em) throws Exception {
-        log.info("Running SG sync based on OS Port notification received.");
-        // Message is related to registered Security Group. Trigger sync
-        this.sgConformJobFactory.startSecurityGroupConformanceJob(sg);
-    }
 }

--- a/osc-server/src/main/java/org/osc/core/broker/rest/client/openstack/vmidc/notification/listener/OsSyncJobSubmitter.java
+++ b/osc-server/src/main/java/org/osc/core/broker/rest/client/openstack/vmidc/notification/listener/OsSyncJobSubmitter.java
@@ -1,0 +1,133 @@
+/*******************************************************************************
+ * Copyright (c) Intel Corporation
+ * Copyright (c) 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package org.osc.core.broker.rest.client.openstack.vmidc.notification.listener;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.persistence.EntityManager;
+
+import org.osc.core.broker.model.entities.virtualization.SecurityGroup;
+import org.osc.core.broker.service.SecurityGroupConformJobFactory;
+import org.osc.core.broker.service.exceptions.VmidcBrokerInvalidRequestException;
+import org.quartz.JobBuilder;
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+import org.quartz.impl.StdSchedulerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class OsSyncJobSubmitter {
+
+    // Anything that a Quartz job is going to touch has to be public
+    public static final int SG_SYNC_WAIT_SECONDS = 45;
+    public static final long DEAD_JOB_TIMEOUT = 7200;
+    public static final Map<Long, Instant> submittedJobs = new HashMap<>();
+    public static final Logger log = LoggerFactory.getLogger(OsSyncJobSubmitter.class);
+    public static Scheduler scheduler;
+
+    public static void triggerSGSync(SecurityGroup sg, EntityManager em,
+            SecurityGroupConformJobFactory sgConformJobFactory)
+                    throws Exception {
+
+        log.info("Running SG sync based on OS Port notification received.");
+
+        if (decisionToSubmit(sg)) {
+            checkScheduler();
+
+            JobDataMap jobDataMap = new JobDataMap();
+            jobDataMap.put("sg", sg);
+            jobDataMap.put("jobFactory", sgConformJobFactory);
+            jobDataMap.put("em", em);
+
+            Trigger trigger = TriggerBuilder.newTrigger()
+                    .startAt(Date.from(Instant.now().plusSeconds(SG_SYNC_WAIT_SECONDS))).build();
+
+            JobDetail syncJob = JobBuilder.newJob(SubmitSGSyncJob.class).setJobData(jobDataMap).build();
+            scheduler.scheduleJob(syncJob, trigger);
+        }
+    }
+
+    private static boolean decisionToSubmit(SecurityGroup sg) {
+
+        synchronized (submittedJobs) {
+            if (!submittedJobs.containsKey(sg.getId())) {
+                submittedJobs.put(sg.getId(), Instant.now());
+                return true;
+            } else if (submittedJobs.get(sg.getId()).isBefore(Instant.now().minusSeconds(DEAD_JOB_TIMEOUT))) {
+                log.warn("Another job is stuck in the queue waiting to synchronize SG {} ", sg.getId());
+                submittedJobs.put(sg.getId(), Instant.now());
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static void checkScheduler() throws SchedulerException {
+        if (scheduler == null || !scheduler.isStarted() || scheduler.isShutdown() || scheduler.isInStandbyMode()) {
+            scheduler = StdSchedulerFactory.getDefaultScheduler();
+            scheduler.start();
+        }
+    }
+
+    public static class SubmitSGSyncJob implements org.quartz.Job {
+        @Override
+        public void execute(JobExecutionContext context) throws JobExecutionException {
+            SecurityGroup sg = (SecurityGroup) context.getMergedJobDataMap().get("sg");
+            log.info("Scheduling SG sync job based on OS Port notification. SG {}", sg.getId());
+
+            synchronized (submittedJobs) {
+                submittedJobs.remove(sg.getId());
+            }
+
+            SecurityGroupConformJobFactory sgConformJobFactory = (SecurityGroupConformJobFactory)
+                    context.getMergedJobDataMap().get("jobFactory");
+
+            try {
+                sgConformJobFactory.startSecurityGroupConformanceJob(sg);
+
+            } catch (VmidcBrokerInvalidRequestException vbire) {
+                log.info("Another sync job is already running for SG {}. Scheduling later.", sg.getId());
+                log.info("Another sync job is already running", vbire);
+
+                EntityManager em = (EntityManager) context.getMergedJobDataMap().get("em");
+
+                try {
+                    triggerSGSync(sg, em, sgConformJobFactory);
+                } catch (Exception e) {
+                    String msg = String.format("Failed to trigger SG %s sync after retry.", sg.getId());
+                    log.error(msg);
+                    throw new JobExecutionException(msg, e);
+                }
+            } catch (Exception e) {
+                String msg = String.format("Exception submitting SG %s sync", sg.getId());
+                log.error(msg);
+                throw new JobExecutionException(e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Upon RabbitMQ messsage about changing ports in openstack, a security group which protects those ports should be synchronized. If we delete multiple protected vms from openstack in quick succession, the SG in the OSC database does not reflect the correct number of the remaining vms.

This was reported in [issue 632](https://github.com/opensecuritycontroller/osc-core/issues/632).

## Motivation and Context

The Security Group membership in OSC should reflect the correct state of the actual openstack. When we delete a single vm from openstack, a RabbitMQ message is sent to OSC and it kicks off a SG Sync job. 

However, if we delete multiple ports, multiple sync jobs are attempted and the way the code is written, later submission attempts fail. Then the last successful sync job may have run without taking into account some VM deletions. This results in the Security Group object not knowing about some of its members missing.

An obvious workaround is to just press the Sync button when the dust settles, but we can buffer sync requests as shown in this PR.

## How Has This Been Tested?
Tested with ISM and NSC plugins. 

- Created a SG with several (5 to 7) vm members. 
- Binded. 
- Deleted several vms, one by one from openstack command line. Command line  allows us to do it very quickly.

## Screenshots (if appropriate):

## Types of change

`OsPortNotificationListener` buffers multiple sync requests. All we have to do is make sure a good sync job is started after changes have stopped coming in.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code style guidelines](https://github.com/opensecuritycontroller/community/blob/master/development/eclipse.md) of this project
- [ ] My unit test follow the [Unit test guidelines](https://github.com/opensecuritycontroller/community/blob/master/development/unit_test_guidelines.md)
- [ ] Unit test coverage percentage is maintained(increased/remains the same but not decreased)