### PR TITLE
Split OsSvaServerCreate into 2 tasks. EnsureSvaActive in between

### DIFF
--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OsSvaCreateMetaTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OsSvaCreateMetaTask.java
@@ -52,6 +52,8 @@ public class OsSvaCreateMetaTask extends TransactionalMetaTask {
     @Reference
     private OsSvaServerCreateTask osSvaServerCreateTask;
     @Reference
+    private OsSvaInspectionPortRegisterTask osSvaInspectionPortRegisterTask;
+    @Reference
     private OsSvaEnsureActiveTask osSvaEnsureActiveTask;
     @Reference
     private OsSvaCheckFloatingIpTask osSvaCheckFloatingIpTask;
@@ -81,6 +83,7 @@ public class OsSvaCreateMetaTask extends TransactionalMetaTask {
         task.apiFactoryService = this.apiFactoryService;
         task.mgrCreateMemberDeviceTask = this.mgrCreateMemberDeviceTask;
         task.osSvaServerCreateTask = this.osSvaServerCreateTask;
+        task.osSvaInspectionPortRegisterTask = this.osSvaInspectionPortRegisterTask;
         task.osSvaEnsureActiveTask = this.osSvaEnsureActiveTask;
         task.osSvaCheckFloatingIpTask = this.osSvaCheckFloatingIpTask;
         task.osSvaCheckNetworkInfoTask = this.osSvaCheckNetworkInfoTask;
@@ -122,6 +125,7 @@ public class OsSvaCreateMetaTask extends TransactionalMetaTask {
 
         this.tg.addTask(this.osSvaServerCreateTask.create(this.dai, this.hypervisorHostName, this.availabilityZone));
         this.tg.appendTask(this.osSvaEnsureActiveTask.create(this.dai));
+        this.tg.appendTask(this.osSvaInspectionPortRegisterTask.create(this.dai));
 
         this.tg.appendTask(this.osSvaCheckNetworkInfoTask.create(this.dai));
 

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OsSvaInspectionPortRegisterTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OsSvaInspectionPortRegisterTask.java
@@ -40,7 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Creates SVA for given dai
+ * Register inspection port for the given dai via RedirectionApi.
  */
 @Component(service = OsSvaInspectionPortRegisterTask.class)
 public class OsSvaInspectionPortRegisterTask extends TransactionalTask {

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OsSvaInspectionPortRegisterTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OsSvaInspectionPortRegisterTask.java
@@ -71,8 +71,6 @@ public class OsSvaInspectionPortRegisterTask extends TransactionalTask {
 
         VirtualizationConnector vc = vs.getVirtualizationConnector();
 
-        this.dai = DistributedApplianceInstanceEntityMgr.findById(em, this.dai.getId());
-
         if (vc.isControllerDefined()) {
             try (SdnRedirectionApi controller = this.apiFactoryService.createNetworkRedirectionApi(this.dai);) {
                 DefaultNetworkPort ingressPort = new DefaultNetworkPort(this.dai.getInspectionOsIngressPortId(),

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OsSvaInspectionPortRegisterTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OsSvaInspectionPortRegisterTask.java
@@ -1,0 +1,135 @@
+/*******************************************************************************
+ * Copyright (c) Intel Corporation
+ * Copyright (c) 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.osc.core.broker.service.tasks.conformance.openstack.deploymentspec;
+
+import java.util.Arrays;
+import java.util.Set;
+
+import javax.persistence.EntityManager;
+
+import org.osc.core.broker.job.lock.LockObjectReference;
+import org.osc.core.broker.model.entities.appliance.DistributedApplianceInstance;
+import org.osc.core.broker.model.entities.appliance.VirtualSystem;
+import org.osc.core.broker.model.entities.virtualization.VirtualizationConnector;
+import org.osc.core.broker.model.entities.virtualization.openstack.DeploymentSpec;
+import org.osc.core.broker.model.plugin.ApiFactoryService;
+import org.osc.core.broker.service.persistence.DistributedApplianceInstanceEntityMgr;
+import org.osc.core.broker.service.persistence.OSCEntityManager;
+import org.osc.core.broker.service.tasks.TransactionalTask;
+import org.osc.sdk.controller.DefaultInspectionPort;
+import org.osc.sdk.controller.DefaultNetworkPort;
+import org.osc.sdk.controller.api.SdnRedirectionApi;
+import org.osc.sdk.controller.element.Element;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Creates SVA for given dai
+ */
+@Component(service = OsSvaInspectionPortRegisterTask.class)
+public class OsSvaInspectionPortRegisterTask extends TransactionalTask {
+
+    private final Logger log = LoggerFactory.getLogger(OsSvaInspectionPortRegisterTask.class);
+
+    @Reference
+    private ApiFactoryService apiFactoryService;
+
+    private DistributedApplianceInstance dai;
+
+    public OsSvaInspectionPortRegisterTask create(DistributedApplianceInstance dai) {
+        OsSvaInspectionPortRegisterTask task = new OsSvaInspectionPortRegisterTask();
+        task.apiFactoryService = this.apiFactoryService;
+        task.dai = dai;
+        task.dbConnectionManager = this.dbConnectionManager;
+        task.txBroadcastUtil = this.txBroadcastUtil;
+
+        return task;
+    }
+
+    @Override
+    public void executeTransaction(EntityManager em) throws Exception {
+        this.dai = DistributedApplianceInstanceEntityMgr.findById(em, this.dai.getId());
+        DeploymentSpec ds = this.dai.getDeploymentSpec();
+
+        VirtualSystem vs = ds.getVirtualSystem();
+
+        VirtualizationConnector vc = vs.getVirtualizationConnector();
+
+        this.dai = DistributedApplianceInstanceEntityMgr.findById(em, this.dai.getId());
+
+        if (vc.isControllerDefined()) {
+            try (SdnRedirectionApi controller = this.apiFactoryService.createNetworkRedirectionApi(this.dai);) {
+                DefaultNetworkPort ingressPort = new DefaultNetworkPort(this.dai.getInspectionOsIngressPortId(),
+                        this.dai.getInspectionIngressMacAddress());
+                DefaultNetworkPort egressPort = new DefaultNetworkPort(this.dai.getInspectionOsIngressPortId(),
+                        this.dai.getInspectionIngressMacAddress());
+
+                if (this.apiFactoryService.supportsNeutronSFC(this.dai.getVirtualSystem())) {
+                    // In case of neutron SFC, port group id needs to be used when registering and updated in the DS
+                    String portGroupId = ds.getPortGroupId();
+                    boolean pgAlreadyCreatedByOther = (portGroupId != null);
+
+                    Element element = controller
+                            .registerInspectionPort(new DefaultInspectionPort(ingressPort, egressPort, null, portGroupId));
+
+                    portGroupId = element.getParentId();
+
+                    this.log.info(String.format("Setting port_group_id to %s on DAI %s (id %d) for Deployment Spec %s (id: %d)",
+                            portGroupId, this.dai.getName(), this.dai.getId(), ds.getName(), ds.getId()));
+
+                    if (!pgAlreadyCreatedByOther) {
+                        ds = em.find(DeploymentSpec.class, ds.getId());
+                        ds.setPortGroupId(portGroupId);
+                        OSCEntityManager.update(em, ds, this.txBroadcastUtil);
+                    }
+
+                } else if (this.apiFactoryService.supportsPortGroup(this.dai.getVirtualSystem())) {
+                    String domainId = OpenstackUtil.extractDomainId(ds.getProjectId(),
+                                                    ds.getProjectName(),
+                                                    ds.getVirtualSystem().getVirtualizationConnector(),
+                                                    Arrays.asList(ingressPort));
+
+                    ingressPort.setParentId(domainId);
+                    egressPort.setParentId(domainId);
+
+                  //Element object in DefaultInspectionport is not used at this point, hence null
+                    controller.registerInspectionPort(
+                            new DefaultInspectionPort(ingressPort, egressPort, null));
+                } else {
+                    controller.registerInspectionPort(
+                            new DefaultInspectionPort(ingressPort, egressPort, null));
+                }
+            }
+        }
+
+        this.log.info("Dai: " + this.dai + " Server Id set to: " + this.dai.getExternalId());
+
+        OSCEntityManager.update(em, this.dai, this.txBroadcastUtil);
+    }
+
+    @Override
+    public String getName() {
+        return String.format("Registering Inspection Port for Distributed Appliance Instance '%s'", this.dai.getName());
+    }
+
+    @Override
+    public Set<LockObjectReference> getObjects() {
+        return LockObjectReference.getObjectReferences(this.dai);
+    }
+}

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OsSvaServerCreateTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OsSvaServerCreateTask.java
@@ -152,6 +152,7 @@ public class OsSvaServerCreateTask extends TransactionalTask {
                 .addSVAIdToListener(this.dai.getDeploymentSpec().getId(), createdServer.getServerId());
 
         OSCEntityManager.update(em, this.dai, this.txBroadcastUtil);
+        this.log.info("Dai: " + this.dai + " Server Id set to: " + this.dai.getExternalId());
     }
 
     private String getImageRefIdByRegion(VirtualSystem vs, String region) {

--- a/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OsSvaServerCreateTask.java
+++ b/osc-server/src/main/java/org/osc/core/broker/service/tasks/conformance/openstack/deploymentspec/OsSvaServerCreateTask.java
@@ -16,7 +16,6 @@
  *******************************************************************************/
 package org.osc.core.broker.service.tasks.conformance.openstack.deploymentspec;
 
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
 
@@ -39,17 +38,13 @@ import org.osc.core.broker.rest.client.openstack.vmidc.notification.runner.Rabbi
 import org.osc.core.broker.service.persistence.DistributedApplianceInstanceEntityMgr;
 import org.osc.core.broker.service.persistence.OSCEntityManager;
 import org.osc.core.broker.service.tasks.TransactionalTask;
-import org.slf4j.LoggerFactory;
-import org.osc.sdk.controller.DefaultInspectionPort;
-import org.osc.sdk.controller.DefaultNetworkPort;
-import org.osc.sdk.controller.api.SdnRedirectionApi;
-import org.osc.sdk.controller.element.Element;
 import org.osc.sdk.manager.api.ManagerDeviceApi;
 import org.osc.sdk.manager.element.ApplianceBootstrapInformationElement;
 import org.osc.sdk.manager.element.BootStrapInfoProviderElement;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -155,53 +150,6 @@ public class OsSvaServerCreateTask extends TransactionalTask {
 
         this.activeRunner.getOsDeploymentSpecNotificationRunner()
                 .addSVAIdToListener(this.dai.getDeploymentSpec().getId(), createdServer.getServerId());
-
-        if (vc.isControllerDefined()) {
-            try (SdnRedirectionApi controller = this.apiFactoryService.createNetworkRedirectionApi(this.dai);) {
-                DefaultNetworkPort ingressPort = new DefaultNetworkPort(createdServer.getIngressInspectionPortId(),
-                        createdServer.getIngressInspectionMacAddr());
-                DefaultNetworkPort egressPort = new DefaultNetworkPort(createdServer.getEgressInspectionPortId(),
-                        createdServer.getEgressInspectionMacAddr());
-
-                if (this.apiFactoryService.supportsNeutronSFC(this.dai.getVirtualSystem())) {
-                    // In case of neutron SFC, port group id needs to be used when registering and updated in the DS
-                    String portGroupId = ds.getPortGroupId();
-                    boolean pgAlreadyCreatedByOther = (portGroupId != null);
-
-                    Element element = controller
-                            .registerInspectionPort(new DefaultInspectionPort(ingressPort, egressPort, null, portGroupId));
-
-                    portGroupId = element.getParentId();
-
-                    this.log.info(String.format("Setting port_group_id to %s on DAI %s (id %d) for Deployment Spec %s (id: %d)",
-                            portGroupId, this.dai.getName(), this.dai.getId(), ds.getName(), ds.getId()));
-
-                    if (!pgAlreadyCreatedByOther) {
-                        ds = em.find(DeploymentSpec.class, ds.getId());
-                        ds.setPortGroupId(portGroupId);
-                        OSCEntityManager.update(em, ds, this.txBroadcastUtil);
-                    }
-
-                } else if (this.apiFactoryService.supportsPortGroup(this.dai.getVirtualSystem())) {
-                    String domainId = OpenstackUtil.extractDomainId(ds.getProjectId(),
-                                                    ds.getProjectName(),
-                                                    ds.getVirtualSystem().getVirtualizationConnector(),
-                                                    Arrays.asList(ingressPort));
-
-                    ingressPort.setParentId(domainId);
-                    egressPort.setParentId(domainId);
-
-                  //Element object in DefaultInspectionport is not used at this point, hence null
-                    controller.registerInspectionPort(
-                            new DefaultInspectionPort(ingressPort, egressPort, null));
-                } else {
-                    controller.registerInspectionPort(
-                            new DefaultInspectionPort(ingressPort, egressPort, null));
-                }
-            }
-        }
-
-        this.log.info("Dai: " + this.dai + " Server Id set to: " + this.dai.getExternalId());
 
         OSCEntityManager.update(em, this.dai, this.txBroadcastUtil);
     }


### PR DESCRIPTION
Ensure SVA server is active before we create the port pair on openstack. This fixes a design issue which only surfaced with the **NSFC Plugin**.

## Description

`OsSvaServerCreateTask` has been both creating a VM with two ports on openstack _and_ calling `redirectionApi.registerPortPair`. Then `OsSvaEnsureActiveTask` was called. It makes sense to wait for the VM (the SVA server) to acually come up before we do the `EnsureActive` step. 

Consequently, we split `OsSvaServerCreateTask` into two tasks and put the `OsSvaEnsureActiveTask` step in between. The calling metatask is rewired accordingly.

## Motivation and Context

Create server call returns before the SVA server has fully come up. Next the `redirectionApi` steps in to create a port pair (see the NSFC plugin). If we attempt to create a port pair with two ports which do not belong (yet) to a running server, that call fails. 

The `OsSvaEnsureActiveTask` task prevents the NSFC plugin from running too soon.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code style guidelines](https://github.com/opensecuritycontroller/community/blob/master/development/eclipse.md) of this project
- [x] My unit test follow the [Unit test guidelines](https://github.com/opensecuritycontroller/community/blob/master/development/unit_test_guidelines.md)
- [x] Unit test coverage percentage is maintained(increased/remains the same but not decreased)